### PR TITLE
Add timeout when installing optional packages (solvers) in conda

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -303,30 +303,31 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Set up environment
-        conda config --set always_yes yes
-        conda config --set auto_update_conda false
-        conda config --remove channels defaults
-        conda config --append channels nodefaults
-        conda config --append channels conda-forge
+        CONDA=`which conda`
+        $CONDA config --set always_yes yes
+        $CONDA config --set auto_update_conda false
+        $CONDA config --remove channels defaults
+        $CONDA config --append channels nodefaults
+        $CONDA config --append channels conda-forge
         # Try to install mamba
         # Note: removed '--update-deps' on 2025-02-28 to work around
         #       broken libffi(?)
-        conda install -q -y -n base conda-libmamba-solver \
+        $CONDA install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"
-            conda config --set solver libmamba
+            $CONDA config --set solver libmamba
         fi
         # Add the rest of the channels
-        conda config --append channels gurobi
-        conda config --append channels ibmdecisionoptimization
-        conda config --append channels fico-xpress
+        $CONDA config --append channels gurobi
+        $CONDA config --append channels ibmdecisionoptimization
+        $CONDA config --append channels fico-xpress
         # Print environment info
         echo "*** CONDA environment: ***"
-        conda info
-        conda config --show-sources
-        conda config --show channels
-        conda list --show-channel-urls
+        $CONDA info
+        $CONDA config --show-sources
+        $CONDA config --show channels
+        $CONDA list --show-channel-urls
         which python
         python --version
         # Note: some pypi packages are not available through conda
@@ -365,7 +366,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        $CONDA install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
@@ -389,7 +390,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
+                _PKGLIST=$($CONDA search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
@@ -405,9 +406,11 @@ jobs:
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True).returncode)" || _BUILDS=""
+                        python -c "import sys, subprocess; \
+                            CMD=['$CONDA', 'install', '-y', '$PKG']; \
+                            print(CMD); \
+                            sys.exit(subprocess.run(CMD, timeout=150).returncode)" \
+                            || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -440,7 +443,7 @@ jobs:
         done
         echo ""
         echo "Final conda environment:"
-        conda list | sed 's/^/    /'
+        $CONDA list | sed 's/^/    /'
 
     - name: Setup TPL package directories
       run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -406,7 +406,7 @@ jobs:
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            subprocess.run(['$CONDA_EXE', 'install', '-y', '$PKG'], \
                             timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -404,10 +404,13 @@ jobs:
                         echo "... INSTALLING $PKG"
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
-                        # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['$CONDA_EXE', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True).returncode)" || _BUILDS=""
+                        # a subshell and kill it after 2.5-minutes.
+                        (conda install -y $PKG) &
+                        conda_pid=$!
+                        (sleep 150 && kill -9 "$conda_pid" 2>/dev/null) &
+                        timeout_pid=$!
+                        wait "$conda_pid" || _BUILDS=""
+                        kill "$timeout_pid" 2>/dev/null
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -406,7 +406,7 @@ jobs:
                         # indefinitely (lately while installing SCIP),
                         # we will run "conda install" in a subshell and
                         # kill it after 5-minutes.
-                        (conda install -y $PKG) &
+                        (conda install -q -y $PKG) &
                         conda_pid=$!
                         (sleep 300 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -407,7 +407,7 @@ jobs:
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
                             subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True))" || _BUILDS=""
+                            timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -303,31 +303,30 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Set up environment
-        CONDA=`which conda`
-        $CONDA config --set always_yes yes
-        $CONDA config --set auto_update_conda false
-        $CONDA config --remove channels defaults
-        $CONDA config --append channels nodefaults
-        $CONDA config --append channels conda-forge
+        conda config --set always_yes yes
+        conda config --set auto_update_conda false
+        conda config --remove channels defaults
+        conda config --append channels nodefaults
+        conda config --append channels conda-forge
         # Try to install mamba
         # Note: removed '--update-deps' on 2025-02-28 to work around
         #       broken libffi(?)
-        $CONDA install -q -y -n base conda-libmamba-solver \
+        conda install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"
-            $CONDA config --set solver libmamba
+            conda config --set solver libmamba
         fi
         # Add the rest of the channels
-        $CONDA config --append channels gurobi
-        $CONDA config --append channels ibmdecisionoptimization
-        $CONDA config --append channels fico-xpress
+        conda config --append channels gurobi
+        conda config --append channels ibmdecisionoptimization
+        conda config --append channels fico-xpress
         # Print environment info
         echo "*** CONDA environment: ***"
-        $CONDA info
-        $CONDA config --show-sources
-        $CONDA config --show channels
-        $CONDA list --show-channel-urls
+        conda info
+        conda config --show-sources
+        conda config --show channels
+        conda list --show-channel-urls
         which python
         python --version
         # Note: some pypi packages are not available through conda
@@ -366,7 +365,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        $CONDA install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
@@ -390,7 +389,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$($CONDA search -f "$PKG") || echo "Package $PKG not found"
+                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
@@ -406,11 +405,9 @@ jobs:
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; \
-                            CMD=['$CONDA', 'install', '-y', '$PKG']; \
-                            print(CMD); \
-                            sys.exit(subprocess.run(CMD, timeout=150).returncode)" \
-                            || _BUILDS=""
+                        python -c "import sys, subprocess; sys.exit( \
+                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -443,7 +440,7 @@ jobs:
         done
         echo ""
         echo "Final conda environment:"
-        $CONDA list | sed 's/^/    /'
+        conda list | sed 's/^/    /'
 
     - name: Setup TPL package directories
       run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -402,7 +402,12 @@ jobs:
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo ""
                         echo "... INSTALLING $PKG"
-                        conda install -y "$PKG" || _BUILDS=""
+                        # Because SCIP frequently causes conda to hang
+                        # indefinitely, we will run "conda insta;;" kin
+                        # a subprocess with a 2.5-minute timeout.
+                        python -c "import sys, subprocess; sys.exit( \
+                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            timeout=150))" || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -412,6 +417,8 @@ jobs:
             done
         fi
         # Re-try Pyomo (optional) dependencies with pip
+        echo ""
+        echo "Installing packages only available on PyPI"
         if test -n "$PYPI_DEPENDENCIES"; then
             python -m pip install --cache-dir cache/pip $PYPI_DEPENDENCIES
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -408,7 +408,7 @@ jobs:
                         # kill it after 5-minutes.
                         (conda install -y $PKG) &
                         conda_pid=$!
-                        (sleep 300 && kill -9 "$conda_pid" 2>/dev/null) &
+                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
                         kill "$timeout_pid" 2>/dev/null \

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -402,15 +402,17 @@ jobs:
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo ""
                         echo "... INSTALLING $PKG"
-                        # Because SCIP frequently causes conda to hang
-                        # indefinitely, we will run "conda install" in
-                        # a subshell and kill it after 2.5-minutes.
+                        # Because conda can occasionally hang
+                        # indefinitely (lately while installing SCIP),
+                        # we will run "conda install" in a subshell and
+                        # kill it after 5-minutes.
                         (conda install -y $PKG) &
                         conda_pid=$!
-                        (sleep 150 && kill -9 "$conda_pid" 2>/dev/null) &
+                        (sleep 300 && kill -9 "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
-                        kill "$timeout_pid" 2>/dev/null
+                        kill "$timeout_pid" 2>/dev/null \
+                            || echo "TIMEOUT: killed conda install process"
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -403,11 +403,11 @@ jobs:
                         echo ""
                         echo "... INSTALLING $PKG"
                         # Because SCIP frequently causes conda to hang
-                        # indefinitely, we will run "conda insta;;" kin
+                        # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
                             subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150))" || _BUILDS=""
+                            timeout=150, shell=True))" || _BUILDS=""
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -436,10 +436,13 @@ jobs:
                         echo "... INSTALLING $PKG"
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
-                        # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['$CONDA_EXE', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True).returncode)" || _BUILDS=""
+                        # a subshell and kill it after 2.5-minutes.
+                        (conda install -y $PKG) &
+                        conda_pid=$!
+                        (sleep 150 && kill -9 "$conda_pid" 2>/dev/null) &
+                        timeout_pid=$!
+                        wait "$conda_pid" || _BUILDS=""
+                        kill "$timeout_pid" 2>/dev/null
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -335,31 +335,30 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Set up environment
-        CONDA=`which conda`
-        $CONDA config --set always_yes yes
-        $CONDA config --set auto_update_conda false
-        $CONDA config --remove channels defaults
-        $CONDA config --append channels nodefaults
-        $CONDA config --append channels conda-forge
+        conda config --set always_yes yes
+        conda config --set auto_update_conda false
+        conda config --remove channels defaults
+        conda config --append channels nodefaults
+        conda config --append channels conda-forge
         # Try to install mamba
         # Note: removed '--update-deps' on 2025-02-28 to work around
         #       broken libffi(?)
-        $CONDA install -q -y -n base conda-libmamba-solver \
+        conda install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"
-            $CONDA config --set solver libmamba
+            conda config --set solver libmamba
         fi
         # Add the rest of the channels
-        $CONDA config --append channels gurobi
-        $CONDA config --append channels ibmdecisionoptimization
-        $CONDA config --append channels fico-xpress
+        conda config --append channels gurobi
+        conda config --append channels ibmdecisionoptimization
+        conda config --append channels fico-xpress
         # Print environment info
         echo "*** CONDA environment: ***"
-        $CONDA info
-        $CONDA config --show-sources
-        $CONDA config --show channels
-        $CONDA list --show-channel-urls
+        conda info
+        conda config --show-sources
+        conda config --show channels
+        conda list --show-channel-urls
         which python
         python --version
         # Note: some pypi packages are not available through conda
@@ -398,7 +397,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        $CONDA install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
@@ -422,7 +421,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$($CONDA search -f "$PKG") || echo "Package $PKG not found"
+                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
@@ -438,11 +437,9 @@ jobs:
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; \
-                            CMD=['$CONDA', 'install', '-y', '$PKG']; \
-                            print(CMD); \
-                            sys.exit(subprocess.run(CMD, timeout=150).returncode)" \
-                            || _BUILDS=""
+                        python -c "import sys, subprocess; sys.exit( \
+                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -475,7 +472,7 @@ jobs:
         done
         echo ""
         echo "Final conda environment:"
-        $CONDA list | sed 's/^/    /'
+        conda list | sed 's/^/    /'
 
     - name: Setup TPL package directories
       run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -438,7 +438,7 @@ jobs:
                         # indefinitely (lately while installing SCIP),
                         # we will run "conda install" in a subshell and
                         # kill it after 5-minutes.
-                        (conda install -y $PKG) &
+                        (conda install -q -y $PKG) &
                         conda_pid=$!
                         (sleep 300 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -435,11 +435,11 @@ jobs:
                         echo ""
                         echo "... INSTALLING $PKG"
                         # Because SCIP frequently causes conda to hang
-                        # indefinitely, we will run "conda insta;;" kin
+                        # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
                             subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150))" || _BUILDS=""
+                            timeout=150, shell=True))" || _BUILDS=""
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -438,7 +438,7 @@ jobs:
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            subprocess.run(['$CONDA_EXE', 'install', '-y', '$PKG'], \
                             timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -335,30 +335,31 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Set up environment
-        conda config --set always_yes yes
-        conda config --set auto_update_conda false
-        conda config --remove channels defaults
-        conda config --append channels nodefaults
-        conda config --append channels conda-forge
+        CONDA=`which conda`
+        $CONDA config --set always_yes yes
+        $CONDA config --set auto_update_conda false
+        $CONDA config --remove channels defaults
+        $CONDA config --append channels nodefaults
+        $CONDA config --append channels conda-forge
         # Try to install mamba
         # Note: removed '--update-deps' on 2025-02-28 to work around
         #       broken libffi(?)
-        conda install -q -y -n base conda-libmamba-solver \
+        $CONDA install -q -y -n base conda-libmamba-solver \
             || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"
-            conda config --set solver libmamba
+            $CONDA config --set solver libmamba
         fi
         # Add the rest of the channels
-        conda config --append channels gurobi
-        conda config --append channels ibmdecisionoptimization
-        conda config --append channels fico-xpress
+        $CONDA config --append channels gurobi
+        $CONDA config --append channels ibmdecisionoptimization
+        $CONDA config --append channels fico-xpress
         # Print environment info
         echo "*** CONDA environment: ***"
-        conda info
-        conda config --show-sources
-        conda config --show channels
-        conda list --show-channel-urls
+        $CONDA info
+        $CONDA config --show-sources
+        $CONDA config --show channels
+        $CONDA list --show-channel-urls
         which python
         python --version
         # Note: some pypi packages are not available through conda
@@ -397,7 +398,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        $CONDA install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (from conda) hangs indefinitely on GHA/Windows under
             # Python 3.10 and 3.11.  Exclude that release on that platform.
@@ -421,7 +422,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
+                _PKGLIST=$($CONDA search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
@@ -437,9 +438,11 @@ jobs:
                         # Because SCIP frequently causes conda to hang
                         # indefinitely, we will run "conda install" in
                         # a subprocess with a 2.5-minute timeout.
-                        python -c "import sys, subprocess; sys.exit( \
-                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True).returncode)" || _BUILDS=""
+                        python -c "import sys, subprocess; \
+                            CMD=['$CONDA', 'install', '-y', '$PKG']; \
+                            print(CMD); \
+                            sys.exit(subprocess.run(CMD, timeout=150).returncode)" \
+                            || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -472,7 +475,7 @@ jobs:
         done
         echo ""
         echo "Final conda environment:"
-        conda list | sed 's/^/    /'
+        $CONDA list | sed 's/^/    /'
 
     - name: Setup TPL package directories
       run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -440,7 +440,7 @@ jobs:
                         # kill it after 5-minutes.
                         (conda install -y $PKG) &
                         conda_pid=$!
-                        (sleep 300 && kill -9 "$conda_pid" 2>/dev/null) &
+                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
                         kill "$timeout_pid" 2>/dev/null \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -439,7 +439,7 @@ jobs:
                         # a subprocess with a 2.5-minute timeout.
                         python -c "import sys, subprocess; sys.exit( \
                             subprocess.run(['conda', 'install', '-y', '$PKG'], \
-                            timeout=150, shell=True))" || _BUILDS=""
+                            timeout=150, shell=True).returncode)" || _BUILDS=""
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -434,7 +434,12 @@ jobs:
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo ""
                         echo "... INSTALLING $PKG"
-                        conda install -y "$PKG" || _BUILDS=""
+                        # Because SCIP frequently causes conda to hang
+                        # indefinitely, we will run "conda insta;;" kin
+                        # a subprocess with a 2.5-minute timeout.
+                        python -c "import sys, subprocess; sys.exit( \
+                            subprocess.run(['conda', 'install', '-y', '$PKG'], \
+                            timeout=150))" || _BUILDS=""
                     fi
                 fi
                 echo ""
@@ -444,6 +449,8 @@ jobs:
             done
         fi
         # Re-try Pyomo (optional) dependencies with pip
+        echo ""
+        echo "Installing packages only available on PyPI"
         if test -n "$PYPI_DEPENDENCIES"; then
             python -m pip install --cache-dir cache/pip $PYPI_DEPENDENCIES
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -434,15 +434,17 @@ jobs:
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo ""
                         echo "... INSTALLING $PKG"
-                        # Because SCIP frequently causes conda to hang
-                        # indefinitely, we will run "conda install" in
-                        # a subshell and kill it after 2.5-minutes.
+                        # Because conda can occasionally hang
+                        # indefinitely (lately while installing SCIP),
+                        # we will run "conda install" in a subshell and
+                        # kill it after 5-minutes.
                         (conda install -y $PKG) &
                         conda_pid=$!
-                        (sleep 150 && kill -9 "$conda_pid" 2>/dev/null) &
+                        (sleep 300 && kill -9 "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
-                        kill "$timeout_pid" 2>/dev/null
+                        kill "$timeout_pid" 2>/dev/null \
+                            || echo "TIMEOUT: killed conda install process"
                     fi
                 fi
                 echo ""


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
We continue to see intermittent test failures (primarily on win/3.11) where conda hangs indefinitely trying to solve the environment while installing SCIP.  As resolving this issue will likely require a SCIP release, this PR updates the process we use to `conda install` optional packages (solvers) to enforce a 5-minute timeout when installing each package.

Timing out on the install will NOT fail the build.

## Changes proposed in this PR:
- Add a 5-minute timeout when attempting to install optional solvers with conda

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
