### PR TITLE
Fix bug in AutoSlots deepcopy

### DIFF
--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -306,7 +306,7 @@ class AutoSlots(type):
             if self.__auto_slots__.has_dict:
                 fields = dict(self.__dict__)
                 # Map (encode) any field values.  It is not an error if
-                # the field if not present.
+                # the field is not present.
                 for name, mapper in self.__auto_slots__.field_mappers.items():
                     if name in fields:
                         fields[name] = mapper(True, fields[name])

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -271,9 +271,7 @@ class AutoSlots(type):
             # 'state' list, significantly speeding things up.
             memo[id(self)] = ans = self.__class__.__new__(self.__class__)
             state = self.__getstate__()
-            ans.__setstate__(
-                [fast_deepcopy(field, memo) for field in state]
-            )
+            ans.__setstate__([fast_deepcopy(field, memo) for field in state])
             # The state ises a temporary dict to store the (mapped)
             # __dict__ state.  It is important that we DO NOT save the
             # id() of that temporary object in the memo

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -272,7 +272,7 @@ class AutoSlots(type):
             memo[id(self)] = ans = self.__class__.__new__(self.__class__)
             state = self.__getstate__()
             ans.__setstate__([fast_deepcopy(field, memo) for field in state])
-            # The state ises a temporary dict to store the (mapped)
+            # The state uses a temporary dict to store the (mapped)
             # __dict__ state.  It is important that we DO NOT save the
             # id() of that temporary object in the memo
             if self.__auto_slots__.has_dict:

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -270,9 +270,15 @@ class AutoSlots(type):
             # Note: this implementation avoids deepcopying the temporary
             # 'state' list, significantly speeding things up.
             memo[id(self)] = ans = self.__class__.__new__(self.__class__)
+            state = self.__getstate__()
             ans.__setstate__(
-                [fast_deepcopy(field, memo) for field in self.__getstate__()]
+                [fast_deepcopy(field, memo) for field in state]
             )
+            # The state ises a temporary dict to store the (mapped)
+            # __dict__ state.  It is important that we DO NOT save the
+            # id() of that temporary object in the memo
+            if self.__auto_slots__.has_dict:
+                del memo[id(state[-1])]
             return ans
 
         def __getstate__(self):

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -2643,7 +2643,7 @@ class ConfigDict(ConfigBase, Mapping):
 
     def __setstate__(self, state):
         super().__setstate__(state)
-        for key, val in zip(ConfigDict.__slots__, state[len(ConfigBase.__slots__):]):
+        for key, val in zip(ConfigDict.__slots__, state[len(ConfigBase.__slots__) :]):
             object.__setattr__(self, key, val)
         for x in self._data.values():
             x._parent = self

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -361,7 +361,7 @@ class PseudoMap(AutoSlots.Mixin):
         TODO
         """
         # Return True is the underlying Block contains the component
-        # name.  Note, if this Pseudomap soecifies a ctype or the
+        # name.  Note, if this Pseudomap specifies a ctype or the
         # active flag, we need to check that the underlying
         # component matches those flags
         if key in self._block._decl:

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1948,8 +1948,9 @@ component, use the block del_component() and add_component() methods.
             # deepcopy() from violating the Python recursion limit.
             # This step is recursive; however, we do not expect "super
             # deep" Pyomo block hierarchies, so should be okay.
-            for comp in self.component_map().values():
-                comp._create_objects_for_deepcopy(memo, component_list)
+            for comp in self._decl_order:
+                if comp[0] is not None:
+                    comp[0]._create_objects_for_deepcopy(memo, component_list)
         return _ans
 
     def private_data(self, scope=None):

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -1708,6 +1708,9 @@ class _ToStringVisitor(ExpressionValueVisitor):
         if node is None:
             return True, None
 
+        if node.__class__ in native_numeric_types:
+            return True, str(node)
+
         if node.__class__ in nonpyomo_leaf_types:
             return True, repr(node)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves an issue where AutoSlots was recording the temporary dict used to hold the class `__dict__` in the memo (and then threw away the temporary dict).  This was causing the deepcopy to corrupt the model in certain situations (IDAES models - but only on Windows with certain environments).

The fix is to remove the temporary dict from the memo.

This PR also updates the ConfigBase / ConfigDict `__getstate__`/`__setstate__` to avoid creating temporary tuples. 

## Changes proposed in this PR:
- Do not record the temporary `__dict__` dict in the deepcopy memo
- Do not create temporary tuples when serializing ConfigBase / ConfigDict objects

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
