### PR TITLE
Address intermittent TeeStream test failure

### DIFF
--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -334,7 +334,7 @@ class BufferTester(object):
         if not ts.check(*baseline):
             self.fail(ts.error)
 
-    def test_buffered_stdout_flush(self):
+    def test_buffered_stdout_flush(self, retry=True):
         # Test 2: short messages to STDOUT that are flushed are flushed
         fd = self.capture_fd
         ts = timestamper()
@@ -345,9 +345,14 @@ class BufferTester(object):
             time.sleep(self.dt)
         ts.write(f"{time.time()}\n")
         if not ts.check([(0, 0), (0, 0), (0, 0), (1, 1)]):
-            # TODO: For some reason, some part of the flush logic is not
-            # reliable under pypy.
-            if not platform.python_implementation().lower().startswith('pypy'):
+            # FIXME: We don't know why, but this test will
+            # intermittently fail.  For the moment, we will just wait a
+            # little and give it a second chance with a longer delay.
+            if retry:
+                time.sleep(self.dt)
+                self.dt *= 2.5
+                self.test_buffered_stdout_flush(False)
+            else:
                 self.fail(ts.error)
 
     def test_buffered_stdout_long_message(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This makes an attempt at addressing an intermittent test failure in the TeeStream buffering tests.  We are occasionally seeing instances where `pyomo/common/tests/test_tee.py::TestBuffering_noCapture::test_buffered_stdout_flush` fails because the `flush()` does not appear to actually flush the output stream.  This PR doesn't actually fix the underlying issue and instead adds an automatic retry before failing the test.

## Changes proposed in this PR:
- Automatically retry `pyomo/common/tests/test_tee.py::TestBuffering_noCapture::test_buffered_stdout_flush` if the first attempt would have led to a failure.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
