### PR TITLE
ConfigDict: prevent recursion on partially-constructed objects

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -2714,7 +2714,9 @@ class ConfigDict(ConfigBase, Mapping):
         # partially constructed ConfigDict (before the _data attribute
         # was declared) can lead to infinite recursion.
         if _attr == "_data" or _attr not in self._data:
-            raise AttributeError("Unknown attribute '%s'" % attr)
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{attr}'"
+            )
         return ConfigDict.__getitem__(self, _attr)
 
     def __setattr__(self, name, value):

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -2705,14 +2705,17 @@ class ConfigDict(ConfigBase, Mapping):
     def __iter__(self):
         return map(attrgetter('_name'), self._data.values())
 
-    def __getattr__(self, name):
+    def __getattr__(self, attr):
         # Note: __getattr__ is only called after all "usual" attribute
         # lookup methods have failed.  So, if we get here, we already
         # know that key is not a __slot__ or a method, etc...
-        _name = name.replace(' ', '_')
-        if _name not in self._data:
-            raise AttributeError("Unknown attribute '%s'" % name)
-        return ConfigDict.__getitem__(self, _name)
+        _attr = attr.replace(' ', '_')
+        # Note: we test for "_data" because finding attributes on a
+        # partially constructed ConfigDict (before the _data attribute
+        # was declared) can lead to infinite recursion.
+        if _attr == "_data" or _attr not in self._data:
+            raise AttributeError("Unknown attribute '%s'" % attr)
+        return ConfigDict.__getitem__(self, _attr)
 
     def __setattr__(self, name, value):
         if name in ConfigDict._reserved_words:

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2736,7 +2736,9 @@ Node information:
         ):
             config.baz = 10
 
-        with self.assertRaisesRegex(AttributeError, "Unknown attribute 'baz'"):
+        with self.assertRaisesRegex(
+            AttributeError, "'ConfigDict' object has no attribute 'baz'"
+        ):
             a = config.baz
 
     def test_nonString_keys(self):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -1863,7 +1863,18 @@ scenarios[1].detection""",
             c.value()
 
         c = ConfigValue('a', domain=int)
-        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(
+            ValueError, '(?s)invalid value for configuration.*casting a'
+        ):
+            c.value()
+
+        # Test that if both the default and the result from calling the
+        # default raise exceptions, the propagated exception is from
+        # castig the original default:
+        c = ConfigValue(default=lambda: 'a', domain=int)
+        with self.assertRaisesRegex(
+            ValueError, "(?s)invalid value for configuration.*lambda"
+        ):
             c.value()
 
     def test_set_default(self):

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -10,6 +10,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import gc
 import os
 import time
 import sys
@@ -23,6 +24,20 @@ import pyomo.common.tee as tee
 
 
 class TestTeeStream(unittest.TestCase):
+    def setUp(self):
+        self.reenable_gc = gc.isenabled()
+        gc.disable()
+        # Set a short switch interval so that the threading tests behave
+        # as expected
+        self.switchinterval = sys.getswitchinterval()
+        sys.setswitchinterval(tee._poll_interval / 100)
+
+    def tearDown(self):
+        sys.setswitchinterval(self.switchinterval)
+        if self.reenable_gc:
+            gc.enable()
+            gc.collect()
+
     def test_stdout(self):
         a = StringIO()
         b = StringIO()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves an infinite recursion error observed in IDAES under Windows where attribute lookup on a partially-constructed ConfigDict could lead to infinite recursion.

## Changes proposed in this PR:
- Do not attempt to lookup a `_data` attribute in the `ConfigDict._data`
- Update the ConfigDict `AttributeError` to match current Python AttributeError messages

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
