### PR TITLE
xpress_direct: resolve error retrieving reduced costs

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -1126,7 +1126,7 @@ class XpressDirect(DirectSolver):
             vars_to_load = var_map.keys()
 
         xpress_vars_to_load = [var_map[pyomo_var] for pyomo_var in vars_to_load]
-        vals = self._getRedCost(self._solver_model, xpress_vars_to_load)
+        vals = self._getRedCosts(self._solver_model, xpress_vars_to_load)
 
         for var, val in zip(vars_to_load, vals):
             if ref_vars[var] > 0:

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -40,9 +40,22 @@ class TestXpressPersistent(unittest.TestCase):
         res = opt.solve()
         self.assertAlmostEqual(m.x.value, -0.4, delta=1e-6)
         self.assertAlmostEqual(m.y.value, 0.2, delta=1e-6)
+
         opt.load_duals()
+        self.assertEqual(len(m.dual), 1)
         self.assertAlmostEqual(m.dual[m.c1], -0.4, delta=1e-6)
         del m.dual
+
+        opt.load_rc()
+        self.assertEqual(len(m.rc), 2)
+        self.assertAlmostEqual(m.rc[m.x], 0, delta=1e-8)
+        self.assertAlmostEqual(m.rc[m.y], 0, delta=1e-8)
+        del m.rc
+
+        opt.load_slacks()
+        self.assertEqual(len(m.slack), 1)
+        self.assertAlmostEqual(m.slack[m.c1], 0, delta=1e-6)
+        del m.slack
 
         m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
         opt.add_constraint(m.c2)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Pyomo/mpi-sppy#451 pointed out a typo in the xpress_direct interface that prevented retrieving the reduced costs.  This resolves that error and adds tests to exercise that functionality.

## Changes proposed in this PR:
- xpress_direct: fix typo (calling `self._getRedCosts`)
- xpress_direct: add test for retrieving `rc` and `slack` Suffixes

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
