### PR TITLE
conda: disable '--update-deps' to work around buggy libffi(?)

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -309,7 +309,9 @@ jobs:
         conda config --append channels nodefaults
         conda config --append channels conda-forge
         # Try to install mamba
-        conda install --update-deps -q -y -n base conda-libmamba-solver \
+        # Note: removed '--update-deps' on 2025-02-28 to work around
+        #       broken libffi(?)
+        conda install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -341,7 +341,9 @@ jobs:
         conda config --append channels nodefaults
         conda config --append channels conda-forge
         # Try to install mamba
-        conda install --update-deps -q -y -n base conda-libmamba-solver \
+        # Note: removed '--update-deps' on 2025-02-28 to work around
+        #       broken libffi(?)
+        conda install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Windows conda builds are currently broken because running conda with `--update-deps` causes libffi to be updated which results in
```
ImportError: DLL load failed while importing _ctypes: The specified module could not be found.
```
when trying to install conda packages.

## Changes proposed in this PR:
- remove `--update-deps` from conda install of conda-libmamba-solver

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
