### PR TITLE
Catch catastrophic solver failure when building MIS

### DIFF
--- a/pyomo/contrib/iis/mis.py
+++ b/pyomo/contrib/iis/mis.py
@@ -287,7 +287,7 @@ def compute_infeasibility_explanation(
     except:
         results = None
 
-    if pyo.check_optimal_termination(results):
+    if (results is not None) and pyo.check_optimal_termination(results):
         msg += "Could not determine Minimal Intractable System\n"
     else:
         deletion_filter = []


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes https://github.com/IDAES/idaes-pse/issues/1520

## Summary/Motivation:
The minimal intractable system calculation had a try/except around a solve we expect to fail, but when we check for failure we failed to first check the results object against `None`.

## Changes proposed in this PR:
- Insert `results is not None` conditional to short-circuit, thus not calling `pyo.check_optimal_termination(results)` if `results is None`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
