### PR TITLE
Add option to skip fixing inputs in sequential decomposition

### DIFF
--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -150,6 +150,13 @@ class SequentialDecomposition(FOQUSGraph):
             Keyword options to pass to solve method.
 
             `default={}`
+        
+        skip_fixing_inputs: `bool`
+            Skip fixing all the variables on the tear ports. Require the user
+            to fix the port variables so that 0 degrees of freedom are
+            maintained.
+
+            `default=False`
     """
 
     def __init__(self, **kwds):
@@ -176,6 +183,7 @@ class SequentialDecomposition(FOQUSGraph):
         options["tear_solver"] = "cplex"
         options["tear_solver_io"] = None
         options["tear_solver_options"] = {}
+        options["skip_fixing_inputs"] = False
 
         options.update(kwds)
 
@@ -390,6 +398,7 @@ class SequentialDecomposition(FOQUSGraph):
         arc_map = self.arc_to_edge(G)
         guesses = self.options["guesses"]
         default = self.options["default_guess"]
+        skip_fixing_inputs = self.options["skip_fixing_inputs"]
         for lev in order:
             for unit in lev:
                 if unit not in fixed_inputs:
@@ -402,7 +411,8 @@ class SequentialDecomposition(FOQUSGraph):
                         continue
                     if use_guesses and port in guesses:
                         self.load_guesses(guesses, port, fixed_ins)
-                    self.load_values(port, default, fixed_ins, use_guesses)
+                    if not skip_fixing_inputs:
+                        self.load_values(port, default, fixed_ins, use_guesses)
 
                 function(unit)
 

--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -150,7 +150,7 @@ class SequentialDecomposition(FOQUSGraph):
             Keyword options to pass to solve method.
 
             `default={}`
-        
+
         skip_fixing_inputs: `bool`
             Skip fixing all the variables on the tear ports. Require the user
             to fix the port variables so that 0 degrees of freedom are


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:

I am working on a problem (within `IDAES`) where pyomo network's sequential decomposition is used to initialize the model. For tear ports, I want to either:
- Fix the variables on that port directly, or
- Remove a degree of freedom by adding a constraint for an expression at that port.

For example, if the port has the variables `[flow_mol, pressure, enth_mol]`, and `temperature` is an expression of `pressure` and `enth_mol`, then I want the ability to unfix `enth_mol` and constrain `temperature` to some value to determine the enthalpy.

In pyomo network's case, when running sequential decomposition, all the variables at the port get fixed if they are currently unfixed. I assume this is to prevent user error from too many degrees of freedom. 

However, in my case, my model gets over-defined, since a constraint is added to remove a degree of freedom when a variable is unfixed, but those variables get fixed anyway when sequential decomposition is run.

## Changes proposed in this PR:
- Add an option in sequential decomposition to skip fixing all the variables at the tear ports. Defaults to False. Variables can be fixed manually or through the `set_guesses_for` method.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
