### PR TITLE
Testing: exclude Xpress 9.5.1 on Windows/GHA/Python3.{0,1}

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -377,6 +377,7 @@ jobs:
             for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
+                echo ""
                 # conda can literally take an hour to determine that a
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
@@ -398,6 +399,7 @@ jobs:
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
+                echo ""
                 if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -71,29 +71,29 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.13']
+        python: [3.13]
         other: [""]
         category: [""]
 
         include:
         - os: ubuntu-latest
-          python: '3.13'
+          python: 3.13
           TARGET: linux
           PYENV: pip
 
         - os: macos-latest
-          python: '3.11'
+          python: 3.12
           TARGET: osx
           PYENV: pip
 
         - os: windows-latest
-          python: 3.9
+          python: 3.11
           TARGET: win
           PYENV: conda
           PACKAGES: glpk pytest-qt filelock
 
         - os: ubuntu-latest
-          python: '3.11'
+          python: 3.11
           other: /conda
           skip_doctest: 1
           TARGET: linux
@@ -110,7 +110,7 @@ jobs:
           PACKAGES: openmpi mpi4py
 
         - os: ubuntu-latest
-          python: '3.12'
+          python: 3.12
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -711,6 +711,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
+        include-hidden-files: true
         path: |
           .coverage
           coverage.xml

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -372,7 +372,7 @@ jobs:
                 #  - "!=9.5.1" (conda errors)
                 #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
                 #  - "<=9.5.0|>9.5.1" (conda seg faults)
-                XPRESS='xpress=9.5.0|>9.5.1'
+                XPRESS='xpress=9.5.0'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -119,7 +119,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: '3.10'
+          python: 3.9
           other: /pip
           skip_doctest: 1
           TARGET: win

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -365,9 +365,16 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
+            # Python 3.10 and 3.11.  Exclude that release on that platform.
+            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
+                XPRESS='xpress!=9.5.1'
+            else
+                XPRESS='xpress'
+            fi
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
+            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 # conda can literally take an hour to determine that a

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -368,7 +368,7 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress!=9.5.1'
+                XPRESS='xpress<9.5.1|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -368,7 +368,7 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress<9.5.1|>9.5.1'
+                XPRESS='xpress<=9.5.0|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -368,7 +368,11 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress<=9.5.0|>9.5.1'
+                # We would like to just use something like:
+                #  - "!=9.5.1" (conda errors)
+                #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
+                #  - "<=9.5.0|>9.5.1" (conda seg faults)
+                XPRESS='xpress=9.5.0|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -404,7 +404,7 @@ jobs:
                 #  - "!=9.5.1" (conda errors)
                 #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
                 #  - "<=9.5.0|>9.5.1" (conda seg faults)
-                XPRESS='xpress=9.5.0|>9.5.1'
+                XPRESS='xpress=9.5.0'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -113,7 +113,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: '3.10'
+          python: 3.9
           other: /pip
           skip_doctest: 1
           TARGET: win

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -397,9 +397,16 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
+            # Python 3.10 and 3.11.  Exclude that release on that platform.
+            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
+                XPRESS='xpress!=9.5.1'
+            else
+                XPRESS='xpress'
+            fi
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
+            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 # conda can literally take an hour to determine that a

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -409,6 +409,7 @@ jobs:
             for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
+                echo ""
                 # conda can literally take an hour to determine that a
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
@@ -430,6 +431,7 @@ jobs:
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
+                echo ""
                 if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -400,7 +400,11 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress<=9.5.0|>9.5.1'
+                # We would like to just use something like:
+                #  - "!=9.5.1" (conda errors)
+                #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
+                #  - "<=9.5.0|>9.5.1" (conda seg faults)
+                XPRESS='xpress=9.5.0|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -400,7 +400,7 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress<9.5.1|>9.5.1'
+                XPRESS='xpress<=9.5.0|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -661,8 +661,7 @@ jobs:
       if: ${{ ! matrix.slim }}
       shell: bash
       run: |
-        echo "NOTE: temporarily pinning to highspy pre-release for testing"
-        $PYTHON_EXE -m pip install --cache-dir cache/pip "highspy>=1.7.1.dev1" \
+        $PYTHON_EXE -m pip install --cache-dir cache/pip highspy \
             || echo "WARNING: highspy is not available"
 
     - name: Set up coverage tracking

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -400,7 +400,7 @@ jobs:
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
             if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                XPRESS='xpress!=9.5.1'
+                XPRESS='xpress<9.5.1|>9.5.1'
             else
                 XPRESS='xpress'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.9, '3.10', '3.11', '3.12', '3.13' ]
+        python: [ 3.9, '3.10', 3.11, 3.12, 3.13 ]
         other: [""]
         category: [""]
 
@@ -87,7 +87,7 @@ jobs:
           PACKAGES: glpk pytest-qt filelock
 
         - os: ubuntu-latest
-          python: '3.11'
+          python: 3.11
           other: /conda
           skip_doctest: 1
           TARGET: linux
@@ -104,7 +104,7 @@ jobs:
           PACKAGES: openmpi mpi4py
 
         - os: ubuntu-latest
-          python: '3.12'
+          python: 3.12
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1
@@ -113,14 +113,14 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: 3.9
+          python: '3.10'
           other: /pip
           skip_doctest: 1
           TARGET: win
           PYENV: pip
 
         - os: ubuntu-latest
-          python: '3.11'
+          python: 3.11
           other: /singletest
           category: "-m 'neos or importtest'"
           skip_doctest: 1


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

The Xpress 9.5.1 release through the `fico-xpress` conda channel hangs when calling `xpress.init()` -- but only on Python 3.10 and 3.11 / Windows GHA.  (Quick) attempts to reproduce this locally were not successful, so it is unclear if this is a GHA issue, Conda issue, an Xpress issue, or an issue with our configuration of the build environment.

@djunglas, is there a good way to report things like this upstream?

This PR gets the Pyomo testing infrastructure "working" again by simply pinning xpress to 9.5.0 under Conda on Windows for Python 3.10 and 3.11.  I attempted to make the version pin "float" (and automatically pick up any future Xpress releases), but that was not successful (see comments in the workflows).  We should monitor upstream and revisit if this is still needed after the next Xpress release.

## Changes proposed in this PR:
- Pin xpress to 9.5.0 on Windows under conda for Python 3.10 and 3.11 (only)
- Do some minor clean up of the GHA drivers

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
