### PR TITLE
appsi_highs: allow solving quadratic problems

### DIFF
--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -397,12 +397,8 @@ class Highs(PersistentBase, PersistentSolver):
 
         for con in cons:
             repn = generate_standard_repn(
-                con.body, quadratic=False, compute_values=False
+                con.body, quadratic=True, compute_values=False
             )
-            if repn.nonlinear_expr is not None:
-                raise DegreeError(
-                    f'Highs interface does not support expressions of degree {repn.polynomial_degree()}'
-                )
 
             starts.append(len(coef_values))
             for ndx, coef in enumerate(repn.linear_coefs):
@@ -589,12 +585,8 @@ class Highs(PersistentBase, PersistentSolver):
                 )
 
             repn = generate_standard_repn(
-                obj.expr, quadratic=False, compute_values=False
+                obj.expr, quadratic=True, compute_values=False
             )
-            if repn.nonlinear_expr is not None:
-                raise DegreeError(
-                    f'Highs interface does not support expressions of degree {repn.polynomial_degree()}'
-                )
 
             for coef, v in zip(repn.linear_coefs, repn.linear_vars):
                 v_id = id(v)

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -50,6 +50,7 @@ qcp_solvers = [
     ('gurobi', Gurobi),
     ('ipopt', Ipopt),
     ('cplex', Cplex),
+    ('highs', Highs),
     ('maingo', MAiNGO),
 ]
 miqcqp_solvers = [('gurobi', Gurobi), ('cplex', Cplex), ('maingo', MAiNGO)]


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3381.

## Summary/Motivation:

Before, the highs solver did not allow to solve quadratic equations, but highs does support solving such.
I did only run a few test cases which are solved by using this.
This was added 3 years ago with the appsi_highs solver, though a lot happened in highs in the meantime.

## Changes proposed in this PR:
- remove highs restriction to disable solving quadratic equations

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


Tested with:
- debian 13 trixie
- highspy 1.7.2
- pyomo derived from main