### PR TITLE
Allow construction of CUID from another CUID

### DIFF
--- a/pyomo/contrib/mpc/data/get_cuid.py
+++ b/pyomo/contrib/mpc/data/get_cuid.py
@@ -37,11 +37,8 @@ def get_indexed_cuid(var, sets=None, dereference=None, context=None):
         ComponentUID corresponding to the provided ``var`` and sets
 
     """
-    # TODO: Does this function have a good name?
     # Should this function be generalized beyond a single indexing set?
-    if isinstance(var, ComponentUID):
-        return var
-    elif isinstance(var, (str, IndexedComponent_slice)):
+    if isinstance(var, (str, IndexedComponent_slice, ComponentUID)):
         # TODO: Raise error if string and context is None
         return ComponentUID(var, context=context)
     # At this point we are assuming var is a Pyomo Var or VarData object.

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -921,11 +921,7 @@ class BlockData(ActiveComponentData):
             a matching component is not found, None is returned.
 
         """
-        if type(label_or_component) is ComponentUID:
-            cuid = label_or_component
-        else:
-            cuid = ComponentUID(label_or_component)
-        return cuid.find_component_on(self)
+        return ComponentUID(label_or_component).find_component_on(self)
 
     @contextmanager
     def _declare_reserved_components(self):

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -12,6 +12,7 @@
 import codecs
 import re
 import ply.lex
+import copy
 
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import pickle
@@ -86,7 +87,8 @@ class ComponentUID(object):
                 self._cids = tuple(self._parse_cuid_v2(component))
             except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
-
+        elif isinstance(component, ComponentUID):
+            self._cids = copy.deepcopy(component._cids)
         elif type(component) is IndexedComponent_slice:
             self._cids = tuple(
                 self._generate_cuid_from_slice(component, context=context)

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -81,6 +81,7 @@ class ComponentUID(object):
             raise ValueError(
                 f"Context is not allowed when initializing a ComponentUID from {_type}."
             )
+
         if isinstance(component, str):
             if context is not None:
                 _context_err(str)

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -88,7 +88,7 @@ class ComponentUID(object):
                 self._cids = tuple(self._parse_cuid_v2(component))
             except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
-        elif type(component) is ComponentUID):
+        elif type(component) is ComponentUID:
             if context is not None:
                 self._context_err(ComponentUID)
             self._cids = component._cids

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -43,6 +43,12 @@ def _index_repr(x):
     return __index_repr(x, _pickle)
 
 
+def _context_err(_type):
+    raise ValueError(
+        f"Context is not allowed when initializing a ComponentUID from {_type}."
+    )
+
+
 class ComponentUID(object):
     """
     A Component unique identifier
@@ -73,24 +79,19 @@ class ComponentUID(object):
         str: lambda x: '$' + str(x),
     }
 
-    def _context_err(self, _type):
-        raise ValueError(
-            f"Context is not allowed when initializing a ComponentUID from {_type}."
-        )
-
     def __init__(self, component, cuid_buffer=None, context=None):
         # A CUID can be initialized from either a reference component or
         # the string representation.
         if isinstance(component, str):
             if context is not None:
-                self._context_err(str)
+                _context_err(str)
             try:
                 self._cids = tuple(self._parse_cuid_v2(component))
             except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
         elif type(component) is ComponentUID:
             if context is not None:
-                self._context_err(ComponentUID)
+                _context_err(ComponentUID)
             self._cids = component._cids
         elif type(component) is IndexedComponent_slice:
             self._cids = tuple(

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -77,17 +77,20 @@ class ComponentUID(object):
     def __init__(self, component, cuid_buffer=None, context=None):
         # A CUID can be initialized from either a reference component or
         # the string representation.
+        def _context_err(_type):
+            raise ValueError(
+                f"Context is not allowed when initializing a ComponentUID from {_type}."
+            )
         if isinstance(component, str):
             if context is not None:
-                raise ValueError(
-                    "Context is not allowed when initializing a "
-                    "ComponentUID object from a string type"
-                )
+                _context_err(str)
             try:
                 self._cids = tuple(self._parse_cuid_v2(component))
             except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
         elif isinstance(component, ComponentUID):
+            if context is not None:
+                _context_err(ComponentUID)
             self._cids = copy.deepcopy(component._cids)
         elif type(component) is IndexedComponent_slice:
             self._cids = tuple(

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -12,7 +12,6 @@
 import codecs
 import re
 import ply.lex
-import copy
 
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import pickle
@@ -74,25 +73,25 @@ class ComponentUID(object):
         str: lambda x: '$' + str(x),
     }
 
+    def _context_err(self, _type):
+        raise ValueError(
+            f"Context is not allowed when initializing a ComponentUID from {_type}."
+        )
+
     def __init__(self, component, cuid_buffer=None, context=None):
         # A CUID can be initialized from either a reference component or
         # the string representation.
-        def _context_err(_type):
-            raise ValueError(
-                f"Context is not allowed when initializing a ComponentUID from {_type}."
-            )
-
         if isinstance(component, str):
             if context is not None:
-                _context_err(str)
+                self._context_err(str)
             try:
                 self._cids = tuple(self._parse_cuid_v2(component))
             except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
-        elif isinstance(component, ComponentUID):
+        elif type(component) is ComponentUID):
             if context is not None:
-                _context_err(ComponentUID)
-            self._cids = copy.deepcopy(component._cids)
+                self._context_err(ComponentUID)
+            self._cids = component._cids
         elif type(component) is IndexedComponent_slice:
             self._cids = tuple(
                 self._generate_cuid_from_slice(component, context=context)

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -1248,6 +1248,23 @@ class TestComponentUID(unittest.TestCase):
         ):
             cuid = ComponentUID(_slice)
 
+    def test_cuid_from_cuid(self):
+        def assert_equal(cuid1, cuid2):
+            self.assertEqual(cuid1, cuid2)
+            self.assertFalse(cuid1 is cuid2)
+
+        cuid_str = ComponentUID("b.var[1]")
+        cuid_str_2 = ComponentUID(cuid_str)
+        assert_equal(cuid_str, cuid_str_2)
+
+        cuid_comp = ComponentUID(self.m.b[1, 1].c)
+        cuid_comp_2 = ComponentUID(cuid_comp)
+        assert_equal(cuid_str, cuid_str_2)
+
+        cuid_slice = ComponentUID(self.m.b[1, :].c)
+        cuid_slice_2 = ComponentUID(cuid_slice)
+        assert_equal(cuid_slice, cuid_slice_2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -81,10 +81,7 @@ class TestComponentUID(unittest.TestCase):
             ValueError, r"Context 'b\[1,'2'\]' does not apply to component 's'"
         ):
             ComponentUID(self.m.s, context=self.m.b[1, '2'])
-        with self.assertRaisesRegex(
-            ValueError,
-            "Context is not allowed when initializing a ComponentUID from"
-        ):
+        with self.assertRaisesRegex(ValueError, "Context is not allowed"):
             ComponentUID("b[1,2].c.a[2]", context=self.m.b[1, '2'])
 
     def test_parseFromString(self):

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -83,8 +83,7 @@ class TestComponentUID(unittest.TestCase):
             ComponentUID(self.m.s, context=self.m.b[1, '2'])
         with self.assertRaisesRegex(
             ValueError,
-            "Context is not allowed when initializing a ComponentUID "
-            "object from a string type",
+            "Context is not allowed when initializing a ComponentUID from"
         ):
             ComponentUID("b[1,2].c.a[2]", context=self.m.b[1, '2'])
 
@@ -1264,6 +1263,9 @@ class TestComponentUID(unittest.TestCase):
         cuid_slice = ComponentUID(self.m.b[1, :].c)
         cuid_slice_2 = ComponentUID(cuid_slice)
         assert_equal(cuid_slice, cuid_slice_2)
+
+        with self.assertRaisesRegex(ValueError, "Context is not allowed"):
+            ComponentUID(cuid_comp, context=self.m.b[1, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes
`ComponentUID(ComponentUID("x[1]"))` raises an error.

## Summary/Motivation:
When processing keys corresponding to components, e.g., in `find_component` or `contrib.mpc.get_indexed_cuid`, we sometimes want to convert a key into a CUID so it can be handled more consistently. However, we have to handle separately the case where the key is already a CUID. This PR proposes to allow construction of a CUID from another CUID.

## Changes proposed in this PR:
- If the argument to `ComponentUID` is another `ComponentUID`, we just copy the `_cids` attribute onto the new instance.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
