### PR TITLE
Resolve errors in mapping ScalarVar to numpy ndarray

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -1201,7 +1201,7 @@ class IndexedComponent_NDArrayMixin(object):
         if not self.is_indexed():
             ans = _ndarray.NumericNDArray(shape=(1,), dtype=object)
             ans[0] = self
-            return ans
+            return ans.reshape(())
 
         _dim = self.dim()
         if _dim is None:

--- a/pyomo/core/expr/compare.py
+++ b/pyomo/core/expr/compare.py
@@ -66,6 +66,11 @@ def handle_external_function_expression(node: ExternalFunctionExpression, pn: Li
     return node.args
 
 
+def handle_sequence(node: collections.abc.Sequence, pn: List):
+    pn.append((collections.abc.Sequence, len(node)))
+    return list(node)
+
+
 def _generic_expression_handler():
     return handle_expression
 
@@ -79,6 +84,7 @@ handler[NPV_ExternalFunctionExpression] = handle_external_function_expression
 handler[AbsExpression] = handle_unary_expression
 handler[NPV_AbsExpression] = handle_unary_expression
 handler[RangedExpression] = handle_expression
+handler[list] = handle_sequence
 
 
 class PrefixVisitor(StreamBasedExpressionVisitor):
@@ -97,19 +103,26 @@ class PrefixVisitor(StreamBasedExpressionVisitor):
             self._result.append(node)
             return tuple(), None
 
-        if node.is_expression_type():
-            if node.is_named_expression_type():
-                return (
-                    handle_named_expression(
-                        node, self._result, self._include_named_exprs
-                    ),
-                    None,
-                )
-            else:
-                return handler[ntype](node, self._result), None
-        else:
-            self._result.append(node)
-            return tuple(), None
+        if ntype in handler:
+            return handler[ntype](node, self._result), None
+
+        if hasattr(node, 'is_expression_type'):
+            if node.is_expression_type():
+                if node.is_named_expression_type():
+                    return (
+                        handle_named_expression(
+                            node, self._result, self._include_named_exprs
+                        ),
+                        None,
+                    )
+                else:
+                    return handler[ntype](node, self._result), None
+        elif hasattr(node, '__len__'):
+            handler[ntype] = handle_sequence
+            return handle_sequence(node, self._result), None
+
+        self._result.append(node)
+        return tuple(), None
 
     def finalizeResult(self, result):
         ans = self._result
@@ -161,10 +174,7 @@ def convert_expression_to_prefix_notation(expr, include_named_exprs=True):
 
     """
     visitor = PrefixVisitor(include_named_exprs=include_named_exprs)
-    if isinstance(expr, Sequence):
-        return expr.__class__(visitor.walk_expression(e) for e in expr)
-    else:
-        return visitor.walk_expression(expr)
+    return visitor.walk_expression(expr)
 
 
 def compare_expressions(expr1, expr2, include_named_exprs=True):

--- a/pyomo/core/tests/unit/test_expr_numpy.py
+++ b/pyomo/core/tests/unit/test_expr_numpy.py
@@ -1,0 +1,95 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2024
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+
+from pyomo.common.dependencies import numpy as np, numpy_available
+from pyomo.environ import ConcreteModel, Var, Constraint
+
+
+@unittest.skipUnless(numpy_available, "tests require numpy")
+class TestNumpyExpr(unittest.TestCase):
+    def test_scalar_operations(self):
+        m = ConcreteModel()
+        m.x = Var()
+
+        a = np.array(m.x)
+        self.assertEqual(a.shape, ())
+
+        self.assertExpressionsEqual(5 * a, 5 * m.x)
+        self.assertExpressionsEqual(np.array([2, 3]) * a, [2 * m.x, 3 * m.x])
+        self.assertExpressionsEqual(np.array([5, 6]) * m.x, [5 * m.x, 6 * m.x])
+        self.assertExpressionsEqual(np.array([8, m.x]) * m.x, [8 * m.x, m.x * m.x])
+
+        a = np.array([m.x])
+        self.assertEqual(a.shape, (1,))
+
+        self.assertExpressionsEqual(5 * a, [5 * m.x])
+        self.assertExpressionsEqual(np.array([2, 3]) * a, [2 * m.x, 3 * m.x])
+        self.assertExpressionsEqual(np.array([5, 6]) * m.x, [5 * m.x, 6 * m.x])
+        self.assertExpressionsEqual(np.array([8, m.x]) * m.x, [8 * m.x, m.x * m.x])
+
+    def test_vector_operations(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var([0, 1, 2])
+
+        with self.assertRaisesRegex(TypeError, "unsupported operand"):
+            # TODO: when we finally support a true matrix expression
+            # system, this test should work
+            self.assertExpressionsEqual(5 * m.y, [5 * m.y[0], 5 * m.y[1], 5 * m.y[2]])
+
+        a = np.array(5)
+        self.assertExpressionsEqual(a * m.y, [5 * m.y[0], 5 * m.y[1], 5 * m.y[2]])
+        self.assertExpressionsEqual(m.y * a, [5 * m.y[0], 5 * m.y[1], 5 * m.y[2]])
+        a = np.array([5])
+        self.assertExpressionsEqual(a * m.y, [5 * m.y[0], 5 * m.y[1], 5 * m.y[2]])
+        self.assertExpressionsEqual(m.y * a, [5 * m.y[0], 5 * m.y[1], 5 * m.y[2]])
+
+        a = np.array(5)
+        with self.assertRaisesRegex(TypeError, "unsupported operand"):
+            # TODO: when we finally support a true matrix expression
+            # system, this test should work
+            self.assertExpressionsEqual(
+                a * m.x * m.y, [5 * m.x * m.y[0], 5 * m.x * m.y[1], 5 * m.x * m.y[2]]
+            )
+        self.assertExpressionsEqual(
+            a * m.y * m.x, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
+        )
+        self.assertExpressionsEqual(
+            a * m.y * m.y,
+            [5 * m.y[0] * m.y[0], 5 * m.y[1] * m.y[1], 5 * m.y[2] * m.y[2]],
+        )
+        self.assertExpressionsEqual(
+            m.y * a * m.x, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
+        )
+        with self.assertRaisesRegex(TypeError, "unsupported operand"):
+            # TODO: when we finally support a true matrix expression
+            # system, this test should work
+            self.assertExpressionsEqual(
+                m.y * m.x * a, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
+            )
+        with self.assertRaisesRegex(TypeError, "unsupported operand"):
+            # TODO: when we finally support a true matrix expression
+            # system, this test should work
+            self.assertExpressionsEqual(
+                m.x * a * m.y, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
+            )
+        with self.assertRaisesRegex(TypeError, "unsupported operand"):
+            # TODO: when we finally support a true matrix expression
+            # system, this test should work
+            self.assertExpressionsEqual(
+                m.x * m.y * a, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3418 .

## Summary/Motivation:
This resolves how we map ScalarVar (and other scalar numeric expression types) into numpy `ndarray` objects.  With this change, Pyomo Var objects behave in a manner consistent with other python scalars (like `float`).

## Changes proposed in this PR:
- implicit casting of a ScalarVar to numpy array should result in a 0d ndarray
- add testing for (current) expected numpy behavior 
- update `assertExpressionsEqual` to allow for lists / ndarrays of expressions (and to compare `list` and 1d `ndarray` as being equal)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
