### PR TITLE
Resolve intermittent test failure (increase sleep time)

### DIFF
--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -333,7 +333,9 @@ class TestTeeStream(unittest.TestCase):
     def test_deadlock(self):
         class MockStream(object):
             def write(self, data):
-                time.sleep(0.2)
+                # This test will kill the write before this sleep is
+                # done, so a long sleep won't impact suite run time.
+                time.sleep(1)
 
             def flush(self):
                 pass

--- a/pyomo/core/tests/examples/test_tutorials.py
+++ b/pyomo/core/tests/examples/test_tutorials.py
@@ -15,15 +15,13 @@
 import runpy
 import sys
 import os
-from os.path import abspath, dirname
-
-topdir = dirname(dirname(dirname(dirname(dirname(abspath(__file__))))))
-currdir = dirname(abspath(__file__)) + os.sep
-tutorial_dir = (
-    topdir + os.sep + "examples" + os.sep + "pyomo" + os.sep + "tutorials" + os.sep
-)
 
 import pyomo.common.unittest as unittest
+
+from pyomo.common.fileutils import PYOMO_ROOT_DIR
+from pyomo.common.tee import capture_output
+
+tutorial_dir = os.path.join(PYOMO_ROOT_DIR, "examples", "pyomo", "tutorials")
 
 try:
     from win32com.client.dynamic import Dispatch
@@ -65,38 +63,25 @@ class PyomoTutorials(unittest.TestCase):
         self.cwd = os.getcwd()
         self.tmp_path = list(sys.path)
         os.chdir(tutorial_dir)
-        sys.path = [os.path.dirname(tutorial_dir)] + sys.path
-        sys.path.append(os.path.dirname(tutorial_dir))
-        sys.stderr.flush()
-        sys.stdout.flush()
-        self.save_stdout = sys.stdout
-        self.save_stderr = sys.stderr
+        sys.path = [tutorial_dir] + sys.path
 
     def tearDown(self):
         os.chdir(self.cwd)
         sys.path = self.tmp_path
-        sys.stdout = self.save_stdout
-        sys.stderr = self.save_stderr
 
     def driver(self, name):
-        OUTPUT = open(currdir + name + '.log', 'w')
-        sys.stdout = OUTPUT
-        sys.stderr = OUTPUT
-        runpy.run_module(name, None, "__main__")
-        OUTPUT.close()
+        with capture_output() as OUT:
+            runpy.run_module(name, None, "__main__")
         self.assertIn(
-            open(tutorial_dir + name + ".out", 'r').read(),
-            open(currdir + name + ".log", 'r').read(),
+            open(os.path.join(tutorial_dir, name + ".out"), 'r').read(), OUT.getvalue()
         )
-        os.remove(currdir + name + ".log")
 
     def test_data(self):
         self.driver('data')
 
-    @unittest.skipIf(not (_xlrd or _openpyxl), "Cannot read excel file.")
-    @unittest.skipIf(
-        not (_win32com and _excel_available and pyutilib_available),
-        "Cannot read excel file.",
+    @unittest.skipUnless(_xlrd or _openpyxl, "Cannot read excel file.")
+    @unittest.skipUnless(
+        _win32com and _excel_available and pyutilib_available, "Cannot read excel file."
     )
     def test_excel(self):
         self.driver('excel')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This should resolve an intermittent test failure (deadlock exception not being raised) being observed on GHA win/pip

## Changes proposed in this PR:
- Increase sleep in deadlock test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
