### PR TITLE
Pin Sphinx to not 8.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -252,7 +252,7 @@ setup_kwargs = dict(
         # the dependencies.
         'tests': ['coverage', 'parameterized', 'pybind11', 'pytest', 'pytest-parallel'],
         'docs': [
-            'Sphinx>4',
+            'Sphinx>4,!=8.2.0',
             'sphinx-copybutton',
             'sphinx_rtd_theme>0.5',
             'sphinxcontrib-jsmath',


### PR DESCRIPTION


## Fixes N/A

## Summary/Motivation:
There is an issue that was revealed with the release of sphinx 8.2.0 in sphinx-toolbox. This is a stop-gap to get our infrastructure working again while we wait for https://github.com/sphinx-toolbox/sphinx-toolbox/issues/178 to be resolved.

## Changes proposed in this PR:
- Pin to `!=8.2.0`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
