### PR TITLE
Resolve change in InvalidNumber handling in writers

### DIFF
--- a/pyomo/repn/ampl.py
+++ b/pyomo/repn/ampl.py
@@ -170,6 +170,10 @@ def _strip_template_comments(vars_, base_):
             vars_[k] = '\n'.join(v_lines)
 
 
+def _inv2str(val):
+    return f"{val._str() if hasattr(val, '_str') else val}"
+
+
 # The "standard" text mode template is the debugging template with the
 # comments removed
 class TextNLTemplate(TextNLDebugTemplate):
@@ -539,7 +543,7 @@ def handle_product_node(visitor, node, arg1, arg2):
                 _prod = mult * arg2[1]
                 if _prod:
                     deprecation_warning(
-                        f"Encountered {mult}*{str(arg2[1])} in expression tree.  "
+                        f"Encountered {mult}*{_inv2str(arg2[1])} in expression tree.  "
                         "Mapping the NaN result to 0 for compatibility "
                         "with the nl_v1 writer.  In the future, this NaN "
                         "will be preserved/emitted to comply with IEEE-754.",
@@ -568,7 +572,7 @@ def handle_product_node(visitor, node, arg1, arg2):
                 _prod = mult * arg2[1]
                 if _prod:
                     deprecation_warning(
-                        f"Encountered {str(mult)}*{arg2[1]} in expression tree.  "
+                        f"Encountered {_inv2str(mult)}*{arg2[1]} in expression tree.  "
                         "Mapping the NaN result to 0 for compatibility "
                         "with the nl_v1 writer.  In the future, this NaN "
                         "will be preserved/emitted to comply with IEEE-754.",
@@ -976,7 +980,7 @@ class AMPLBeforeChildDispatcher(BeforeChildDispatcher):
                 arg2 = visitor.fixed_vars[_id]
                 if arg2 != arg2:
                     deprecation_warning(
-                        f"Encountered {arg1}*{arg2} in expression tree.  "
+                        f"Encountered {arg1}*{_inv2str(arg2)} in expression tree.  "
                         "Mapping the NaN result to 0 for compatibility "
                         "with the nl_v1 writer.  In the future, this NaN "
                         "will be preserved/emitted to comply with IEEE-754.",
@@ -1016,7 +1020,7 @@ class AMPLBeforeChildDispatcher(BeforeChildDispatcher):
                         arg2 = visitor.check_constant(arg2.value, arg2)
                         if arg2 != arg2:
                             deprecation_warning(
-                                f"Encountered {arg1}*{str(arg2.value)} in expression "
+                                f"Encountered {arg1}*{_inv2str(arg2)} in expression "
                                 "tree.  Mapping the NaN result to 0 for compatibility "
                                 "with the nl_v1 writer.  In the future, this NaN "
                                 "will be preserved/emitted to comply with IEEE-754.",

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -61,6 +61,10 @@ _LINEAR = ExprType.LINEAR
 _GENERAL = ExprType.GENERAL
 
 
+def _inv2str(val):
+    return f"{val._str() if hasattr(val, '_str') else val}"
+
+
 def _merge_dict(dest_dict, mult, src_dict):
     if mult == 1:
         for vid, coef in src_dict.items():
@@ -206,8 +210,10 @@ def _handle_product_constant_constant(visitor, node, arg1, arg2):
     ans = arg1[1] * arg2[1]
     if ans != ans:
         if not arg1[1] or not arg2[1]:
+            a = _inv2str(arg1[1])
+            b = _inv2str(arg2[1])
             deprecation_warning(
-                f"Encountered {str(arg1[1])}*{str(arg2[1])} in expression tree.  "
+                f"Encountered {a}*{b} in expression tree.  "
                 "Mapping the NaN result to 0 for compatibility "
                 "with the lp_v1 writer.  In the future, this NaN "
                 "will be preserved/emitted to comply with IEEE-754.",
@@ -599,7 +605,7 @@ class LinearBeforeChildDispatcher(BeforeChildDispatcher):
                 arg2 = visitor.check_constant(arg2.value, arg2)
                 if arg2 != arg2:
                     deprecation_warning(
-                        f"Encountered {arg1}*{str(arg2.value)} in expression "
+                        f"Encountered {arg1}*{_inv2str(arg2)} in expression "
                         "tree.  Mapping the NaN result to 0 for compatibility "
                         "with the lp_v1 writer.  In the future, this NaN "
                         "will be preserved/emitted to comply with IEEE-754.",
@@ -633,7 +639,7 @@ class LinearBeforeChildDispatcher(BeforeChildDispatcher):
                         arg2 = visitor.check_constant(arg2.value, arg2)
                         if arg2 != arg2:
                             deprecation_warning(
-                                f"Encountered {arg1}*{str(arg2.value)} in expression "
+                                f"Encountered {arg1}*{_inv2str(arg2)} in expression "
                                 "tree.  Mapping the NaN result to 0 for compatibility "
                                 "with the lp_v1 writer.  In the future, this NaN "
                                 "will be preserved/emitted to comply with IEEE-754.",
@@ -813,7 +819,7 @@ class LinearRepnVisitor(StreamBasedExpressionVisitor):
                     c != c for c in ans.linear.values()
                 ):
                     deprecation_warning(
-                        f"Encountered {str(mult)}*nan in expression tree.  "
+                        f"Encountered {mult}*nan in expression tree.  "
                         "Mapping the NaN result to 0 for compatibility "
                         "with the lp_v1 writer.  In the future, this NaN "
                         "will be preserved/emitted to comply with IEEE-754.",

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -48,7 +48,7 @@ from pyomo.environ import (
 )
 import pyomo.environ as pyo
 
-_invalid_1j = r'InvalidNumber\((\([-+0-9.e]+\+)?1j\)?\)'
+nan = float('nan')
 
 
 class INFO(object):
@@ -171,7 +171,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -186,7 +186,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -201,7 +201,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -216,7 +216,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -231,7 +231,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -424,7 +424,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertRegex(str(repn.const), _invalid_1j)
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(1j))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -440,7 +440,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertRegex(str(repn.const), _invalid_1j)
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(1j))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -460,7 +460,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -484,7 +484,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         )
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -494,7 +494,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
             repn = info.visitor.walk_expression((expr, None, None, 1))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.const, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -149,7 +149,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -203,7 +203,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -214,7 +214,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(1j)')
+        self.assertEqual(repn.constant, InvalidNumber(1j))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -253,7 +253,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -488,7 +488,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -498,7 +498,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -508,7 +508,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -551,7 +551,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -765,7 +765,8 @@ class TestLinear(unittest.TestCase):
         with LoggingIntercept() as LOG:
             repn = LinearRepnVisitor(*cfg).walk_expression(e)
         self.assertIn(
-            "DEPRECATED: Encountered 0*nan in expression tree.", LOG.getvalue()
+            "DEPRECATED: Encountered 0*InvalidNumber(nan) in expression tree.",
+            LOG.getvalue(),
         )
 
         self.assertEqual(cfg.subexpr, {})
@@ -1447,9 +1448,8 @@ class TestLinear(unittest.TestCase):
             "\texpression: (x + 1)/p\n",
         )
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
-        self.assertEqual(len(repn.linear), 1)
-        self.assertEqual(str(repn.linear[id(m.x)]), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
+        self.assertStructuredAlmostEqual(repn.linear, {id(m.x): InvalidNumber(nan)})
         self.assertEqual(repn.nonlinear, None)
 
         expr = m.y + m.x + m.z + ((3 * m.x) / m.p) / m.y
@@ -1464,16 +1464,16 @@ class TestLinear(unittest.TestCase):
         )
         self.assertEqual(repn.multiplier, 1)
         self.assertEqual(repn.constant, 1)
-        self.assertEqual(len(repn.linear), 2)
-        self.assertEqual(repn.linear[id(m.z)], 1)
-        self.assertEqual(str(repn.linear[id(m.x)]), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(
+            repn.linear, {id(m.z): 1, id(m.x): InvalidNumber(nan)}
+        )
         self.assertEqual(repn.nonlinear, None)
 
         m.y.fix(None)
         expr = log(m.y) + 3
         repn = LinearRepnVisitor(*cfg).walk_expression(expr)
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertStructuredAlmostEqual(repn.constant, InvalidNumber(nan))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -1631,7 +1631,9 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(array([3, 4]))')
+        self.assertStructuredAlmostEqual(
+            repn.constant, InvalidNumber(numpy.array([3, 4]))
+        )
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -242,7 +242,7 @@ class TestRepnUtils(unittest.TestCase):
             pyomo.repn.util.HALT_ON_EVALUATION_ERROR = False
             with LoggingIntercept() as LOG:
                 val = apply_node_operation(div, [1, 0])
-                self.assertEqual(str(val), "InvalidNumber(nan)")
+                self.assertStructuredAlmostEqual(val, InvalidNumber(float('nan')))
             self.assertEqual(
                 LOG.getvalue(),
                 "Exception encountered evaluating expression 'div(1, 0)'\n"
@@ -293,7 +293,7 @@ class TestRepnUtils(unittest.TestCase):
             pyomo.repn.util.HALT_ON_EVALUATION_ERROR = False
             with LoggingIntercept() as LOG:
                 val = complex_number_error(1j, visitor, exp)
-                self.assertEqual(str(val), "InvalidNumber(1j)")
+                self.assertEqual(val, InvalidNumber(1j))
             self.assertEqual(
                 LOG.getvalue(),
                 "Complex number returned from expression\n"

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -157,19 +157,37 @@ class InvalidNumber(PyomoObject):
             return InvalidNumber(self.value, causes)
 
     def __eq__(self, other):
-        return self._cmp(operator.eq, other)
+        ans = self._cmp(operator.eq, other)
+        try:
+            return bool(ans)
+        except ValueError:
+            # ValueError can be raised by numpy.ndarray when two arrays
+            # are returned.  In that case, ndarray returns a new ndarray
+            # of bool values.  We will fall back on using `all` to
+            # reduce it to a single bool.
+            try:
+                return all(ans)
+            except:
+                pass
+            raise
 
     def __lt__(self, other):
-        return self._cmp(operator.lt, other)
+        # Note that as < is ambiguous for arrays, we will attempt to
+        # cast the result to bool and if it was an array, allow the
+        # exception to propagate
+        return bool(self._cmp(operator.lt, other))
 
     def __gt__(self, other):
-        return self._cmp(operator.gt, other)
+        # See the comment in __lt__() on the use of bool()
+        return bool(self._cmp(operator.gt, other))
 
     def __le__(self, other):
-        return self._cmp(operator.le, other)
+        # See the comment in __lt__() on the use of bool()
+        return bool(self._cmp(operator.le, other))
 
     def __ge__(self, other):
-        return self._cmp(operator.ge, other)
+        # See the comment in __lt__() on the use of bool()
+        return bool(self._cmp(operator.ge, other))
 
     def _error(self, msg):
         causes = list(filter(None, self.causes))

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -197,14 +197,21 @@ class InvalidNumber(PyomoObject):
         raise InvalidValueError(msg)
 
     def __str__(self):
-        # We will support simple conversion of InvalidNumber to strings
-        # (for reporting purposes)
+        # We want attempts to convert InvalidNumber to a string
+        # representation to raise a InvalidValueError, unless we are in
+        # the middle of processing an exception.  In that case, it is
+        # very likely that an exception handler is generating an error
+        # message.  We will play nice and return a reasonable string.
+        if sys.exc_info()[1] is None:
+            self._error(f'Cannot emit {self._str()} in compiled representation')
+        else:
+            return self._str()
+
+    def _str(self):
         return f'InvalidNumber({self.value!r})'
 
     def __repr__(self):
-        # We want attempts to convert InvalidNumber to a string
-        # representation to raise a InvalidValueError.
-        self._error(f'Cannot emit {str(self)} in compiled representation')
+        return str(self)
 
     def __format__(self, format_spec):
         # FIXME: We want to move to where converting InvalidNumber to


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3386 .

## Summary/Motivation:
This resolves #3386 by making it so that *both* `InvalidNumber.__str__` and `InvalidNumber.__repr__` raise exceptions.  It was relatively straightforward to remove the use of string conversions in the tests so that we no longer needed t cast InvalidNumber to a string.  

Note that this includes an exception to the "str(InvalidNumber) raises an exception rule: if we are in the middle of processing an exception, this does not raise another exception and instead returns the old string representation.

## Changes proposed in this PR:
- Update `InvalidNumber` so that both `str()` and `repr()` raise exceptions
- Clean up how some deprecation warnings generate warnings about NaN
- Update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
