### PR TITLE
Update Gurobi NL interface for Gurobi 12.x

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -87,7 +87,21 @@ class GUROBI(OptSolver):
         else:
             logger.error('Unknown IO type: %s' % mode)
             return
-        opt.set_options('solver=gurobi_ampl')
+        # The Gurobi ASL solver was 'gurobi_ampl' through Gurobi 11, then
+        # was renamed to 'gurobi'
+        for exe_name in ('gurobi', 'gurobi_ampl'):
+            exe = Executable(exe_name)
+            if exe.available() and b'[-AMPL]' in subprocess.run(
+                exe.executable,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=1,
+            ).stdout:
+                opt.set_options(f'solver={exe_name}')
+                break
+        else:
+            opt.set_options('solver=gurobi')
         return opt
 
 

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -88,7 +88,7 @@ class GUROBI(OptSolver):
             logger.error('Unknown IO type: %s' % mode)
             return
         # The Gurobi ASL solver was 'gurobi_ampl' through Gurobi 11,
-        # then was renamed to 'gurobi'.  Check 'gurobi' frst, then
+        # then was renamed to 'gurobi'.  Check 'gurobi' first, then
         # 'gurobi_ampl'.
         for exe_name in ('gurobi', 'gurobi_ampl'):
             exe = Executable(exe_name)

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -87,20 +87,27 @@ class GUROBI(OptSolver):
         else:
             logger.error('Unknown IO type: %s' % mode)
             return
-        # The Gurobi ASL solver was 'gurobi_ampl' through Gurobi 11, then
-        # was renamed to 'gurobi'
+        # The Gurobi ASL solver was 'gurobi_ampl' through Gurobi 11,
+        # then was renamed to 'gurobi'.  Check 'gurobi' frst, then
+        # 'gurobi_ampl'.
         for exe_name in ('gurobi', 'gurobi_ampl'):
             exe = Executable(exe_name)
-            if exe.available() and b'[-AMPL]' in subprocess.run(
-                exe.executable,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=1,
-            ).stdout:
+            if (
+                exe.available()
+                and b'[-AMPL]'
+                in subprocess.run(
+                    exe.executable,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=1,
+                ).stdout
+            ):
                 opt.set_options(f'solver={exe_name}')
                 break
         else:
+            # Fall back on 'gurobi' (matching the current Gurobi
+            # release) if neither appears to be available.
             opt.set_options('solver=gurobi')
         return opt
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Starting in Gurobi 12.0.0, Gurobi no longer distributes the AMPL interface binary.  The interface is now distributed by AMPL through a different channel.  However, as part of this change, the *name* of the executable has changed from `gurobi_ampl` to just `gurobi`.  This PR tracks that change by having the Gurobi NL interface first look for `gurobi`, then fall back on `gurobi_ampl`.  Because of the high probability of running into other executables names "gurobi", in addition to looking for a executable file, we will also check that the file appears to be the NL bindings by executing it and looking for a specific string (`[-AMPL]`) from the ASL usage message. 

## Changes proposed in this PR:
- Look for `gurobi` and `gurobi_ampl` executables when instantiating the Gurobi NL solver interface.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
