### PR TITLE
Remove Python 3.8 Support

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13</compiler>
+				<compiler>Python 3.9, 3.10, 3.11, 3.12, 3.13</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -29,12 +29,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest]
         arch: [all]
-        wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
+        wheel-version: ['cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
 
         include:
-        - wheel-version: 'cp38*'
-          TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
           GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
@@ -96,12 +93,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         arch: [all]
-        wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
+        wheel-version: ['cp39*', 'cp310*', 'cp311*', 'cp312*', 'cp313*']
 
         include:
-        - wheel-version: 'cp38*'
-          TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
           GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
@@ -185,7 +179,7 @@ jobs:
         include:
         - os: ubuntu-latest
           TARGET: generic_tarball
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -75,12 +75,6 @@ jobs:
         other: [""]
         category: [""]
 
-        # win/3.8 conda builds no longer work due to environment not being able
-        # to resolve. We are skipping it now.
-        exclude:
-        - os: windows-latest
-          python: 3.8
-
         include:
         - os: ubuntu-latest
           python: '3.13'
@@ -88,7 +82,7 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: '3.10'
+          python: '3.11'
           TARGET: osx
           PYENV: pip
 
@@ -125,7 +119,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: 3.8
+          python: '3.10'
           other: /pip
           skip_doctest: 1
           TARGET: win
@@ -693,17 +687,17 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.8/bare-env
+    name: linux/3.9/bare-env
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Pyomo
       run: |
@@ -761,17 +755,17 @@ jobs:
     #  id: pip-cache
     #  with:
     #    path: cache/pip
-    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.9
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         path: artifacts
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Python Packages (pip)
       shell: bash # DO NOT REMOVE: see note above

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -68,15 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.8, 3.9, '3.10', '3.11', '3.12', '3.13' ]
+        python: [ 3.9, '3.10', '3.11', '3.12', '3.13' ]
         other: [""]
         category: [""]
-
-        # win/3.8 conda builds no longer work due to environment not being able
-        # to resolve. We are skipping it now.
-        exclude:
-        - os: windows-latest
-          python: 3.8
 
         include:
         - os: ubuntu-latest
@@ -119,7 +113,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: 3.8
+          python: 3.9
           other: /pip
           skip_doctest: 1
           TARGET: win
@@ -134,7 +128,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.8
+          python: 3.9
           other: /slim
           slim: 1
           skip_doctest: 1
@@ -151,7 +145,7 @@ jobs:
           PACKAGES: "gurobipy dill numpy>2.0 scipy networkx"
 
         - os: ubuntu-latest
-          python: 3.9
+          python: '3.10'
           other: /pyutilib
           TARGET: linux
           PYENV: pip
@@ -727,7 +721,7 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.8/bare-env
+    name: linux/3.9/bare-env
     needs: lint  # the linter job is a prerequisite for PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -735,10 +729,10 @@ jobs:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Pyomo
       run: |
@@ -796,17 +790,17 @@ jobs:
     #  id: pip-cache
     #  with:
     #    path: cache/pip
-    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.9
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         path: artifacts
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Python Packages (pip)
       shell: bash # DO NOT REMOVE: see note above

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Pyomo is available under the BSD License - see the
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+* CPython: 3.9, 3.10, 3.11, 3.12, 3.13
 * PyPy: 3.9
 
 _Testing and support policy_:

--- a/doc/OnlineDocs/getting_started/installation.rst
+++ b/doc/OnlineDocs/getting_started/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+* CPython: 3.9, 3.10, 3.11, 3.12, 3.13
 * PyPy: 3
 
 At the time of the first Pyomo release after the end-of-life of a minor Python

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,6 @@ setup_kwargs = dict(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -245,7 +244,7 @@ setup_kwargs = dict(
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=['ply'],
     extras_require={
         # There are certain tests that also require pytest-qt, but because those


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
Undo the undo. Once again remove 3.8

## Changes proposed in this PR:
- Remove Python 3.8 support

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
