### PR TITLE
fix running pyomo test-solvers

### DIFF
--- a/pyomo/opt/plugins/driver.py
+++ b/pyomo/opt/plugins/driver.py
@@ -50,7 +50,7 @@ def setup_test_parser(parser):
 def test_exec(options):
     import pyomo.solvers.tests.testcases
 
-    pyomo.solvers.tests.testcases.run_test_scenarios(options)
+    pyomo.solvers.tests.testcases.run_scenarios(options)
 
 
 #

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -355,7 +355,7 @@ def run_scenarios(options):
 
     for key, test_case in generate_scenarios():
         model, solver, io = key
-        if len(solvers) > 0 and not solver in solvers:
+        if len(solvers) > 0 and solver not in solvers:
             continue
         if test_case.status == 'skip':
             continue
@@ -381,7 +381,7 @@ def run_scenarios(options):
         # Validate solution status
         try:
             model_class.post_solve_test_validation(None, results)
-        except:
+        except Exception:
             if test_case.status == 'expected failure':
                 stat[key] = (True, "Expected failure")
             else:
@@ -431,7 +431,7 @@ def run_scenarios(options):
     total = Bunch(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
     for key in stat:
         model, solver, io = key
-        if not solver in summary:
+        if solver not in summary:
             summary[solver] = Bunch(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
         _pass, _str = stat[key]
         if _pass:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

pyomo test-solvers

did fail previously.
Now at least `pyomo test-solvers glpk` works fine. Others do not work well, so I would suggest to remove the code all together or update it, so that it works well to benchmark various solvers :)


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
