### PR TITLE
Reduce the number of formats built on readthedocs to avoid timing out

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,8 @@ build:
 sphinx:
    configuration: doc/OnlineDocs/conf.py
 
-formats: all
+formats:
+  - pdf
 
 # Set the version of Python and requirements required to build the docs
 python:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Following some recent online doc changes (including more extensive library references and improved enum documentation) we are now hitting the build time limit on readthedocs. This PR reduces the number of downloadable formats that we build to get us back under the time limit. 

## Changes proposed in this PR:
- Only build the pdf downloadable format on readthedocs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
