### PR TITLE
NL writer: Add custom exception for no free variables

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -85,6 +85,14 @@ ScalingFactors = namedtuple(
 )
 
 
+class NLWriterEmptyModelError(ValueError):
+    """
+    A custom exception to allow handling of a
+    model with no free variables.
+    """
+    pass
+
+
 # TODO: make a proper base class
 class NLWriterInfo(object):
     """Return type for NLWriter.write()
@@ -320,7 +328,7 @@ class NLWriter(object):
             if config.symbolic_solver_labels:
                 os.remove(row_fname)
                 os.remove(col_fname)
-            raise ValueError(
+            raise NLWriterEmptyModelError(
                 "No variables appear in the Pyomo model constraints or"
                 " objective. This is not supported by the NL file interface"
             )


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes https://github.com/Pyomo/pyomo/issues/3411.

## Summary/Motivation:

`nl_writer.py` raises a `ValueError` for when no free variables are found when writing the `nl` file. However, this is potentially a valid case in my situation (ie. everything is defined; all expressions can just be evaluated). I don't want to try...catch for a `ValueError` because it is a pretty generic exception, and I do want to error if there are other problems. 

See the linked issue for a full description.

## Changes proposed in this PR:
- Add a custom exception `NLWriterEmptyModelError`, which inherits from `ValueError`. This means a try...catch around the `solve` statement (with this specific exception) can be used to handle this case gracefully.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
