### PR TITLE
BUGFIX: Add logic for highspy versions

### DIFF
--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -273,7 +273,8 @@ class Highs(PersistentBase, PersistentSolver):
                 self._warm_start()
             timer.start('optimize')
             ostreams[-1].write("RUN!\n")
-            self._solver_model.HandleKeyboardInterrupt = True
+            if self.version()[1] >= 8:
+                self._solver_model.HandleKeyboardInterrupt = True
             self._solver_model.run()
             timer.stop('optimize')
 

--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -273,7 +273,7 @@ class Highs(PersistentBase, PersistentSolver):
                 self._warm_start()
             timer.start('optimize')
             ostreams[-1].write("RUN!\n")
-            if (self.version()[0] >= 1 and self.version()[1] >= 8):
+            if self.version()[0] >= 1 and self.version()[1] >= 8:
                 self._solver_model.HandleKeyboardInterrupt = True
             self._solver_model.run()
             timer.stop('optimize')

--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -273,7 +273,7 @@ class Highs(PersistentBase, PersistentSolver):
                 self._warm_start()
             timer.start('optimize')
             ostreams[-1].write("RUN!\n")
-            if self.version()[1] >= 8:
+            if (self.version()[0] >= 1 and self.version()[1] >= 8):
                 self._solver_model.HandleKeyboardInterrupt = True
             self._solver_model.run()
             timer.stop('optimize')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3489 

## Summary/Motivation:
There is a new feature in `highspy` that allows keyboard interruption. It's not available in old versions. This PR checks the version to make sure it meets the minimum requirement.

## Changes proposed in this PR:
- Ensure that version is at least 1.8 before setting keyboard interrupt


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
