### PR TITLE
Verify we are testing all NEOS solvers

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -208,7 +208,7 @@ class kestrelAMPL(object):
         return (jobNumber, password)
 
     def getAvailableSolvers(self):
-        """Return a list of all NNEOS solvers that this interface supports"""
+        """Return a list of all NEOS solvers that this interface supports"""
         allKestrelSolvers = self.neos.listSolversInCategory("kestrel")
         _ampl = ':AMPL'
         return sorted(s[: -len(_ampl)] for s in allKestrelSolvers if s.endswith(_ampl))

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -211,7 +211,7 @@ class kestrelAMPL(object):
         """Return a list of all NNEOS solvers that this interface supports"""
         allKestrelSolvers = self.neos.listSolversInCategory("kestrel")
         _ampl = ':AMPL'
-        return sorted(s[: len(_ampl)] for s in allKestrelSolvers if s.endswith(_ampl))
+        return sorted(s[: -len(_ampl)] for s in allKestrelSolvers if s.endswith(_ampl))
 
     def getSolverName(self):
         """

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -207,6 +207,12 @@ class kestrelAMPL(object):
                 password = m.groups()[0]
         return (jobNumber, password)
 
+    def getAvailableSolvers(self):
+        """Return a list of all NNEOS solvers that this interface supports"""
+        allKestrelSolvers = self.neos.listSolversInCategory("kestrel")
+        _ampl = ':AMPL'
+        return sorted(s[: len(_ampl)] for s in allKestrelSolvers if s.endswith(_ampl))
+
     def getSolverName(self):
         """
         Read in the kestrel_options to pick out the solver name.
@@ -218,12 +224,7 @@ class kestrelAMPL(object):
 
         """
         # Get a list of available kestrel solvers from NEOS
-        allKestrelSolvers = self.neos.listSolversInCategory("kestrel")
-        kestrelAmplSolvers = []
-        for s in allKestrelSolvers:
-            i = s.find(':AMPL')
-            if i > 0:
-                kestrelAmplSolvers.append(s[0:i])
+        kestrelAmplSolvers = self.getAvailableSolvers()
         self.options = None
         # Read kestrel_options to get solver name
         if "kestrel_options" in os.environ:

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -176,7 +176,7 @@ class RunAllNEOSSolvers(object):
     def test_path(self):
         # The simple tests aren't complementarity
         # problems
-        self.skip("The simple NEOS test is not a complementarity problem")
+        self.skipTest("The simple NEOS test is not a complementarity problem")
 
     def test_snopt(self):
         self._run('snopt')

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -100,10 +100,11 @@ class TestKestrel(unittest.TestCase):
 
     def test_check_all_ampl_solvers(self):
         kestrel = kestrelAMPL()
-        solvers = kestrelAMPL.getAvailableSolvers()
+        solvers = kestrel.getAvailableSolvers()
         for solver in solvers:
-            if not hasattr(RunAllNEOSSolvers, 'test_' + solver.lower()):
-                self.fail("RunAllNEOSSolvers missing test for '{solver}'")
+            name = solver.lower().replace('-', '')
+            if not hasattr(RunAllNEOSSolvers, 'test_' + name):
+                self.fail(f"RunAllNEOSSolvers missing test for '{solver}'")
 
 
 class RunAllNEOSSolvers(object):
@@ -172,10 +173,10 @@ class RunAllNEOSSolvers(object):
         else:
             self._run('ooqp')
 
-    # The simple tests aren't complementarity
-    # problems
-    # def test_path(self):
-    #    self._run('path')
+    def test_path(self):
+        # The simple tests aren't complementarity
+        # problems
+        self.skip("The simple NEOS test is not a complementarity problem")
 
     def test_snopt(self):
         self._run('snopt')

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -98,6 +98,13 @@ class TestKestrel(unittest.TestCase):
         finally:
             pyomo.neos.kestrel.NEOS.host = orig_host
 
+    def test_check_all_ampl_solvers(self):
+        kestrel = kestrelAMPL()
+        solvers = kestrelAMPL.getAvailableSolvers()
+        for solver in solvers:
+            if not hasattr(RunAllNEOSSolvers, 'test_' + solver.lower()):
+                self.fail("RunAllNEOSSolvers missing test for '{solver}'")
+
 
 class RunAllNEOSSolvers(object):
     def test_bonmin(self):

--- a/pyomo/opt/plugins/driver.py
+++ b/pyomo/opt/plugins/driver.py
@@ -50,7 +50,7 @@ def setup_test_parser(parser):
 def test_exec(options):
     import pyomo.solvers.tests.testcases
 
-    pyomo.solvers.tests.testcases.run_test_scenarios(options)
+    pyomo.solvers.tests.testcases.run_scenarios(options)
 
 
 #

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -355,7 +355,7 @@ def run_scenarios(options):
 
     for key, test_case in generate_scenarios():
         model, solver, io = key
-        if len(solvers) > 0 and not solver in solvers:
+        if len(solvers) > 0 and solver not in solvers:
             continue
         if test_case.status == 'skip':
             continue
@@ -381,7 +381,7 @@ def run_scenarios(options):
         # Validate solution status
         try:
             model_class.post_solve_test_validation(None, results)
-        except:
+        except Exception:
             if test_case.status == 'expected failure':
                 stat[key] = (True, "Expected failure")
             else:
@@ -431,7 +431,7 @@ def run_scenarios(options):
     total = Bunch(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
     for key in stat:
         model, solver, io = key
-        if not solver in summary:
+        if solver not in summary:
             summary[solver] = Bunch(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
         _pass, _str = stat[key]
         if _pass:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #N/A.

## Closes #3321

## Summary/Motivation:
This is a small PR to test that we are actually testing all NEOS AMPL solvers.  As part of this, it moves the logic for identifying all compatible NEOS solvers to a public method on the `kestrelAAMPL` interface.

By checking that we are testing against all advertised NEOS AMPL solvers, we can close #3321 (if Octeract is added back to the list of advertised solvers, then the test will start failing and we can revisit that issue).

## Changes proposed in this PR:
- Add `kestrelAMPL.getAvailableSolvers()`
- Add a test that verifies `RunAllNEOSSolvers` has a test method for every solver.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
