### PR TITLE
Defer starting the SAS session until needed

### DIFF
--- a/pyomo/solvers/tests/checks/test_SAS.py
+++ b/pyomo/solvers/tests/checks/test_SAS.py
@@ -26,7 +26,7 @@ from pyomo.environ import (
     Suffix,
 )
 from pyomo.opt.results import SolverStatus, TerminationCondition, ProblemSense
-from pyomo.opt import SolverFactory, check_available_solvers
+from pyomo.opt import SolverFactory
 import warnings
 
 CFGFILE = os.environ.get("SAS_CFG_FILE_PATH", None)
@@ -38,7 +38,10 @@ CAS_OPTIONS = {
 }
 
 
-sas_available = check_available_solvers("sas")
+try:
+    sas94_available = SolverFactory('_sas94').available()
+except:
+    sas94_available = False
 
 
 class SASTestAbc:
@@ -292,7 +295,7 @@ class SASTestLP(SASTestAbc):
         )
 
 
-@unittest.skipIf(not sas_available, "The SAS solver is not available")
+@unittest.skipIf(not sas94_available, "The SAS94 solver interface is not available")
 class SASTestLP94(SASTestLP, unittest.TestCase):
     @mock.patch(
         "pyomo.solvers.plugins.solvers.SAS.SAS94.sas_version",
@@ -325,7 +328,7 @@ class SASTestLP94(SASTestLP, unittest.TestCase):
         self.assertEqual(results.solver.status, SolverStatus.error)
 
 
-# @unittest.skipIf(not sas_available, "The SAS solver is not available")
+# @unittest.skipIf(not sascas_available, "The SAS solver is not available")
 @unittest.skip("Tests not yet configured for SAS Viya interface.")
 class SASTestLPCAS(SASTestLP, unittest.TestCase):
     solver_io = "_sascas"
@@ -526,13 +529,13 @@ class SASTestMILP(SASTestAbc):
         self.assertTrue(self.opt_sas.warm_start_capable())
 
 
-# @unittest.skipIf(not sas_available, "The SAS solver is not available")
+# @unittest.skipIf(not sas94_available, "The SAS solver is not available")
 @unittest.skip("MILP94 tests disabled.")
 class SASTestMILP94(SASTestMILP, unittest.TestCase):
     pass
 
 
-# @unittest.skipIf(not sas_available, "The SAS solver is not available")
+# @unittest.skipIf(not sascas_available, "The SAS solver is not available")
 @unittest.skip("Tests not yet configured for SAS Viya interface.")
 class SASTestMILPCAS(SASTestMILP, unittest.TestCase):
     solver_io = "_sascas"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves an issue with the SAS interface where the SAS session was being started in the interface `__init__.py`.  This meant that any time the interface was created it immediately tried to connect - which, if you are offline, hung until the connection timed out (~10 seconds).  With these changes (and some changes with how SAS tests are skipped), running the tests offline only hits the timeout once (and not a dozen times). 

## Changes proposed in this PR:
- Move the logic to start the SAS session into a helper method
- Only start the SAS session when needed (for the `available()` check or for `solve()`)
- Update the SAS tests to minimize the number of times `available()` needed to be checked.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
