### PR TITLE
Increase conda timeout by 50%

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -407,7 +407,7 @@ jobs:
                         # kill it after 5-minutes.
                         (conda install -q -y $PKG) &
                         conda_pid=$!
-                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
+                        (sleep 450 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
                         kill "$timeout_pid" 2>/dev/null \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -444,7 +444,7 @@ jobs:
                         # kill it after 5-minutes.
                         (conda install -q -y $PKG) &
                         conda_pid=$!
-                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
+                        (sleep 450 && kill "$conda_pid" 2>/dev/null) &
                         timeout_pid=$!
                         wait "$conda_pid" || _BUILDS=""
                         kill "$timeout_pid" 2>/dev/null \


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:
We are getting a lot more failures due to the new timeout introduced in conda. These have been helpful because they kill jobs quickly rather than letting them spin forever; however, we'd like to see fewer false failures. While we figure out how to correctly handle timeouts, this is a stopgap that increases the timeout to allow a bit more time for conda to resolve environments.

## Changes proposed in this PR:
- Increase sleep timer to 450 seconds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
