### PR TITLE
Resolve PyNumero incompatibilities with NumPy2

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -142,7 +142,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.13
+          python: 3.12
           other: /numpy2
           slim: 1
           skip_doctest: 1

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -142,6 +142,15 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
+          python: 3.13
+          other: /numpy2
+          slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+          PACKAGES: 'numpy>2.0' scipy networkx dill gurobipy
+
+        - os: ubuntu-latest
           python: 3.9
           other: /pyutilib
           TARGET: linux

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -148,7 +148,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
-          PACKAGES: numpy scipy networkx dill gurobipy
+          PACKAGES: "gurobipy dill 'numpy>2.0' scipy networkx"
 
         - os: ubuntu-latest
           python: 3.9

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -148,7 +148,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
-          PACKAGES: 'numpy>2.0' scipy networkx dill gurobipy
+          PACKAGES: numpy scipy networkx dill gurobipy
 
         - os: ubuntu-latest
           python: 3.9

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -148,7 +148,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
-          PACKAGES: "gurobipy dill 'numpy>2.0' scipy networkx"
+          PACKAGES: "gurobipy dill numpy>2.0 scipy networkx"
 
         - os: ubuntu-latest
           python: 3.9

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -15,10 +15,10 @@ from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.core.expr.visitor import identify_variables
 import pyomo.environ as pyo
 
+from pyomo.common.dependencies import networkx_available as nx_available
 from pyomo.contrib.pynumero.dependencies import (
     numpy as np,
     numpy_available,
-    scipy,
     scipy_available,
 )
 
@@ -151,6 +151,7 @@ def make_dynamic_model():
 
 
 class TestExternalGreyBoxBlock(unittest.TestCase):
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_construct_scalar(self):
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)
@@ -171,6 +172,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
         self.assertEqual(len(block.outputs), 0)
         self.assertEqual(len(block._equality_constraint_names), 2)
 
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_construct_indexed(self):
         block = ExternalGreyBoxBlock([0, 1, 2], concrete=True)
         self.assertIs(type(block), IndexedExternalGreyBoxBlock)
@@ -192,6 +194,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
             self.assertEqual(len(b._equality_constraint_names), 2)
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_solve_square(self):
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)
@@ -234,6 +237,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
         self.assertAlmostEqual(m_ex.y.value, y.value, delta=1e-8)
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_optimize(self):
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)
@@ -292,6 +296,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
         self.assertAlmostEqual(m_ex.y.value, y.value, delta=1e-8)
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_optimize_with_cyipopt_for_inner_problem(self):
         # Use CyIpopt, rather than the default SciPy solvers,
         # for the inner problem
@@ -427,6 +432,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
         self.assertAlmostEqual(m_ex.x.value, x.value, delta=1e-8)
         self.assertAlmostEqual(m_ex.y.value, y.value, delta=1e-8)
 
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_construct_dynamic(self):
         m = make_dynamic_model()
         time = m.time
@@ -504,6 +510,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
         )
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_solve_square_dynamic(self):
         # Create the "external model"
         m = make_dynamic_model()
@@ -571,6 +578,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
             self.assertStructuredAlmostEqual(values, target_values, delta=1e-5)
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_optimize_dynamic(self):
         # Create the "external model"
         m = make_dynamic_model()
@@ -653,6 +661,7 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
             self.assertStructuredAlmostEqual(values, target_values, delta=1e-5)
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    @unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
     def test_optimize_dynamic_references(self):
         """
         When when pre-existing variables are attached to the EGBB
@@ -717,7 +726,8 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
             self.assertStructuredAlmostEqual(values, target_values, delta=1e-5)
 
 
-class TestPyomoNLPWithGreyBoxBLocks(unittest.TestCase):
+@unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
+class TestPyomoNLPWithGreyBoxBlocks(unittest.TestCase):
     def test_set_and_evaluate(self):
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_model.py
@@ -13,6 +13,7 @@ import itertools
 import pyomo.common.unittest as unittest
 import pyomo.environ as pyo
 
+from pyomo.common.dependencies import networkx_available as nx_available
 from pyomo.contrib.pynumero.dependencies import (
     numpy as np,
     numpy_available,
@@ -513,6 +514,7 @@ class TestGetHessianOfConstraint(unittest.TestCase):
         np.testing.assert_allclose(hess.data, data, rtol=1e-8)
 
 
+@unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
 class TestExternalPyomoModel(unittest.TestCase):
     def test_evaluate_SimpleModel1(self):
         model = SimpleModel1()
@@ -838,6 +840,7 @@ class TestExternalPyomoModel(unittest.TestCase):
             np.testing.assert_allclose(hess_lag, expected_hess_lag, rtol=1e-8)
 
 
+@unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
 class TestUpdatedHessianCalculationMethods(unittest.TestCase):
     """
     These tests exercise the methods for fast Hessian-of-Lagrangian
@@ -1021,6 +1024,7 @@ class TestUpdatedHessianCalculationMethods(unittest.TestCase):
             )
 
 
+@unittest.skipUnless(nx_available, "SCCImplicitFunctionSolver requires networkx")
 class TestScaling(unittest.TestCase):
     def con_3_body(self, x, y, u, v):
         return 1e5 * x**2 + 1e4 * y**2 + 1e1 * u**2 + 1e0 * v**2

--- a/pyomo/contrib/pynumero/sparse/base_block.py
+++ b/pyomo/contrib/pynumero/sparse/base_block.py
@@ -258,7 +258,7 @@ vec_binary_ufuncs = {
     np.remainder,
     np.mod,
     np.fmod,
-    # np.divmod,  # dieabled because shape is not preserved
+    # np.divmod,  # disabled because shape is not preserved
     np.heaviside,
     np.gcd,
     np.lcm,

--- a/pyomo/contrib/pynumero/sparse/base_block.py
+++ b/pyomo/contrib/pynumero/sparse/base_block.py
@@ -11,6 +11,8 @@
 
 # These classes are for checking types consistently and raising errors
 
+from ..dependencies import numpy as np
+
 
 class BaseBlockVector(object):
     """Base class for block vectors"""
@@ -177,3 +179,128 @@ class BaseBlockMatrix(object):
     def tostring(self, order='C'):
         msg = "tostring not implemented for {}".format(self.__class__.__name__)
         raise NotImplementedError(msg)
+
+
+#: NumPy ufuncs that take one vector and are compatible with pyNumero vectors
+vec_unary_ufuncs = {
+    ## MATH ufuncs
+    np.negative,
+    np.positive,
+    np.absolute,
+    np.fabs,
+    np.rint,
+    np.sign,
+    np.conj,
+    np.conjugate,
+    np.exp,
+    np.exp2,
+    np.log,
+    np.log2,
+    np.log10,
+    np.expm1,
+    np.log1p,
+    np.sqrt,
+    np.square,
+    np.cbrt,
+    np.reciprocal,
+    ## TRIG ufuncs
+    np.sin,
+    np.cos,
+    np.tan,
+    np.arcsin,
+    np.arccos,
+    np.arctan,
+    np.sinh,
+    np.cosh,
+    np.tanh,
+    np.arcsinh,
+    np.arccosh,
+    np.arctanh,
+    np.degrees,
+    np.radians,
+    np.deg2rad,
+    np.rad2deg,
+    ## COMPARISON ufuncs
+    np.logical_not,
+    ## BIT-TWIDDLING ufuncs
+    np.invert,
+    ## FLOATING ufuncs
+    np.isfinite,
+    np.isinf,
+    np.isnan,
+    # np.isnat,  # only defined for datetime
+    np.fabs,  # numpy docs list here and in MATH
+    np.signbit,
+    np.spacing,
+    # np.modf, # disabled because shape is not preserved
+    # np.frexp, # disabled because shape is not preserved
+    np.floor,
+    np.ceil,
+    np.trunc,
+    # OTHER (not listed in ufuncs docs)
+    np.abs,
+}
+
+#: NumPy ufuncs that take two vectors and are compatible with pyNumero vectors
+vec_binary_ufuncs = {
+    ## MATH ufuncs
+    np.add,
+    np.subtract,
+    np.multiply,
+    # np.matmult, # disabled because shape is not preserved
+    np.divide,
+    np.logaddexp,
+    np.logaddexp2,
+    np.true_divide,
+    np.floor_divide,
+    np.power,
+    np.float_power,
+    np.remainder,
+    np.mod,
+    np.fmod,
+    # np.divmod,  # dieabled because shape is not preserved
+    np.heaviside,
+    np.gcd,
+    np.lcm,
+    ## TRIG ufuncs
+    np.arctan2,
+    np.hypot,
+    ## BIT-TWIDDLING ufuncs
+    np.bitwise_and,
+    np.bitwise_or,
+    np.bitwise_xor,
+    np.left_shift,
+    np.right_shift,
+    ## COMPARISON ufuncs
+    np.greater,
+    np.greater_equal,
+    np.less,
+    np.less_equal,
+    np.not_equal,
+    np.equal,
+    np.logical_and,
+    np.logical_or,
+    np.logical_xor,
+    np.maximum,
+    np.minimum,
+    np.fmax,
+    np.fmin,
+    ## FLOATING ufincs
+    np.copysign,
+    np.nextafter,
+    np.ldexp,
+    np.fmod,  # numpy docs list here and in MATH
+}
+
+#: NumPy ufuncs can be used as reductions for pyNumero vectors
+vec_associative_reductions = {
+    np.add,
+    np.multiply,
+    np.bitwise_and,
+    np.bitwise_or,
+    np.bitwise_xor,
+    np.maximum,
+    np.minimum,
+    np.fmax,
+    np.fmin,
+}

--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -183,7 +183,12 @@ For example,
 import operator
 
 from ..dependencies import numpy as np
-from .base_block import BaseBlockVector
+from .base_block import (
+    BaseBlockVector,
+    vec_unary_ufuncs,
+    vec_binary_ufuncs,
+    vec_associative_reductions,
+)
 
 
 class NotFullyDefinedBlockVectorError(Exception):
@@ -265,74 +270,6 @@ class BlockVector(BaseBlockVector, np.ndarray):
         return super(BlockVector, self).__array_wrap__(self, out_arr, context)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        """Runs ufuncs speciallizations to BlockVector"""
-        # functions that take one vector
-        unary_funcs = [
-            np.log10,
-            np.sin,
-            np.cos,
-            np.exp,
-            np.ceil,
-            np.floor,
-            np.tan,
-            np.arctan,
-            np.arcsin,
-            np.arccos,
-            np.sinh,
-            np.cosh,
-            np.abs,
-            np.tanh,
-            np.arccosh,
-            np.arcsinh,
-            np.arctanh,
-            np.fabs,
-            np.sqrt,
-            np.log,
-            np.log2,
-            np.absolute,
-            np.isfinite,
-            np.isinf,
-            np.isnan,
-            np.log1p,
-            np.logical_not,
-            np.expm1,
-            np.exp2,
-            np.sign,
-            np.rint,
-            np.square,
-            np.positive,
-            np.negative,
-            np.rad2deg,
-            np.deg2rad,
-            np.conjugate,
-            np.reciprocal,
-            np.signbit,
-        ]
-
-        # functions that take two vectors
-        binary_funcs = [
-            np.add,
-            np.multiply,
-            np.divide,
-            np.subtract,
-            np.greater,
-            np.greater_equal,
-            np.less,
-            np.less_equal,
-            np.not_equal,
-            np.maximum,
-            np.minimum,
-            np.fmax,
-            np.fmin,
-            np.equal,
-            np.logical_and,
-            np.logical_or,
-            np.logical_xor,
-            np.logaddexp,
-            np.logaddexp2,
-            np.remainder,
-            np.heaviside,
-            np.hypot,
         ]
 
         args = [input_ for i, input_ in enumerate(inputs)]

--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -57,7 +57,7 @@ NumPy compatible methods:
    * :py:meth:`~numpy.ndarray.conj`
    * :py:meth:`~numpy.ndarray.conjugate`
    * :py:meth:`~numpy.ndarray.nonzero`
-   * :py:meth:`~numpy.ndarray.ptp`
+   * :py:meth:`~numpy.ndarray.ptp` (NumPy 1.x only)
    * :py:meth:`~numpy.ndarray.round`
    * :py:meth:`~numpy.ndarray.std`
    * :py:meth:`~numpy.ndarray.var`
@@ -679,13 +679,15 @@ class BlockVector(BaseBlockVector, np.ndarray):
             result.set_block(idx, self.get_block(idx).nonzero()[0])
         return (result,)
 
-    def ptp(self, axis=None, out=None, keepdims=False):
-        """
-        Peak to peak (maximum - minimum) value along a given axis.
-        """
-        assert_block_structure(self)
-        assert out is None, 'Out keyword not supported'
-        return self.max() - self.min()
+    if np.__version__[0] < '2':
+
+        def ptp(self, axis=None, out=None, keepdims=False):
+            """
+            Peak to peak (maximum - minimum) value along a given axis.
+            """
+            assert_block_structure(self)
+            assert out is None, 'Out keyword not supported'
+            return self.max() - self.min()
 
     def round(self, decimals=0, out=None):
         """

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -11,7 +11,12 @@
 
 from pyomo.common.dependencies import mpi4py
 from pyomo.contrib.pynumero.sparse import BlockVector
-from .base_block import BaseBlockVector
+from .base_block import (
+    BaseBlockVector,
+    vec_unary_ufuncs,
+    vec_binary_ufuncs,
+    vec_associative_reductions,
+)
 from .block_vector import NotFullyDefinedBlockVectorError
 from .block_vector import assert_block_structure as block_vector_assert_block_structure
 import numpy as np
@@ -136,74 +141,6 @@ class MPIBlockVector(BaseBlockVector, np.ndarray):
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """Runs ufuncs speciallizations to MPIBlockVector"""
-        # functions that take one vector
-        unary_funcs = [
-            np.log10,
-            np.sin,
-            np.cos,
-            np.exp,
-            np.ceil,
-            np.floor,
-            np.tan,
-            np.arctan,
-            np.arcsin,
-            np.arccos,
-            np.sinh,
-            np.cosh,
-            np.abs,
-            np.tanh,
-            np.arccosh,
-            np.arcsinh,
-            np.arctanh,
-            np.fabs,
-            np.sqrt,
-            np.log,
-            np.log2,
-            np.absolute,
-            np.isfinite,
-            np.isinf,
-            np.isnan,
-            np.log1p,
-            np.logical_not,
-            np.expm1,
-            np.exp2,
-            np.sign,
-            np.rint,
-            np.square,
-            np.positive,
-            np.negative,
-            np.rad2deg,
-            np.deg2rad,
-            np.conjugate,
-            np.reciprocal,
-            np.signbit,
-        ]
-        # functions that take two vectors
-        binary_funcs = [
-            np.add,
-            np.multiply,
-            np.divide,
-            np.subtract,
-            np.greater,
-            np.greater_equal,
-            np.less,
-            np.less_equal,
-            np.not_equal,
-            np.maximum,
-            np.minimum,
-            np.fmax,
-            np.fmin,
-            np.equal,
-            np.logical_and,
-            np.logical_or,
-            np.logical_xor,
-            np.logaddexp,
-            np.logaddexp2,
-            np.remainder,
-            np.heaviside,
-            np.hypot,
-        ]
-
         outputs = kwargs.pop('out', None)
         if outputs is not None:
             raise NotImplementedError(
@@ -211,10 +148,10 @@ class MPIBlockVector(BaseBlockVector, np.ndarray):
                 + ' cannot be used with MPIBlockVector if the out keyword argument is given.'
             )
 
-        if ufunc in unary_funcs:
+        if ufunc in vec_unary_ufuncs:
             results = self._unary_operation(ufunc, method, *inputs, **kwargs)
             return results
-        elif ufunc in binary_funcs:
+        elif ufunc in vec_binary_ufuncs:
             results = self._binary_operation(ufunc, method, *inputs, **kwargs)
             return results
         else:

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -24,6 +24,9 @@ if not (numpy_available and scipy_available):
 from pyomo.contrib.pynumero.sparse.block_vector import (
     BlockVector,
     NotFullyDefinedBlockVectorError,
+    vec_associative_reductions,
+    vec_unary_ufuncs,
+    vec_binary_ufuncs,
 )
 
 
@@ -1023,64 +1026,34 @@ class TestBlockVector(unittest.TestCase):
         self.assertEqual(v.get_block(1).size, v2.get_block(1).size)
 
     def test_unary_ufuncs(self):
-        v = BlockVector(2)
         a = np.ones(3) * 0.5
         b = np.ones(2) * 0.8
+        v = BlockVector(2)
         v.set_block(0, a)
         v.set_block(1, b)
+        # Some operations only accept integers
+        ai = np.ones(3, dtype='i') * 5
+        bi = np.ones(2, dtype='i') * 8
+        vi = BlockVector(2)
+        vi.set_block(0, ai)
+        vi.set_block(1, bi)
+
+        _int_ufuncs = {np.invert, np.arccosh}
 
         v2 = BlockVector(2)
-
-        unary_funcs = [
-            np.log10,
-            np.sin,
-            np.cos,
-            np.exp,
-            np.ceil,
-            np.floor,
-            np.tan,
-            np.arctan,
-            np.arcsin,
-            np.arccos,
-            np.sinh,
-            np.cosh,
-            np.abs,
-            np.tanh,
-            np.arcsinh,
-            np.arctanh,
-            np.fabs,
-            np.sqrt,
-            np.log,
-            np.log2,
-            np.absolute,
-            np.isfinite,
-            np.isinf,
-            np.isnan,
-            np.log1p,
-            np.logical_not,
-            np.exp2,
-            np.expm1,
-            np.sign,
-            np.rint,
-            np.square,
-            np.positive,
-            np.negative,
-            np.rad2deg,
-            np.deg2rad,
-            np.conjugate,
-            np.reciprocal,
-        ]
-
-        for fun in unary_funcs:
-            v2.set_block(0, fun(v.get_block(0)))
-            v2.set_block(1, fun(v.get_block(1)))
-            res = fun(v)
+        for fun in vec_unary_ufuncs:
+            _v = vi if fun in _int_ufuncs else v
+            v2.set_block(0, fun(_v.get_block(0)))
+            v2.set_block(1, fun(_v.get_block(1)))
+            res = fun(_v)
             self.assertIsInstance(res, BlockVector)
             self.assertEqual(res.nblocks, 2)
             for i in range(2):
                 self.assertTrue(np.allclose(res.get_block(i), v2.get_block(i)))
 
-        other_funcs = [np.cumsum, np.cumprod, np.cumproduct]
+        other_funcs = [np.cumsum, np.cumprod]
+        if np.__version__[0] == '1':
+            other_funcs.append(np.cumproduct)
 
         for fun in other_funcs:
             res = fun(v)
@@ -1088,13 +1061,14 @@ class TestBlockVector(unittest.TestCase):
             self.assertEqual(res.nblocks, 2)
             self.assertTrue(np.allclose(fun(v.flatten()), res.flatten()))
 
-        with self.assertRaises(Exception) as context:
-            np.cbrt(v)
+        with self.assertRaises(TypeError):
+            np.modf(v)
 
     def test_reduce_ufuncs(self):
         v = BlockVector(2)
-        a = np.ones(3) * 0.5
-        b = np.ones(2) * 0.8
+        # Some operations only accept integers, so we will test with integers
+        a = np.ones(3, dtype='i') * 5
+        b = np.ones(2, dtype='i') * 8
         v.set_block(0, a)
         v.set_block(1, b)
 
@@ -1108,56 +1082,45 @@ class TestBlockVector(unittest.TestCase):
 
     def test_binary_ufuncs(self):
         v = BlockVector(2)
-        a = np.ones(3) * 0.5
-        b = np.ones(2) * 0.8
-        v.set_block(0, a)
-        v.set_block(1, b)
-
+        v.set_blocks([np.ones(3) * 0.5, np.ones(2) * 0.8])
         v2 = BlockVector(2)
-        a2 = np.ones(3) * 3.0
-        b2 = np.ones(2) * 2.8
-        v2.set_block(0, a2)
-        v2.set_block(1, b2)
+        v2.set_blocks([np.ones(3) * 3.0, np.ones(2) * 2.8])
 
-        binary_ufuncs = [
-            np.add,
-            np.multiply,
-            np.divide,
-            np.subtract,
-            np.greater,
-            np.greater_equal,
-            np.less,
-            np.less_equal,
-            np.not_equal,
-            np.maximum,
-            np.minimum,
-            np.fmax,
-            np.fmin,
-            np.equal,
-            np.logaddexp,
-            np.logaddexp2,
-            np.remainder,
-            np.heaviside,
-            np.hypot,
-        ]
+        vi = BlockVector(2)
+        vi.set_blocks([np.ones(3, dtype='i') * 5, np.ones(2, dtype='i') * 8])
+        v2i = BlockVector(2)
+        v2i.set_blocks([np.ones(3, dtype='i') * 3, np.ones(2, dtype='i') * 2])
 
-        for fun in binary_ufuncs:
-            flat_res = fun(v.flatten(), v2.flatten())
-            res = fun(v, v2)
+        _int_ufuncs = {
+            np.gcd,
+            np.lcm,
+            np.ldexp,
+            np.left_shift,
+            np.right_shift,
+            np.bitwise_and,
+            np.bitwise_or,
+            np.bitwise_xor,
+        }
+
+        for fun in vec_binary_ufuncs:
+            _v, _v2, _s = (vi, v2i, 3) if fun in _int_ufuncs else (v, v2, 3.0)
+
+            flat_res = fun(_v.flatten(), _v2.flatten())
+            res = fun(_v, _v2)
             self.assertTrue(np.allclose(flat_res, res.flatten()))
 
-            res = fun(v, v2.flatten())
+            res = fun(_v, _v2.flatten())
             self.assertTrue(np.allclose(flat_res, res.flatten()))
 
-            res = fun(v.flatten(), v2)
+            res = fun(_v.flatten(), _v2)
             self.assertTrue(np.allclose(flat_res, res.flatten()))
 
-            flat_res = fun(v.flatten(), 5)
-            res = fun(v, 5)
+            flat_res = fun(_v.flatten(), 5)
+            res = fun(_v, 5)
             self.assertTrue(np.allclose(flat_res, res.flatten()))
 
-            flat_res = fun(3.0, v2.flatten())
-            res = fun(3.0, v2)
+            flat_res = fun(_s, _v2.flatten())
+            res = fun(_s, _v2)
             self.assertTrue(np.allclose(flat_res, res.flatten()))
 
         v = BlockVector(2)

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -1073,6 +1073,9 @@ class TestBlockVector(unittest.TestCase):
         v.set_block(0, a)
         v.set_block(1, b)
 
+        for fun in vec_associative_reductions:
+            self.assertAlmostEqual(fun.reduce(v), fun.reduce(v.flatten()))
+
         reduce_funcs = [np.sum, np.max, np.min, np.prod, np.mean]
         for fun in reduce_funcs:
             self.assertAlmostEqual(fun(v), fun(v.flatten()))

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -204,6 +204,7 @@ class TestBlockVector(unittest.TestCase):
         for bid, blk in enumerate(n[0]):
             self.assertTrue(np.allclose(blk, v2.get_block(bid)))
 
+    @unittest.skipUnless(np.__version__[0] == "1", "PTP only included in Numpy 1.x")
     def test_ptp(self):
         v = BlockVector(2)
         a = np.arange(5)

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -1403,48 +1403,13 @@ class TestMPIBlockVector(unittest.TestCase):
         bv.set_block(0, a)
         bv.set_block(1, b)
 
-        unary_funcs = [
-            np.log10,
-            np.sin,
-            np.cos,
-            np.exp,
-            np.ceil,
-            np.floor,
-            np.tan,
-            np.arctan,
-            np.arcsin,
-            np.arccos,
-            np.sinh,
-            np.cosh,
-            np.abs,
-            np.tanh,
-            np.arcsinh,
-            np.arctanh,
-            np.fabs,
-            np.sqrt,
-            np.log,
-            np.log2,
-            np.absolute,
-            np.isfinite,
-            np.isinf,
-            np.isnan,
-            np.log1p,
-            np.logical_not,
-            np.exp2,
-            np.expm1,
-            np.sign,
-            np.rint,
-            np.square,
-            np.positive,
-            np.negative,
-            np.rad2deg,
-            np.deg2rad,
-            np.conjugate,
-            np.reciprocal,
-        ]
+        _int_ufuncs = {np.invert, np.arccosh}
 
         bv2 = BlockVector(2)
         for fun in unary_funcs:
+            if fun in _int_ufuncs:
+                continue
+
             bv2.set_block(0, fun(bv.get_block(0)))
             bv2.set_block(1, fun(bv.get_block(1)))
             res = fun(v)
@@ -1454,7 +1419,7 @@ class TestMPIBlockVector(unittest.TestCase):
                 self.assertTrue(np.allclose(res.get_block(i), bv2.get_block(i)))
 
         with self.assertRaises(Exception) as context:
-            np.cbrt(v)
+            np.modf(v)
 
         with self.assertRaises(Exception) as context:
             np.cumsum(v)
@@ -1504,29 +1469,21 @@ class TestMPIBlockVector(unittest.TestCase):
         bv2.set_block(0, np.ones(3) * 3.0)
         bv2.set_block(1, np.ones(2) * 2.8)
 
-        binary_ufuncs = [
-            np.add,
-            np.multiply,
-            np.divide,
-            np.subtract,
-            np.greater,
-            np.greater_equal,
-            np.less,
-            np.less_equal,
-            np.not_equal,
-            np.maximum,
-            np.minimum,
-            np.fmax,
-            np.fmin,
-            np.equal,
-            np.logaddexp,
-            np.logaddexp2,
-            np.remainder,
-            np.heaviside,
-            np.hypot,
-        ]
+        _int_ufuncs = {
+            np.gcd,
+            np.lcm,
+            np.ldexp,
+            np.left_shift,
+            np.right_shift,
+            np.bitwise_and,
+            np.bitwise_or,
+            np.bitwise_xor,
+        }
 
         for fun in binary_ufuncs:
+            if fun in _int_ufuncs:
+                continue
+
             serial_res = fun(bv, bv2)
             res = fun(v, v2)
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -1410,7 +1410,7 @@ class TestMPIBlockVector(unittest.TestCase):
         _int_ufuncs = {np.invert, np.arccosh}
 
         bv2 = BlockVector(2)
-        for fun in unary_funcs:
+        for fun in vec_unary_ufuncs:
             if fun in _int_ufuncs:
                 continue
 
@@ -1484,7 +1484,7 @@ class TestMPIBlockVector(unittest.TestCase):
             np.bitwise_xor,
         }
 
-        for fun in binary_ufuncs:
+        for fun in vec_binary_ufuncs:
             if fun in _int_ufuncs:
                 continue
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -35,6 +35,10 @@ except ImportError:
 
 if not SKIPTESTS:
     from pyomo.contrib.pynumero.sparse import BlockVector
+    from pyomo.contrib.pynumero.sparse.base_block import (
+        vec_unary_ufuncs,
+        vec_binary_ufuncs,
+    )
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 
 

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -779,7 +779,6 @@ class TestFactorModelSet(unittest.TestCase):
                 beta=1 / 6,
             )
 
-    @unittest.skipUnless(baron_available, "BARON is not available")
     @parameterized.expand(
         [
             # map beta to expected parameter bounds
@@ -813,6 +812,7 @@ class TestFactorModelSet(unittest.TestCase):
             ["beta1", 1, [(-3.0, 3.0), (-1.1, 3.1), (-13.0, 17.0), (-12.0, 18.0)]],
         ]
     )
+    @unittest.skipUnless(baron_available, "BARON is not available")
     def test_compute_parameter_bounds(self, name, beta, expected_param_bounds):
         """
         Test parameter bounds computations give expected results.

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -2401,6 +2401,7 @@ class TestCustomUncertaintySet(unittest.TestCase):
         self.assertEqual(len(uq.uncertainty_cons), 3)
         self.assertEqual(len(uq.uncertain_param_vars), 2)
 
+    @unittest.skipUnless(baron_available, "BARON is not available")
     def test_compute_parameter_bounds(self):
         """
         Test parameter bounds computations give expected results.

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -53,7 +53,6 @@ import pyomo.gdp.tests.models as models
 import pyomo.gdp.tests.common_tests as ct
 
 
-
 currdir = this_file_dir()
 
 EPS = TransformationFactory('gdp.hull').CONFIG.EPS

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import logging
+import sys
 import random
 from io import StringIO
 
@@ -2874,7 +2875,14 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
 
     @unittest.skipIf(not dill_available, "Dill is not available")
     def test_dill_pickle(self):
-        ct.check_transformed_model_pickles_with_dill(self, 'hull')
+        try:
+            # As of Nov 2024, this test needs a larger recursion limit
+            # due to the various references among the modeling objects
+            rl = sys.getrecursionlimit()
+            sys.setrecursionlimit(1385)
+            ct.check_transformed_model_pickles_with_dill(self, 'hull')
+        finally:
+            sys.setrecursionlimit(rl)
 
 
 @unittest.skipUnless(gurobi_available, "Gurobi is not available")

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -2883,6 +2883,7 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
             ct.check_transformed_model_pickles_with_dill(self, 'hull')
         finally:
             sys.setrecursionlimit(rl)
+        self.fail()
 
 
 @unittest.skipUnless(gurobi_available, "Gurobi is not available")

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -2878,6 +2878,7 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
             # As of Nov 2024, this test needs a larger recursion limit
             # due to the various references among the modeling objects
             rl = sys.getrecursionlimit()
+            print(f"RECURSIONLIMIT {rl}")
             sys.setrecursionlimit(1385)
             ct.check_transformed_model_pickles_with_dill(self, 'hull')
         finally:

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -9,10 +9,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.dependencies import dill_available
-import pyomo.common.unittest as unittest
-from pyomo.common.log import LoggingIntercept
 import logging
+import random
+from io import StringIO
+
+import pyomo.common.unittest as unittest
+
+from pyomo.common.dependencies import dill_available
+from pyomo.common.log import LoggingIntercept
+from pyomo.common.fileutils import this_file_dir
 
 from pyomo.environ import (
     TransformationFactory,
@@ -46,14 +51,9 @@ from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 import pyomo.gdp.tests.models as models
 import pyomo.gdp.tests.common_tests as ct
 
-import random
-from io import StringIO
-import os
-from os.path import abspath, dirname, join
 
 
-currdir = dirname(abspath(__file__))
-from filecmp import cmp
+currdir = this_file_dir()
 
 EPS = TransformationFactory('gdp.hull').CONFIG.EPS
 linear_solvers = ct.linear_solvers

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -2877,13 +2877,12 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         try:
             # As of Nov 2024, this test needs a larger recursion limit
             # due to the various references among the modeling objects
+            # 1385 is sufficient locally, but not always on GHA.
             rl = sys.getrecursionlimit()
-            print(f"RECURSIONLIMIT {rl}")
-            sys.setrecursionlimit(1385)
+            sys.setrecursionlimit(max(1500, rl))
             ct.check_transformed_model_pickles_with_dill(self, 'hull')
         finally:
             sys.setrecursionlimit(rl)
-        self.fail()
 
 
 @unittest.skipUnless(gurobi_available, "Gurobi is not available")


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves some incompatibilities between PyNumero and NumPy>=2, and should resolve the last of the test failures in #3401.

## Changes proposed in this PR:
- Some PyNumero tests were missing guards for networkx
- NumPy2 no longer supports `ndarray.ptp`: remove that from the PyNumero BlockVector API when running with NumPy2
- NumPy2's implementation of `numpy.ptp` performs vector reductions (using the `reduce` ufunc method).  Update BlockVector to support (a limited set of) `ufunc.reduce()`
- Start to clean up some of the logic in `BlockVector.__arrau_ufunc__` (and helper functions)
- Add a new GHA test that should exercise pynumero with numpy2 (at least until dependencies for the the main GHA jobs allow installation of NumPy2)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
