### PR TITLE
BUGFIX: f-string in contrib/solver

### DIFF
--- a/pyomo/contrib/solver/config.py
+++ b/pyomo/contrib/solver/config.py
@@ -44,7 +44,7 @@ def TextIO_or_Logger(val):
             ans.append(LogStream(level=logging.INFO, logger=v))
         else:
             raise ValueError(
-                "Expected bool, TextIOBase, or Logger, but received {v.__class__}"
+                f"Expected bool, TextIOBase, or Logger, but received {v.__class__}"
             )
     return ans
 


### PR DESCRIPTION


## Fixes N/A

## Summary/Motivation:
A downstream issue in IDAES revealed that there is a (pretty unhelpful) bug in `contrib.solver.config`

## Changes proposed in this PR:
- Correctly use an f-string

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
