### PR TITLE
Resolve `timeout()` failures on Windows/py3.13

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -232,7 +232,7 @@ class TestPyomoUnittest(unittest.TestCase):
             self.bound_function_require_fork()
             return
         with self.assertRaisesRegex(
-            unittest.SkipTest, "timeout requires unavailable fork interface"
+            unittest.SkipTest, r"timeout\(\) requires unavailable fork interface"
         ):
             self.bound_function_require_fork()
 

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -189,7 +189,7 @@ class TestPyomoUnittest(unittest.TestCase):
     @unittest.timeout(0.01)
     def test_timeout_timeout(self):
         time.sleep(1)
-        self.assertEqual(0, 1)
+        self.assertEqual(0, 0)
 
     @unittest.timeout(10)
     def test_timeout_skip(self):

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -13,7 +13,6 @@ import datetime
 import multiprocessing
 import os
 import time
-from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
@@ -218,8 +217,7 @@ class TestPyomoUnittest(unittest.TestCase):
         if multiprocessing.get_start_method() == 'fork':
             self.bound_function()
             return
-        LOG = StringIO()
-        with LoggingIntercept(LOG):
+        with LoggingIntercept() as LOG:
             with self.assertRaises((TypeError, EOFError, AttributeError)):
                 self.bound_function()
         self.assertIn("platform that does not support 'fork'", LOG.getvalue())

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -308,11 +308,11 @@ def _assertStructuredAlmostEqual(
     raise exception(msg)
 
 
-def _runner(q, qualname):
+def _runner(pipe, qualname):
     "Utility wrapper for running functions, used by timeout()"
     resultType = _RunnerResult.call
-    if q in _runner.data:
-        fcn, args, kwargs = _runner.data[q]
+    if pipe in _runner.data:
+        fcn, args, kwargs = _runner.data[pipe]
     elif isinstance(qualname, str):
         # Use unittest to instantiate the TestCase and run it
         resultType = _RunnerResult.unittest
@@ -332,7 +332,7 @@ def _runner(q, qualname):
     try:
         with capture_output(OUT):
             result = fcn(*args, **kwargs)
-        q.put((resultType, result, OUT.getvalue()))
+        pipe.send((resultType, result, OUT.getvalue()))
     except:
         import traceback
 
@@ -341,7 +341,7 @@ def _runner(q, qualname):
             e = etype(
                 "%s\nOriginal traceback:\n%s" % (e, ''.join(traceback.format_tb(tb)))
             )
-        q.put((_RunnerResult.exception, e, OUT.getvalue()))
+        pipe.send((_RunnerResult.exception, e, OUT.getvalue()))
     finally:
         _runner.data.pop(qualname)
 
@@ -423,13 +423,13 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
             if require_fork and multiprocessing.get_start_method() != 'fork':
                 raise _unittest.SkipTest("timeout requires unavailable fork interface")
 
-            q = multiprocessing.Queue()
+            pipe_recv, pipe_send = multiprocessing.Pipe(False)
             if multiprocessing.get_start_method() == 'fork':
                 # Option 1: leverage fork if possible.  This minimizes
                 # the reliance on serialization and ensures that the
                 # wrapped function operates in the same environment.
-                _runner.data[q] = (fcn, args, kwargs)
-                runner_args = (q, qualname)
+                _runner.data[pipe_send] = (fcn, args, kwargs)
+                runner_arg = qualname
             elif (
                 args
                 and fcn.__name__.startswith('test')
@@ -439,20 +439,22 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                 # unittest in the child process with this function as
                 # the sole target.  This ensures that things like setUp
                 # and tearDown are correctly called.
-                runner_args = (q, qualname)
+                runner_arg = qualname
             else:
                 # Option 3: attempt to serialize the function and all
                 # arguments and send them to the (spawned) child
                 # process.  The wrapped function cannot count on any
                 # environment configuration that it does not set up
                 # itself.
-                runner_args = (q, (qualname, test_timer, args, kwargs))
-            test_proc = multiprocessing.Process(target=_runner, args=runner_args)
+                runner_arg = (qualname, test_timer, args, kwargs)
+            test_proc = multiprocessing.Process(
+                target=_runner, args=(pipe_send, runner_arg)
+            )
             test_proc.daemon = True
             try:
                 test_proc.start()
             except:
-                if type(runner_args[1]) is tuple:
+                if type(runner_arg) is tuple:
                     logging.getLogger(__name__).error(
                         "Exception raised spawning timeout subprocess "
                         "on a platform that does not support 'fork'.  "
@@ -461,14 +463,15 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                     )
                 raise
             try:
-                resultType, result, stdout = q.get(True, seconds)
-            except queue.Empty:
-                test_proc.terminate()
-                raise timeout_raises(
-                    "test timed out after %s seconds" % (seconds,)
-                ) from None
+                if pipe_recv.poll(seconds):
+                    resultType, result, stdout = pipe_recv.recv()
+                else:
+                    test_proc.terminate()
+                    raise timeout_raises(
+                        "test timed out after %s seconds" % (seconds,)
+                    ) from None
             finally:
-                _runner.data.pop(q, None)
+                _runner.data.pop(pipe_send, None)
             sys.stdout.write(stdout)
             test_proc.join()
             if resultType == _RunnerResult.call:

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -328,9 +328,8 @@ def _runner(pipe, qualname):
     else:
         qualname, fcn, args, kwargs = qualname
     _runner.data[qualname] = None
-    OUT = StringIO()
     try:
-        with capture_output(OUT):
+        with capture_output() as OUT:
             result = fcn(*args, **kwargs)
         pipe.send((resultType, result, OUT.getvalue()))
     except:

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -420,7 +420,9 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
             if qualname in _runner.data:
                 return fcn(*args, **kwargs)
             if require_fork and multiprocessing.get_start_method() != 'fork':
-                raise _unittest.SkipTest("timeout requires unavailable fork interface")
+                raise _unittest.SkipTest(
+                    "timeout() requires unavailable fork interface"
+                )
 
             pipe_recv, pipe_send = multiprocessing.Pipe(False)
             if multiprocessing.get_start_method() == 'fork':
@@ -455,7 +457,7 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
             except:
                 if type(runner_arg) is tuple:
                     logging.getLogger(__name__).error(
-                        "Exception raised spawning timeout subprocess "
+                        "Exception raised spawning timeout() subprocess "
                         "on a platform that does not support 'fork'.  "
                         "It is likely that either the wrapped function or "
                         "one of its arguments is not serializable"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The `timeout()` decorator was failing intermittently on Windows under Python 3.13.  We would either see errors like:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from multiprocessing.spawn import spawn_main; spawn_main(parent_pid=3444, pipe_handle=1048)
                                                  ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Miniconda\envs\test\Lib\multiprocessing\spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "C:\Miniconda\envs\test\Lib\multiprocessing\spawn.py", line 130, in _main
    preparation_data = reduction.pickle.load(from_parent)
EOFError: Ran out of input
```
or
```
self = <multiprocessing.queues.Queue object at 0x0000021A13039590>, block = True, timeout = 9.999996200000169

    def get(self, block=True, timeout=None):
        if self._closed:
            raise ValueError(f"Queue {self!r} is closed")
        if block and timeout is None:
            with self._rlock:
                res = self._recv_bytes()
            self._sem.release()
        else:
            if block:
                deadline = time.monotonic() + timeout
            if not self._rlock.acquire(block, timeout):
                raise Empty
            try:
                if block:
                    timeout = deadline - time.monotonic()
                    if not self._poll(timeout):
                        raise Empty
                elif not self._poll():
                    raise Empty
                res = self._recv_bytes()
>               self._sem.release()
E               ValueError: semaphore or lock released too many times
```

I was never quite able to determine *why* the test was suddenly failing (I suspect that there may actually be a bug in Python 3.13's implementation of Queue).  This PR "resolves" the problem by switching from using a `multiprocessing.Queue` to communicate results back from the child process to the simpler `multiprocessing.Pipe`.  Whereas previously we were seeing the error about 1/3 of the time (out of 25 runs, 7 failed, and 1 hung indefinitely), with this new implementation 25 attempts all passed.

## Changes proposed in this PR:
- switch from `multiprocessing.Queue` to `multiprocessing.Pipe` for communicating results back from the subprocess
- simplify some I/O management
- update some documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
