### PR TITLE
Resolve error parenthesizing pow mantissa

### DIFF
--- a/pyomo/contrib/cp/scheduling_expr/precedence_expressions.py
+++ b/pyomo/contrib/cp/scheduling_expr/precedence_expressions.py
@@ -13,6 +13,8 @@ from pyomo.core.expr.logical_expr import BooleanExpression
 
 
 class PrecedenceExpression(BooleanExpression):
+    PRECEDENCE = None
+
     def nargs(self):
         return 3
 

--- a/pyomo/contrib/cp/scheduling_expr/step_function_expressions.py
+++ b/pyomo/contrib/cp/scheduling_expr/step_function_expressions.py
@@ -17,6 +17,7 @@ from pyomo.contrib.cp.interval_var import (
 )
 from pyomo.core.expr.base import ExpressionBase
 from pyomo.core.expr.logical_expr import BooleanExpression
+from pyomo.core.expr.numeric_expr import SumExpression
 
 
 def _sum_two_units(_self, _other):
@@ -119,6 +120,7 @@ class StepFunction(ExpressionBase):
     """
 
     __slots__ = ()
+    PRECEDENCE = None
 
     def __add__(self, other):
         return _generate_sum_expression(self, other)
@@ -287,6 +289,7 @@ class CumulativeFunction(StepFunction):
     """
 
     __slots__ = ('_args_', '_nargs')
+    PRECEDENCE = SumExpression.PRECEDENCE
 
     def __init__(self, args, nargs=None):
         # We make sure args are a list because we might add to them later, if
@@ -363,7 +366,7 @@ class AlwaysIn(BooleanExpression):
         return 5
 
     def _to_string(self, values, verbose, smap):
-        return "(%s).within(bounds=(%s, %s), times=(%s, %s))" % (
+        return "%s.within(bounds=(%s, %s), times=(%s, %s))" % (
             values[0],
             values[1],
             values[2],

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -1674,6 +1674,12 @@ class _ToStringVisitor(ExpressionValueVisitor):
             for i, (val, arg) in enumerate(zip(values, node.args)):
                 arg_prec = getattr(arg, 'PRECEDENCE', None)
                 if arg_prec is None:
+                    # This embedded constant (4) is evil, but to actually
+                    # import the NegationExpression.PRECEDENCE from
+                    # numeric_expr would create a circular dependency.
+                    #
+                    # FIXME: rework the dependencies between
+                    # numeric_expr and visitor
                     if val[0] == '-' and node_prec < 4:
                         values[i] = f"({val})"
                 else:
@@ -1703,7 +1709,7 @@ class _ToStringVisitor(ExpressionValueVisitor):
         Return True if the node is not expanded.
         """
         if node is None:
-            return True, None
+            return True, 'Undefined'
 
         if node.__class__ in native_numeric_types:
             return True, str(node)

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -1669,35 +1669,27 @@ class _ToStringVisitor(ExpressionValueVisitor):
 
     def visit(self, node, values):
         """Visit nodes that have been expanded"""
-        for i, val in enumerate(values):
-            arg = node.arg(i)
-
-            if arg is None:
-                values[i] = 'Undefined'
-            elif arg.__class__ in native_numeric_types:
-                pass
-            elif arg.__class__ in nonpyomo_leaf_types:
-                values[i] = f"{val}"
-            else:
-                parens = False
-                if (
-                    not self.verbose
-                    and arg.is_expression_type()
-                    and node.PRECEDENCE is not None
-                ):
-                    if arg.PRECEDENCE is None:
-                        pass
-                    elif node.PRECEDENCE < arg.PRECEDENCE:
+        node_prec = node.PRECEDENCE
+        if node_prec is not None and not self.verbose:
+            for i, (val, arg) in enumerate(zip(values, node.args)):
+                arg_prec = getattr(arg, 'PRECEDENCE', None)
+                if arg_prec is None:
+                    if val[0] == '-' and node_prec < 4:
+                        values[i] = f"({val})"
+                else:
+                    if node_prec < arg_prec:
                         parens = True
-                    elif node.PRECEDENCE == arg.PRECEDENCE:
+                    elif node_prec == arg_prec:
                         if i == 0:
                             parens = node.ASSOCIATIVITY != LEFT_TO_RIGHT
                         elif i == node.nargs() - 1:
                             parens = node.ASSOCIATIVITY != RIGHT_TO_LEFT
                         else:
                             parens = True
-                if parens:
-                    values[i] = f"({val})"
+                    else:
+                        parens = False
+                    if parens:
+                        values[i] = f"({val})"
 
         if self._expression_handlers and node.__class__ in self._expression_handlers:
             return self._expression_handlers[node.__class__](self, node, values)

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -1934,6 +1934,22 @@ class TestPrettyPrinter_oldStyle(unittest.TestCase):
         expr = 5 * model.a / model.a / 2
         self.assertEqual("div(div(mon(5, a), a), 2)", str(expr))
 
+    def test_pow(self):
+        model = ConcreteModel()
+
+        model.x = Var()
+        model.A = Expression(initialize=1)
+        model.B = Expression(initialize=-2)
+
+        expr = model.A**2 + model.B**2
+        self.assertEqual("sum(pow(A{1}, 2), pow(B{-2}, 2))", str(expr))
+
+        expr = model.A**2 - model.B**2
+        self.assertEqual("sum(pow(A{1}, 2), neg(pow(B{-2}, 2)))", str(expr))
+
+        expr = (1) ** model.x + (-1) ** model.x
+        self.assertEqual("sum(pow(1, x), pow(-1, x))", str(expr))
+
     def test_other(self):
         #
         # Print other stuff
@@ -2166,6 +2182,22 @@ class TestPrettyPrinter_newStyle(unittest.TestCase):
         model.a = 1
         model.a.fixed = True
         self.assertEqual("b", expression_to_string(expr, compute_values=True))
+
+    def test_pow(self):
+        model = ConcreteModel()
+
+        model.x = Var()
+        model.A = Expression(initialize=1)
+        model.B = Expression(initialize=-2)
+
+        expr = model.A**2 + model.B**2
+        self.assertEqual("1**2 + (-2)**2", str(expr))
+
+        expr = model.A**2 - model.B**2
+        self.assertEqual("1**2 - (-2)**2", str(expr))
+
+        expr = (1) ** model.x + (-1) ** model.x
+        self.assertEqual("1**x + (-1)**x", str(expr))
 
     def test_inequality(self):
         #


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3471 .

## Summary/Motivation:
This resolves a logic error in the expression to string visitor where we did not correctly interpret negative constants as "neg(const)" when determining if we needed to parenthesize infix expressions.

## Changes proposed in this PR:
- Correctly interpret negative constants as negation
- Add test for behavior from #3471

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
