### PR TITLE
Fixing spelling found by new typos release (v1.27.0)

### DIFF
--- a/doc/OnlineDocs/howto/manipulating.rst
+++ b/doc/OnlineDocs/howto/manipulating.rst
@@ -162,7 +162,7 @@ that the expression be greater than or equal to one:
 .. literalinclude:: /src/scripting/iterative1_Add_expression_constraint.spy
    :language: python
 
-The proof that this precludes the last solution is left as an exerise
+The proof that this precludes the last solution is left as an exercise
 for the reader.
 
 The final lines in the outer for loop find a solution and display it:

--- a/pyomo/contrib/gdpopt/config_options.py
+++ b/pyomo/contrib/gdpopt/config_options.py
@@ -436,7 +436,7 @@ def _add_mip_solver_configs(CONFIG):
         ConfigValue(
             default="gurobi",
             description="""
-            Mixed-integer linear solver to use. Note that no persisent solvers
+            Mixed-integer linear solver to use. Note that no persistent solvers
             other than the auto-persistent solvers in the APPSI package are
             supported.""",
         ),
@@ -457,7 +457,7 @@ def _add_nlp_solver_configs(CONFIG, default_solver):
         ConfigValue(
             default=default_solver,
             description="""
-            Nonlinear solver to use. Note that no persisent solvers
+            Nonlinear solver to use. Note that no persistent solvers
             other than the auto-persistent solvers in the APPSI package are
             supported.""",
         ),
@@ -475,7 +475,7 @@ def _add_nlp_solver_configs(CONFIG, default_solver):
         ConfigValue(
             default="baron",
             description="""
-            Mixed-integer nonlinear solver to use. Note that no persisent solvers
+            Mixed-integer nonlinear solver to use. Note that no persistent solvers
             other than the auto-persistent solvers in the APPSI package are
             supported.""",
         ),
@@ -493,7 +493,7 @@ def _add_nlp_solver_configs(CONFIG, default_solver):
         ConfigValue(
             default="bonmin",
             description="""
-            Mixed-integer nonlinear solver to use. Note that no persisent solvers
+            Mixed-integer nonlinear solver to use. Note that no persistent solvers
             other than the auto-persistent solvers in the APPSI package are
             supported.""",
         ),

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -3477,7 +3477,7 @@ class TestPolynomialDegree(unittest.TestCase):
     def test_Expr_if(self):
         m = self.instance
         #
-        # When IF conditional is constant, then polynomial degree is propigated
+        # When IF conditional is constant, then polynomial degree is propagated
         #
         expr = Expr_if(1, m.a**3, m.a**2)
         self.assertEqual(expr.polynomial_degree(), 3)

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -189,7 +189,7 @@ def help_transformations():
         # The next best thing is to ensure that the deprecation status
         # is indicated here.
         _init_doc = TransformationFactory.get_class(xform).__init__.__doc__ or ""
-        if _init_doc.strip().startswith('DEPRECATED') and 'DEPRECAT' not in _doc:
+        if _init_doc.strip().startswith('DEPRECATED') and 'DEPRECATE' not in _doc:
             _doc = ' '.join(('[DEPRECATED]', _doc))
         if _doc:
             print(wrapper.fill(_doc))


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This fixes spelling errors detected by the new release of the `typos` package (v1.27.0)

## Changes proposed in this PR:
- Change one search pattern in the `pyomo help` processing.  This should not change the current behavior
- NFC: fix spelling errors.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
