### PR TITLE
Fix error when xpress is imported before xpress_direct

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -197,21 +197,6 @@ class _xpress_importer_class(object):
         return xpress
 
 
-_xpress_importer = _xpress_importer_class()
-xpress, xpress_available = attempt_import(
-    'xpress',
-    error_message=_xpress_importer,
-    # Other forms of exceptions can be thrown by the xpress python
-    # import.  For example, an xpress.InterfaceError exception is thrown
-    # if the Xpress license is not valid.  Unfortunately, you can't
-    # import without a license, which means we can't test for that
-    # explicit exception!
-    catch_exceptions=(Exception,),
-    importer=_xpress_importer,
-    callback=_finalize_xpress_import,
-)
-
-
 @SolverFactory.register('xpress_direct', doc='Direct python interface to XPRESS')
 class XpressDirect(DirectSolver):
     _name = None
@@ -1222,3 +1207,21 @@ class XpressDirect(DirectSolver):
 
         """
         self._load_slacks(cons_to_load)
+
+
+# Note: because _finalize_xpress_import references XpressDirect, we need
+# to make sure to not attempt the xpress import until after the
+# XpressDirect class is fully declared.
+_xpress_importer = _xpress_importer_class()
+xpress, xpress_available = attempt_import(
+    'xpress',
+    error_message=_xpress_importer,
+    # Other forms of exceptions can be thrown by the xpress python
+    # import.  For example, an xpress.InterfaceError exception is thrown
+    # if the Xpress license is not valid.  Unfortunately, you can't
+    # import without a license, which means we can't test for that
+    # explicit exception!
+    catch_exceptions=(Exception,),
+    importer=_xpress_importer,
+    callback=_finalize_xpress_import,
+)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3406 .

## Summary/Motivation:
This resolves a NameError if `xpress` was imported before `xpress_direct`

## Changes proposed in this PR:
- Ensure `XpressDirect` is declared before attempting the `xpress` import

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
