### PR TITLE
Overhaul implementation of `AutoSlots.__deepcopy__`

### DIFF
--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -107,6 +107,29 @@ def fast_deepcopy(obj, memo):
     deepcopy that provides special handling to circumvent some of the
     slowest parts of deepcopy().
 
+    Note
+    ----
+
+    This implementation is not as aggressive about keeping the copied
+    state alive until the end of the deepcopy operation.  In particular,
+    the ``dict``, ``list`` and ``tuple`` handlers do not register their
+    source objects with the memo.  This is acceptable, as
+    fast_deepcopy() is only called in situations where we are ensuring
+    that the source object will persist:
+
+    - :meth:`AutoSlots.__deepcopy_state__` explicitly preserved the
+      source state
+    - :meth:`Component.__deepcopy_field__` is only called by
+      :meth:`AutoSlots.__deepcopy_state__` -
+    - :meth:`IndexedComponent._create_objects_for_deepcopy` is
+      deepcopying the raw keys from the source ``_data`` dict (which is
+      not a temporary object and will persist)
+
+    If other consumers wish to make use of this function (e.g., within
+    their implementation of ``__deepcopy__``), they must remember that
+    they are responsible to ensure that any temporary source ``obj``
+    persists.
+
     """
     if obj.__class__ in _atomic_types:
         return obj

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -373,7 +373,7 @@ class AutoSlots(type):
                 # Note: if has_dict, then __auto_slots__.slots will be 1
                 # shorter than the state (the last element is the
                 # __dict__).  Zip will ignore it.
-                _copier = getattr(self, '__deepcopy_field__', _deepcopier)
+                _copier = getattr(self, '__deepcopy_field__', _deepcopy)
                 new_state = [
                     _copier(value, memo, slot)
                     for slot, value in zip(self.__auto_slots__.slots, state)

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -342,6 +342,12 @@ class AutoSlots(type):
             # memo.
             #
             state = self.__getstate__()
+            # It is important to keep this temporary state alive (which
+            # in turn keeps things like the temporary fields dict alive)
+            # until after deepcopy is finished in order to prevent
+            # accidentally recycling id()'s for temporary objects that
+            # were recorded in the memo.  We will follow the pattern
+            # used by copy._keep_alive():
             try:
                 memo['__auto_slots__'].append(state)
             except KeyError:

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1942,15 +1942,15 @@ component, use the block del_component() and add_component() methods.
         _new = self.__class__.__new__(self.__class__)
         _ans = memo.setdefault(id(self), _new)
         if _ans is _new:
-            component_list.append(self)
+            component_list.append((self, _new))
             # Blocks (and block-like things) need to pre-populate all
             # Components / ComponentData objects to help prevent
             # deepcopy() from violating the Python recursion limit.
             # This step is recursive; however, we do not expect "super
             # deep" Pyomo block hierarchies, so should be okay.
-            for comp in self._decl_order:
-                if comp[0] is not None:
-                    comp[0]._create_objects_for_deepcopy(memo, component_list)
+            for comp, _ in self._decl_order:
+                if comp is not None:
+                    comp._create_objects_for_deepcopy(memo, component_list)
         return _ans
 
     def private_data(self, scope=None):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -112,7 +112,7 @@ class ComponentBase(PyomoObject):
         # Templates (and the corresponding _GetItemExpression object),
         # expressions can refer to container (non-Simple) components, so
         # we need to override __deepcopy__ for both Component and
-        # ComponentData.
+        # ComponentData (so we put it here on ComponentBase).
         #
         if '__block_scope__' in memo:
             _scope = memo['__block_scope__']

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -185,7 +185,7 @@ class ComponentBase(PyomoObject):
         _new = self.__class__.__new__(self.__class__)
         _ans = memo.setdefault(id(self), _new)
         if _ans is _new:
-            component_list.append(self)
+            component_list.append((self, _new))
         return _ans
 
     def __deepcopy_field__(self, value, memo, slot_name):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -196,7 +196,7 @@ class ComponentBase(PyomoObject):
         # Note that self is now the first element of component_list
         #
         # Now that we have created (but not populated) all the
-        # components that we expect to need in hte memo, we can go
+        # components that we expect to need in the memo, we can go
         # through and populate all the components.
         #
         # The component_list is roughly in declaration order.  This

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -227,15 +227,11 @@ class ComponentBase(PyomoObject):
             # warn the user
             if '__block_scope__' not in memo:
                 logger.warning(
-                    """
-                    Uncopyable field encountered when deep
-                    copying outside the scope of Block.clone().
-                    There is a distinct possibility that the new
-                    copy is not complete.  To avoid this
-                    situation, either use Block.clone() or set
-                    'paranoid' mode by adding '__paranoid__' ==
-                    True to the memo before calling
-                    copy.deepcopy."""
+                    "Uncopyable field encountered when deep "
+                    "copying Pyomo components outside the scope of "
+                    "Block.clone().  There is a distinct possibility "
+                    "that the new copy is not complete.  To avoid "
+                    "this situation, please use Block.clone()"
                 )
             if self.model() is self:
                 what = 'Model'

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -354,10 +354,12 @@ class IndexedComponent(Component):
                 # for the _data dict, we can effectively "deepcopy" it
                 # right now (almost for free!)
                 _src = self._data
-                memo[id(_src)] = _new._data = _data = _src.__class__()
+                memo[id(_src)] = _new._data = _src.__class__()
+                _setter = _new._data.__setitem__
                 for idx, obj in _src.items():
-                    _data[fast_deepcopy(idx, memo)] = obj._create_objects_for_deepcopy(
-                        memo, component_list
+                    _setter(
+                        fast_deepcopy(idx, memo),
+                        obj._create_objects_for_deepcopy(memo, component_list),
                     )
 
         return _ans

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -340,7 +340,7 @@ class IndexedComponent(Component):
         _new = self.__class__.__new__(self.__class__)
         _ans = memo.setdefault(id(self), _new)
         if _ans is _new:
-            component_list.append(self)
+            component_list.append((self, _new))
             # For indexed components, we will pre-emptively clone all
             # component data objects as well (as those are the objects
             # that will be referenced by things like expressions).  It

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -751,7 +751,7 @@ You can silence this warning by one of three ways:
     def _construct_from_rule_using_setitem(self):
         if self._rule is None:
             return
-        index = None
+        index = None  # set so it is defined for scalars for `except:` below
         rule = self._rule
         block = self.parent_block()
         try:

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -996,7 +996,7 @@ class IndexedParam(Param):
         _new = self.__class__.__new__(self.__class__)
         _ans = memo.setdefault(id(self), _new)
         if _ans is _new:
-            component_list.append(self)
+            component_list.append((self, _new))
         return _ans
 
     # Because CP supports indirection [the ability to index objects by

--- a/pyomo/core/base/range.py
+++ b/pyomo/core/base/range.py
@@ -12,6 +12,7 @@
 import math
 from collections.abc import Sequence
 
+from pyomo.common.autoslots import AutoSlots
 from pyomo.common.numeric_types import check_if_numeric_type
 
 try:
@@ -33,7 +34,7 @@ class RangeDifferenceError(ValueError):
     pass
 
 
-class NumericRange(object):
+class NumericRange(AutoSlots.Mixin):
     """A representation of a numeric range.
 
     This class represents a contiguous range of numbers.  The class
@@ -125,29 +126,6 @@ class NumericRange(object):
                 "NumericRange %s is discrete, but passed closed=%s."
                 "  Discrete ranges must be closed." % (self, self.closed)
             )
-
-    def __getstate__(self):
-        """
-        Retrieve the state of this object as a dictionary.
-
-        This method must be defined because this class uses slots.
-        """
-        state = {}  # super(NumericRange, self).__getstate__()
-        for i in NumericRange.__slots__:
-            state[i] = getattr(self, i)
-        return state
-
-    def __setstate__(self, state):
-        """
-        Set the state of this object using values from a state dictionary.
-
-        This method must be defined because this class uses slots.
-        """
-        for key, val in state.items():
-            # Note: per the Python data model docs, we explicitly
-            # set the attribute using object.__setattr__() instead
-            # of setting self.__dict__[key] = val.
-            object.__setattr__(self, key, val)
 
     def __str__(self):
         if not self.isdiscrete():

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -3450,40 +3450,6 @@ class SetOperator(SetData, Set):
             return self.name
         return self._expression_str()
 
-    def __deepcopy__(self, memo):
-        # SetOperators form an expression system.  As we allow operators
-        # on abstract Set objects, it is important to *always* deepcopy
-        # SetOperators that have not been assigned to a Block.  For
-        # example, consider an abstract indexed model component whose
-        # domain is specified by a Set expression:
-        #
-        #   def x_init(m,i):
-        #       if i == 2:
-        #           return Set.Skip
-        #       else:
-        #           return []
-        #   m.x = Set( [1,2],
-        #              domain={1: m.A*m.B, 2: m.A*m.A},
-        #              initialize=x_init )
-        #
-        # We do not want to automatically add all the Set operators to
-        # the model at declaration time, as m.x[2] is never actually
-        # created.  Plus, doing so would require complex parsing of the
-        # initializers.  BUT, we need to ensure that the operators are
-        # deepcopied, otherwise when the model is cloned before
-        # construction the operators will still refer to the sets on the
-        # original abstract model (in particular, the Set x will have an
-        # unknown dimen).
-        #
-        # Our solution is to cause SetOperators to be automatically
-        # cloned if they haven't been assigned to a block.
-        if '__block_scope__' in memo:
-            if self.parent_block() is None:
-                # Hijack the block scope rules to cause this object to
-                # be deepcopied.
-                memo['__block_scope__'][id(self)] = True
-        return super(SetOperator, self).__deepcopy__(memo)
-
     def _expression_str(self):
         _args = []
         for arg in self._sets:

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2525,7 +2525,7 @@ class TestBlock(unittest.TestCase):
             "'unknown' contains an uncopyable field 'bad1'", OUTPUT.getvalue()
         )
         self.assertIn("'b' contains an uncopyable field 'bad2'", OUTPUT.getvalue())
-        self.assertIn("'__paranoid__'", OUTPUT.getvalue())
+        self.assertIn("outside the scope of Block.clone()", OUTPUT.getvalue())
         self.assertTrue(hasattr(m.b, 'bad2'))
         self.assertIsNotNone(m.b.bad2)
         self.assertTrue(hasattr(nb, 'bad2'))


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves some lingering issues when deepcopying AutoSlot classes / Pyomo models.
- Ensure that the temporary state created when deepcopying Components is preserved until deepcopy is finished.  This is a more robust solution to a patch that was introduced in #3412
- Remove redundant __deepcopy__ implementations (standardize all logic in AutoSlots)
- Fix a minor logic error when determining if components are in/out of the `__block_scope__`
- Minor performance improvements (enough so that pmedian8 runs slightly faster, even after the additional overhead of keeping the temporary states alive)

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
