### PR TITLE
Update test for GAMS mapping 'infeasible or unbounded' to infeasible

### DIFF
--- a/pyomo/solvers/tests/models/LP_unbounded.py
+++ b/pyomo/solvers/tests/models/LP_unbounded.py
@@ -46,19 +46,17 @@ class LP_unbounded(_BaseTestModel):
         model.y.value = None
 
     def post_solve_test_validation(self, tester, results):
+        outcomes = [
+            TerminationCondition.unbounded,
+            TerminationCondition.infeasibleOrUnbounded,
+        ]
+        if '_gams_' in str(tester):
+            # GAMS maps CPLEX's InfeasibleOrUnbounded to Infeasible
+            outcomes.append(TerminationCondition.infeasible)
         if tester is None:
-            assert results['Solver'][0]['termination condition'] in (
-                TerminationCondition.unbounded,
-                TerminationCondition.infeasibleOrUnbounded,
-            )
+            assert results['Solver'][0]['termination condition'] in outcomes
         else:
-            tester.assertIn(
-                results['Solver'][0]['termination condition'],
-                (
-                    TerminationCondition.unbounded,
-                    TerminationCondition.infeasibleOrUnbounded,
-                ),
-            )
+            tester.assertIn(results['Solver'][0]['termination condition'], outcomes)
 
 
 @register_model


### PR DESCRIPTION

<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves test failures due to GAMS mapping CPLEX's "infeasible or unbounded" solution status to "infeasible".

## Changes proposed in this PR:
- Allow unbounded LPs to return "infeasible" for tests using GAMS

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
