### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13</compiler>
+				<compiler>Python 3.9, 3.10, 3.11, 3.12, 3.13</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -29,12 +29,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest]
         arch: [all]
-        wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
+        wheel-version: ['cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
 
         include:
-        - wheel-version: 'cp38*'
-          TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
           GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
@@ -96,12 +93,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         arch: [all]
-        wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
+        wheel-version: ['cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
 
         include:
-        - wheel-version: 'cp38*'
-          TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
           GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
@@ -185,7 +179,7 @@ jobs:
         include:
         - os: ubuntu-latest
           TARGET: generic_tarball
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -75,12 +75,6 @@ jobs:
         other: [""]
         category: [""]
 
-        # win/3.8 conda builds no longer work due to environment not being able
-        # to resolve. We are skipping it now.
-        exclude:
-        - os: windows-latest
-          python: 3.8
-
         include:
         - os: ubuntu-latest
           python: '3.13'
@@ -88,7 +82,7 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: '3.10'
+          python: '3.11'
           TARGET: osx
           PYENV: pip
 
@@ -125,7 +119,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: 3.8
+          python: '3.10'
           other: /pip
           skip_doctest: 1
           TARGET: win
@@ -693,17 +687,17 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.8/bare-env
+    name: linux/3.9/bare-env
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Pyomo
       run: |
@@ -761,17 +755,17 @@ jobs:
     #  id: pip-cache
     #  with:
     #    path: cache/pip
-    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.9
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         path: artifacts
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Python Packages (pip)
       shell: bash # DO NOT REMOVE: see note above

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -68,15 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.8, 3.9, '3.10', '3.11', '3.12', '3.13' ]
+        python: [ 3.9, '3.10', '3.11', '3.12', '3.13' ]
         other: [""]
         category: [""]
-
-        # win/3.8 conda builds no longer work due to environment not being able
-        # to resolve. We are skipping it now.
-        exclude:
-        - os: windows-latest
-          python: 3.8
 
         include:
         - os: ubuntu-latest
@@ -119,7 +113,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: 3.8
+          python: 3.9
           other: /pip
           skip_doctest: 1
           TARGET: win
@@ -134,7 +128,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.8
+          python: 3.9
           other: /slim
           slim: 1
           skip_doctest: 1
@@ -151,7 +145,7 @@ jobs:
           PACKAGES: "gurobipy dill numpy>2.0 scipy networkx"
 
         - os: ubuntu-latest
-          python: 3.9
+          python: '3.10'
           other: /pyutilib
           TARGET: linux
           PYENV: pip
@@ -727,7 +721,7 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.8/bare-env
+    name: linux/3.9/bare-env
     needs: lint  # the linter job is a prerequisite for PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -735,10 +729,10 @@ jobs:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Pyomo
       run: |
@@ -796,17 +790,17 @@ jobs:
     #  id: pip-cache
     #  with:
     #    path: cache/pip
-    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.9
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         path: artifacts
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Python Packages (pip)
       shell: bash # DO NOT REMOVE: see note above

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Pyomo is available under the BSD License - see the
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+* CPython: 3.9, 3.10, 3.11, 3.12, 3.13
 * PyPy: 3.9
 
 _Testing and support policy_:

--- a/doc/OnlineDocs/getting_started/installation.rst
+++ b/doc/OnlineDocs/getting_started/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+* CPython: 3.9, 3.10, 3.11, 3.12, 3.13
 * PyPy: 3
 
 At the time of the first Pyomo release after the end-of-life of a minor Python

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -3450,40 +3450,6 @@ class SetOperator(SetData, Set):
             return self.name
         return self._expression_str()
 
-    def __deepcopy__(self, memo):
-        # SetOperators form an expression system.  As we allow operators
-        # on abstract Set objects, it is important to *always* deepcopy
-        # SetOperators that have not been assigned to a Block.  For
-        # example, consider an abstract indexed model component whose
-        # domain is specified by a Set expression:
-        #
-        #   def x_init(m,i):
-        #       if i == 2:
-        #           return Set.Skip
-        #       else:
-        #           return []
-        #   m.x = Set( [1,2],
-        #              domain={1: m.A*m.B, 2: m.A*m.A},
-        #              initialize=x_init )
-        #
-        # We do not want to automatically add all the Set operators to
-        # the model at declaration time, as m.x[2] is never actually
-        # created.  Plus, doing so would require complex parsing of the
-        # initializers.  BUT, we need to ensure that the operators are
-        # deepcopied, otherwise when the model is cloned before
-        # construction the operators will still refer to the sets on the
-        # original abstract model (in particular, the Set x will have an
-        # unknown dimen).
-        #
-        # Our solution is to cause SetOperators to be automatically
-        # cloned if they haven't been assigned to a block.
-        if '__block_scope__' in memo:
-            if self.parent_block() is None:
-                # Hijack the block scope rules to cause this object to
-                # be deepcopied.
-                memo['__block_scope__'][id(self)] = True
-        return super(SetOperator, self).__deepcopy__(memo)
-
     def _expression_str(self):
         _args = []
         for arg in self._sets:

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2999,52 +2999,6 @@ class RangeSet(Component):
         else:
             return super(RangeSet, cls).__new__(AbstractInfiniteScalarRangeSet)
 
-    # `start`, `end`, `step` in `*args` are positional-only that cannot be filled with keywords.
-    # But positional-only params syntax are not supported before python 3.8.
-    # To emphasize they are positional-only, an underscore is added before their name.
-    @overload
-    def __init__(
-        self,
-        _end,
-        *,
-        finite=None,
-        ranges=(),
-        bounds=None,
-        filter=None,
-        validate=None,
-        name=None,
-        doc=None,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        _start,
-        _end,
-        _step=1,
-        *,
-        finite=None,
-        ranges=(),
-        bounds=None,
-        filter=None,
-        validate=None,
-        name=None,
-        doc=None,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        *,
-        finite=None,
-        ranges=(),
-        bounds=None,
-        filter=None,
-        validate=None,
-        name=None,
-        doc=None,
-    ): ...
-
     def __init__(self, *args, **kwds):
         # Finite was processed by __new__
         kwds.setdefault('ctype', RangeSet)

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,6 @@ setup_kwargs = dict(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -245,7 +244,7 @@ setup_kwargs = dict(
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=['ply'],
     extras_require={
         # There are certain tests that also require pytest-qt, but because those


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:
Remove Python 3.8 support because it is EOL.

## Changes proposed in this PR:
- Remove all references to 3.8 in tests and docs
- Remove code that was necessary for pre-3.8 reasons

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
