### PR TITLE
BUGFIX: Validator for `tee` in `contrib.solver`

### DIFF
--- a/pyomo/contrib/solver/config.py
+++ b/pyomo/contrib/solver/config.py
@@ -31,21 +31,45 @@ from pyomo.common.timing import HierarchicalTimer
 
 
 def TextIO_or_Logger(val):
-    ans = []
-    if not isinstance(val, Sequence):
+    """
+    Validates and converts input into a list of valid output streams.
+
+    Accepts:
+      - sys.stdout
+      - Instances of io.TextIOBase
+      - logging.Logger (wrapped as LogStream)
+      - Boolean values (`True` → sys.stdout)
+
+    Returns:
+      - A list of validated output streams.
+
+    Raises:
+      - ValueError if an invalid type is provided.
+    """
+    if isinstance(val, (sys.stdout.__class__, io.TextIOBase, logging.Logger)):
         val = [val]
+
+    elif isinstance(val, Sequence) and not isinstance(val, (str, bytes)):
+        val = list(val)
+
+    else:
+        val = [val]
+
+    ans = []
+
     for v in val:
         if v.__class__ in native_logical_types:
             if v:
                 ans.append(sys.stdout)
-        elif isinstance(v, io.TextIOBase):
+        elif isinstance(v, (sys.stdout.__class__, io.TextIOBase)):
             ans.append(v)
         elif isinstance(v, logging.Logger):
             ans.append(LogStream(level=logging.INFO, logger=v))
         else:
             raise ValueError(
-                f"Expected bool, TextIOBase, or Logger, but received {v.__class__}"
+                f"Expected sys.stdout, io.TextIOBase, Logger, or bool, but received {v.__class__}"
             )
+
     return ans
 
 

--- a/pyomo/contrib/solver/config.py
+++ b/pyomo/contrib/solver/config.py
@@ -38,7 +38,7 @@ def TextIO_or_Logger(val):
       - sys.stdout
       - Instances of io.TextIOBase
       - logging.Logger (wrapped as LogStream)
-      - Boolean values (`True` → sys.stdout)
+      - Boolean values (`True` -> sys.stdout)
 
     Returns:
       - A list of validated output streams.

--- a/pyomo/contrib/solver/config.py
+++ b/pyomo/contrib/solver/config.py
@@ -46,10 +46,7 @@ def TextIO_or_Logger(val):
     Raises:
       - ValueError if an invalid type is provided.
     """
-    if isinstance(val, (sys.stdout.__class__, io.TextIOBase, logging.Logger)):
-        val = [val]
-
-    elif isinstance(val, Sequence) and not isinstance(val, (str, bytes)):
+    if isinstance(val, Sequence) and not isinstance(val, (str, bytes)):
         val = list(val)
 
     else:
@@ -62,6 +59,9 @@ def TextIO_or_Logger(val):
             if v:
                 ans.append(sys.stdout)
         elif isinstance(v, (sys.stdout.__class__, io.TextIOBase)):
+            # We are guarding against file-like classes that do not derive from
+            # TextIOBase but are assigned to stdout / stderr.
+            # We still want to accept those classes.
             ans.append(v)
         elif isinstance(v, logging.Logger):
             ans.append(LogStream(level=logging.INFO, logger=v))

--- a/pyomo/contrib/solver/tests/unit/test_config.py
+++ b/pyomo/contrib/solver/tests/unit/test_config.py
@@ -42,9 +42,6 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
 
     @unittest.skipIf(not ipopt_available, 'ipopt is not available')
     def test_real_example(self):
-        log_stream = io.StringIO()
-        logging.basicConfig(stream=log_stream, level=logging.DEBUG)
-        logger = logging.getLogger('contrib.solver.config.test.1')
 
         m = pyo.ConcreteModel()
         m.x = pyo.Var([1, 2], initialize=1, bounds=(0, None))
@@ -52,13 +49,11 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
         m.obj = pyo.Objective(expr=m.x[1] ** 2 + m.x[2] ** 2)
 
         solver = pyo.SolverFactory("ipopt_v2")
-        with capture_output(logger):
+        with capture_output() as OUT:
             solver.solve(m, tee=True, timelimit=5)
 
-        for handler in logger.handlers:
-            handler.flush()
-        log_contents = log_stream.getvalue()
-        self.assertIn('EXIT: Optimal Solution Found.', log_contents)
+        contents = OUT.getvalue()
+        self.assertIn('EXIT: Optimal Solution Found.', contents)
 
 
 class TestSolverConfig(unittest.TestCase):

--- a/pyomo/contrib/solver/tests/unit/test_config.py
+++ b/pyomo/contrib/solver/tests/unit/test_config.py
@@ -36,7 +36,7 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
         self.assertEqual(ans, [])
 
     def test_logger(self):
-        logger = logging.getLogger(__name__)
+        logger = logging.getLogger('contrib.solver.config.test.1')
         ans = TextIO_or_Logger(logger)
         self.assertTrue(isinstance(ans[0], LogStream))
 
@@ -44,7 +44,7 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
     def test_real_example(self):
         log_stream = io.StringIO()
         logging.basicConfig(stream=log_stream, level=logging.DEBUG)
-        logger = logging.getLogger(__name__)
+        logger = logging.getLogger('contrib.solver.config.test.1')
 
         m = pyo.ConcreteModel()
         m.x = pyo.Var([1, 2], initialize=1, bounds=(0, None))

--- a/pyomo/contrib/solver/tests/unit/test_config.py
+++ b/pyomo/contrib/solver/tests/unit/test_config.py
@@ -56,7 +56,7 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
             solver.solve(m, tee=True, timelimit=5)
 
         log_contents = log_stream.getvalue()
-        self.assertIn('DEBUG:', log_contents)
+        self.assertIn('EXIT: Optimal Solution Found.', log_contents)
 
 
 class TestSolverConfig(unittest.TestCase):

--- a/pyomo/contrib/solver/tests/unit/test_config.py
+++ b/pyomo/contrib/solver/tests/unit/test_config.py
@@ -55,6 +55,8 @@ class TestTextIO_or_LoggerValidator(unittest.TestCase):
         with capture_output(logger):
             solver.solve(m, tee=True, timelimit=5)
 
+        for handler in logger.handlers:
+            handler.flush()
         log_contents = log_stream.getvalue()
         self.assertIn('EXIT: Optimal Solution Found.', log_contents)
 


### PR DESCRIPTION


## Fixes N/A

## Summary/Motivation:
There is repeatable bug in the interaction between `capture_output` and any of the `*_v2` solvers in `contrib.solver` due to the way the `TextIO_or_Logger` domain validator was working. A minimal reproducible example of the bug:

```
import pyomo.environ as pyo
from pyomo.common.tee import capture_output

m = pyo.ConcreteModel()
m.x = pyo.Var([1,2],initialize=1, bounds=(0, None))
m.eq = pyo.Constraint(expr=m.x[1]*m.x[2]**1.5 == 3)
m.obj = pyo.Objective(expr=m.x[1]**2 + m.x[2]**2)

solver = pyo.SolverFactory("ipopt_v2")
with capture_output():
    solver.solve(m, tee=True)

```


## Changes proposed in this PR:
- Slightly change the logic in `TextIO_or_Logger`
- Add tests to ensure correct behavior, both alone and under `capture_output`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
