### PR TITLE
Be more careful when/how we timeout conda install

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -377,6 +377,7 @@ jobs:
             else
                 XPRESS='xpress'
             fi
+            TIMEOUT_MSG="TIMEOUT: killing conda install process"
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
@@ -405,13 +406,22 @@ jobs:
                         # indefinitely (lately while installing SCIP),
                         # we will run "conda install" in a subshell and
                         # kill it after 5-minutes.
-                        (conda install -q -y $PKG) &
-                        conda_pid=$!
-                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
+                        (conda install -q -y $PKG |& tee conda.log) &
+                        conda_subshell_pid=$!
+                        sleep 1
+                        conda_pid=$(ps | grep conda | sed 's/^ *//' | sed 's/ .*//')
+                        # Only timeout the conda process if it's not to
+                        # the installation phase yet.  Signalling conda
+                        # after it has started the installation process
+                        # can irrecoverably corrupt the environment.
+                        (sleep 300 \
+                            && if test `grep 'Package Plan' conda.log | wc -l` -eq 0; \
+                            then echo "$TIMEOUT_MSG $conda_pid (TERM)" \
+                            && kill -TERM $conda_pid 2>/dev/null ; fi) &
                         timeout_pid=$!
-                        wait "$conda_pid" || _BUILDS=""
-                        kill "$timeout_pid" 2>/dev/null \
-                            || echo "TIMEOUT: killed conda install process"
+                        wait $conda_subshell_pid || _BUILDS=""
+                        kill $timeout_pid 2>/dev/null \
+                            || echo "TIMEOUT: time limit expired"
                     fi
                 fi
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -414,6 +414,7 @@ jobs:
             else
                 XPRESS='xpress'
             fi
+            TIMEOUT_MSG="TIMEOUT: killing conda install process"
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
@@ -442,13 +443,22 @@ jobs:
                         # indefinitely (lately while installing SCIP),
                         # we will run "conda install" in a subshell and
                         # kill it after 5-minutes.
-                        (conda install -q -y $PKG) &
-                        conda_pid=$!
-                        (sleep 300 && kill "$conda_pid" 2>/dev/null) &
+                        (conda install -q -y $PKG |& tee conda.log) &
+                        conda_subshell_pid=$!
+                        sleep 1
+                        conda_pid=$(ps | grep conda | sed 's/^ *//' | sed 's/ .*//')
+                        # Only timeout the conda process if it's not to
+                        # the installation phase yet.  Signalling conda
+                        # after it has started the installation process
+                        # can irrecoverably corrupt the environment.
+                        (sleep 300 \
+                            && if test `grep 'Package Plan' conda.log | wc -l` -eq 0; \
+                            then echo "$TIMEOUT_MSG $conda_pid (TERM)" \
+                            && kill -TERM $conda_pid 2>/dev/null ; fi) &
                         timeout_pid=$!
-                        wait "$conda_pid" || _BUILDS=""
-                        kill "$timeout_pid" 2>/dev/null \
-                            || echo "TIMEOUT: killed conda install process"
+                        wait $conda_subshell_pid || _BUILDS=""
+                        kill $timeout_pid 2>/dev/null \
+                            || echo "TIMEOUT: time limit expired"
                     fi
                 fi
                 echo ""


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This should resolve ongoing issues with managing conda environments on Windows.  `conda install` can get stuck (indefinitely) resolving the environment when installing scip on Windows/Python3.12.  However, we cannot just kill conda at will: if conda has started installation, we must wait for it to complete.  Instead of making the timeout longer (as in #3507), we will monitor the conda install process and only kill conda if it hasn't gotten to the installation phase when the timeout happens. 

This PR supersedes #3507

## Changes proposed in this PR:
- explicitly look up the conda install PID (and signal it directly)
- only signal conda if it hasn't started the installation process when the timeout happens.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
