### PR TITLE
Disallow calling `del_component` with ComponentData arguments

### DIFF
--- a/pyomo/contrib/fme/fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/fourier_motzkin_elimination.py
@@ -730,12 +730,9 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
                 continue
             # deactivate the constraint
             projected_constraints[i].deactivate()
-            m.del_component(obj)
-            # make objective to maximize its infeasibility
-            obj = Objective(
-                expr=projected_constraints[i].body - projected_constraints[i].lower
-            )
-            m.add_component(obj_name, obj)
+            # Our constraint looks like: 0 <= a^Tx - b, so make objective to
+            # maximize its infeasibility
+            obj.expr = projected_constraints[i].body - projected_constraints[i].lower
             results = solver_factory.solve(m)
             if results.solver.termination_condition == TerminationCondition.unbounded:
                 obj_val = -float('inf')
@@ -753,13 +750,13 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
                 obj_val = value(obj)
             # if we couldn't make it infeasible, it's useless
             if obj_val >= tolerance:
-                m.del_component(projected_constraints[i])
                 del projected_constraints[i]
             else:
                 projected_constraints[i].activate()
 
         # clean up
         m.del_component(obj)
+        del obj
         for obj in active_objs:
             obj.activate()
         # undo relax integrality

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -34,6 +34,7 @@ from pyomo.common.pyomo_typing import overload
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import (
     Component,
+    ComponentData,
     ActiveComponentData,
     ModelComponentFactory,
 )
@@ -1139,6 +1140,14 @@ component, use the block del_component() and add_component() methods.
         #    return
 
         name = obj.local_name
+        if isinstance(obj, ComponentData) and not isinstance(obj, Component):
+            raise ValueError(
+                "Argument '%s' to del_component is a ComponentData object. Please "
+                "use the Python 'del' function to delete members of indexed "
+                "Pyomo objects. The del_component function can only be used to "
+                "delete IndexedComponents and ScalarComponents." % name
+            )
+
         if name in self._Block_reserved_words:
             raise ValueError(
                 "Attempting to delete a reserved block component:\n\t%s" % (obj.name,)

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -732,11 +732,7 @@ class ComponentData(ComponentBase):
     This is the base class for the component data used
     in Pyomo modeling components.  Subclasses of ComponentData are
     used in indexed components, and this class assumes that indexed
-    components are subclasses of IndexedComponent.  Note that
-    ComponentData instances do not store their index.  This makes
-    some operations significantly more expensive, but these are (a)
-    associated with I/O generation and (b) this cost can be managed
-    with caches.
+    components are subclasses of IndexedComponent.
 
     Constructor arguments:
         owner           The component that owns this data object


### PR DESCRIPTION
## Fixes #3435

## Summary/Motivation:

I think silently deleting the containing component when we call `del_component` on a ComponentData is rude, and the post-processing in Fourier-Motzkin elimination was falling victim to this mistake. This PR adds a `ValueError` to `del_component` if it is given a ComponentData and revises the FME transformation post-processing routine.

## Changes proposed in this PR:
- Sneaks in a documentation fix for ComponentData
- Adds error to `del_component` if the arguments is a ComponentData
- Revises FME post-processing routine to not misuse `del_component` and, in fact, to not add and delete as many components in general.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
