### PR TITLE
Update Xpress interfaces to support 9.5

### DIFF
--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -47,6 +47,15 @@ class _Hasher(collections.defaultdict):
     def _tuple(self, val):
         return tuple(self[i.__class__](i) for i in val)
 
+    def hashable(self, obj, hashable=None):
+        if isinstance(obj, type):
+            cls = obj
+        else:
+            cls = type(cls)
+        if hashable is None:
+            return self.get(cls, None) is self._hashable
+        self[cls] = self._hashable if hashable else self._unhashable
+
 
 _hasher = _Hasher()
 
@@ -78,6 +87,8 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
 
     __slots__ = ("_dict",)
     __autoslot_mappers__ = {'_dict': _rehash_keys}
+    # A "public" interface to the global _hasher dict
+    hasher = _hasher
 
     def __init__(self, *args, **kwds):
         # maps id_hash(obj) -> (obj,val)

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -51,9 +51,12 @@ class _Hasher(collections.defaultdict):
         if isinstance(obj, type):
             cls = obj
         else:
-            cls = type(cls)
+            cls = type(obj)
         if hashable is None:
-            return self.get(cls, None) is self._hashable
+            fcn = self.get(cls, None)
+            if fcn is None:
+                raise KeyError(obj)
+            return fcn is self._hashable
         self[cls] = self._hashable if hashable else self._unhashable
 
 
@@ -87,7 +90,7 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
 
     __slots__ = ("_dict",)
     __autoslot_mappers__ = {'_dict': _rehash_keys}
-    # A "public" interface to the global _hasher dict
+    # Expose a "public" interface to the global _hasher dict
     hasher = _hasher
 
     def __init__(self, *args, **kwds):

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -61,6 +61,8 @@ class ComponentSet(AutoSlots.Mixin, collections_MutableSet):
 
     __slots__ = ("_data",)
     __autoslot_mappers__ = {'_data': _rehash_keys}
+    # Expose a "public" interface to the global _hasher dict
+    hasher = _hasher
 
     def __init__(self, iterable=None):
         # maps id_hash(obj) -> obj

--- a/pyomo/common/tests/test_component_map.py
+++ b/pyomo/common/tests/test_component_map.py
@@ -49,6 +49,27 @@ class TestComponentMap(unittest.TestCase):
         self.assertIn((1, (2, m.v)), m.cm)
         self.assertNotIn((1, (2, m.v)), i.cm)
 
+    def test_hasher(self):
+        m = ComponentMap()
+        a = 'str'
+        m[a] = 5
+        self.assertTrue(m.hasher.hashable(a))
+        self.assertTrue(m.hasher.hashable(str))
+        self.assertEqual(m._dict, {a: (a, 5)})
+        del m[a]
+
+        m.hasher.hashable(a, False)
+        m[a] = 5
+        self.assertFalse(m.hasher.hashable(a))
+        self.assertFalse(m.hasher.hashable(str))
+        self.assertEqual(m._dict, {id(a): (a, 5)})
+
+        class TMP:
+            pass
+
+        with self.assertRaises(KeyError):
+            m.hasher.hashable(TMP)
+
 
 class TestDefaultComponentMap(unittest.TestCase):
     def test_default_component_map(self):

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -400,11 +400,15 @@ class PersistentSolver(DirectOrPersistentSolver):
                 + 'objective or one or more constraints'
             )
         solver_var = self._pyomo_var_to_solver_var_map[var]
-        self._remove_var(solver_var)
         self._symbol_map.removeSymbol(var)
         del self._referenced_variables[var]
         del self._pyomo_var_to_solver_var_map[var]
         del self._solver_var_to_pyomo_var_map[solver_var]
+        # Note: we want to remove the solver_var from all our internal
+        # mappings *before* removing it from the solver (the solver may
+        # invalidate teh object, leading to exceptions when looking it
+        # up in ComponentMaps)
+        self._remove_var(solver_var)
 
     """ This method should be implemented by subclasses."""
 

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -400,15 +400,11 @@ class PersistentSolver(DirectOrPersistentSolver):
                 + 'objective or one or more constraints'
             )
         solver_var = self._pyomo_var_to_solver_var_map[var]
+        self._remove_var(solver_var)
         self._symbol_map.removeSymbol(var)
         del self._referenced_variables[var]
         del self._pyomo_var_to_solver_var_map[var]
         del self._solver_var_to_pyomo_var_map[solver_var]
-        # Note: we want to remove the solver_var from all our internal
-        # mappings *before* removing it from the solver (the solver may
-        # invalidate the object, leading to exceptions when looking it
-        # up in ComponentMaps)
-        self._remove_var(solver_var)
 
     """ This method should be implemented by subclasses."""
 

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -406,7 +406,7 @@ class PersistentSolver(DirectOrPersistentSolver):
         del self._solver_var_to_pyomo_var_map[solver_var]
         # Note: we want to remove the solver_var from all our internal
         # mappings *before* removing it from the solver (the solver may
-        # invalidate teh object, leading to exceptions when looking it
+        # invalidate the object, leading to exceptions when looking it
         # up in ComponentMaps)
         self._remove_var(solver_var)
 

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -313,7 +313,8 @@ class XpressDirect(DirectSolver):
         if self._tee and XpressDirect._version[0] < 36:
             self._solver_model.removecbmessage(_print_message, None)
 
-        # FIXME: can we get a return code indicating if XPRESS had a significant failure?
+        # FIXME: can we get a return code indicating if XPRESS had a
+        # significant failure?
         return Bunch(rc=None, log=None)
 
     def _get_mip_results(self, results, soln):
@@ -333,7 +334,8 @@ class XpressDirect(DirectSolver):
             )
             results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.unknown
-            # no MIP solution, first LP did not solve, second LP did, third search started but incomplete
+            # no MIP solution, first LP did not solve, second LP did,
+            # third search started but incomplete
         elif (
             status == xp.mip_lp_not_optimal
             or status == xp.mip_lp_optimal
@@ -862,10 +864,12 @@ class XpressDirect(DirectSolver):
         self._solver_con_to_pyomo_con_map[xpress_con] = con
 
     def _xpress_vartype_from_var(self, var):
-        """
-        This function takes a pyomo variable and returns the appropriate xpress variable type
+        """This function takes a pyomo variable and returns the appropriate
+        xpress variable type
+
         :param var: pyomo.core.base.var.Var
         :return: xpress.continuous or xpress.binary or xpress.integer
+
         """
         if var.is_binary():
             vartype = xpress.binary
@@ -994,10 +998,9 @@ class XpressDirect(DirectSolver):
         # see if there is a solution available - this may not always
         # be the case, both in LP and MIP contexts.
         if self._save_results:
-            """
-            This code in this if statement is only needed for backwards compatibility. It is more efficient to set
-            _save_results to False and use load_vars, load_duals, etc.
-            """
+            # This code in this if statement is only needed for backwards
+            # compatibility. It is more efficient to set _save_results to
+            # False and use load_vars, load_duals, etc.
             if have_soln:
                 soln_variables = soln.variable
                 soln_constraints = soln.constraint
@@ -1163,32 +1166,34 @@ class XpressDirect(DirectSolver):
                 slack[pyomo_con] = val
 
     def load_duals(self, cons_to_load=None):
-        """
-        Load the duals into the 'dual' suffix. The 'dual' suffix must live on the parent model.
+        """Load the duals into the 'dual' suffix. The 'dual' suffix must live
+        on the parent model.
 
         Parameters
         ----------
         cons_to_load: list of Constraint
+
         """
         self._load_duals(cons_to_load)
 
     def load_rc(self, vars_to_load=None):
-        """
-        Load the reduced costs into the 'rc' suffix. The 'rc' suffix must live on the parent model.
+        """Load the reduced costs into the 'rc' suffix. The 'rc' suffix must
+        live on the parent model.
 
         Parameters
         ----------
         vars_to_load: list of Var
+
         """
         self._load_rc(vars_to_load)
 
     def load_slacks(self, cons_to_load=None):
-        """
-        Load the values of the slack variables into the 'slack' suffix. The 'slack' suffix must live on the parent
-        model.
+        """Load the values of the slack variables into the 'slack' suffix. The
+        'slack' suffix must live on the parent model.
 
         Parameters
         ----------
         cons_to_load: list of Constraint
+
         """
         self._load_slacks(cons_to_load)

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -162,6 +162,13 @@ def _finalize_xpress_import(xpress, avail):
         XpressDirect._getDuals = lambda self, prob, con: prob.getDuals(con)
         XpressDirect._getRedCosts = lambda self, prob, con: prob.getRedCosts(con)
 
+        # Note that as of 9.5, xpress.var raises an exception when
+        # compared using '==' after it has been removed from the model.
+        # This can fould up ComponentMaps in the persistent interface,
+        # so we will hard-code the `var` as not being hashable (so the
+        # ComponentMap will use the id() as the key)
+        ComponentMap.hasher.hashable(xpress.var, False)
+
 
 class _xpress_importer_class(object):
     # We want to be able to *update* the message that the deferred

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -76,8 +76,8 @@ def _finalize_xpress_import(xpress, avail):
         xpress.rng = xpress.range
 
     #
-    # Xpress 9.5 (44.1.1) changed the Python fairly significantly.  we will map
-    # between the two APIs based on the version.
+    # Xpress 9.5 (44.1.1) changed the Python API fairly significantly.
+    # We will map between the two APIs based on the version.
     #
     if XpressDirect._version < (44,):
 
@@ -164,7 +164,7 @@ def _finalize_xpress_import(xpress, avail):
 
         # Note that as of 9.5, xpress.var raises an exception when
         # compared using '==' after it has been removed from the model.
-        # This can fould up ComponentMaps in the persistent interface,
+        # This can foul up ComponentMaps in the persistent interface,
         # so we will hard-code the `var` as not being hashable (so the
         # ComponentMap will use the id() as the key)
         ComponentMap.hasher.hashable(xpress.var, False)

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -291,6 +291,9 @@ class TestXpressPersistent(unittest.TestCase):
 
         opt = pe.SolverFactory('xpress_direct')
         opt.options['XSLP_SOLVER'] = 0
+        # xpress 9.5.0 now defaults to trying (and failing) to solve this problem
+        # using the global solver. This option forces the use of the local solver.
+        opt.options['NLPSOLVER'] = 1
 
         results = opt.solve(m)
         self.assertEqual(results.solver.status, SolverStatus.ok)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3391 .

## Summary/Motivation:
Xpress 9.5 was a disruptive release that introduced deprecation warnings and broke a number of tests.  This PR builds on https://github.com/blnicho/pyomo/tree/xpress-9.5.0 and adds a compatibility shim to the underlying `xpress` module to support both pre- and post-9.5 Xpress.

## Changes proposed in this PR:
- Add a compatibility shim to the XpressDirect class for interacting with `xpress`
- Update one test to track a change in the default Xpress behavior
- Update ComponentMap / ComponentSet to expost the internal `hasher` dict and add a `hasher.hashable()` method to query / set the hashability for a given type.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
