### PR TITLE
BUGFIX: Fix timeout logic

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -379,7 +379,7 @@ jobs:
             fi
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in scip 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -416,7 +416,7 @@ jobs:
             fi
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in scip 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""


### PR DESCRIPTION


## Followup to #3501 

## Summary/Motivation:
The timeout in #3501 was causing issues on 3.11 when it actually hit the timeout. It turns out that moving `scip` to the front of the line allows the timeout to work as intended without a catastrophic failure.

## Changes proposed in this PR:
- Move `scip` to first in line

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
