### PR TITLE
Update missing future solver interfaces docs

### DIFF
--- a/doc/OnlineDocs/explanation/experimental/solvers.rst
+++ b/doc/OnlineDocs/explanation/experimental/solvers.rst
@@ -51,6 +51,9 @@ with existing interfaces).
    * - Gurobi (direct)
      - ``gurobi_direct``
      - ``gurobi_direct_v2``
+   * - HiGHS
+     - ``highs``
+     - ``highs``
 
 Using the new interfaces through the legacy interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/OnlineDocs/reference/topical/appsi/appsi.rst
+++ b/doc/OnlineDocs/reference/topical/appsi/appsi.rst
@@ -24,17 +24,17 @@ example of using an APPSI solver interface.
 
 .. code-block:: python
 
-    >>> import pyomo.environ as pe
+    >>> import pyomo.environ as pyo
     >>> from pyomo.contrib import appsi
     >>> import numpy as np
     >>> from pyomo.common.timing import HierarchicalTimer
-    >>> m = pe.ConcreteModel()
-    >>> m.x = pe.Var()
-    >>> m.y = pe.Var()
-    >>> m.p = pe.Param(mutable=True)
-    >>> m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-    >>> m.c1 = pe.Constraint(expr=m.y >= pe.exp(m.x))
-    >>> m.c2 = pe.Constraint(expr=m.y >= (m.x - m.p)**2)
+    >>> m = pyo.ConcreteModel()
+    >>> m.x = pyo.Var()
+    >>> m.y = pyo.Var()
+    >>> m.p = pyo.Param(mutable=True)
+    >>> m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+    >>> m.c1 = pyo.Constraint(expr=m.y >= pyo.exp(m.x))
+    >>> m.c2 = pyo.Constraint(expr=m.y >= (m.x - m.p)**2)
     >>> opt = appsi.solvers.Ipopt()
     >>> timer = HierarchicalTimer()
     >>> for p_val in np.linspace(1, 10, 100):
@@ -43,6 +43,15 @@ example of using an APPSI solver interface.
     >>>     assert res.termination_condition == appsi.base.TerminationCondition.optimal
     >>>     print(res.best_feasible_objective)
     >>> print(timer)
+
+Alternatively, you can access the APPSI solvers through the classic
+``SolverFactory`` using the pattern ``appsi_solvername``.
+
+.. code-block:: python
+
+    >>> import pyomo.environ as pyo
+    >>> opt_ipopt = pyo.SolverFactory('appsi_ipopt')
+    >>> opt_highs = pyo.SolverFactory('appsi_highs')
 
 Extra performance improvements can be made if you know exactly what
 changes will be made in your model. In the example above, only


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Related to #1030 

## Summary/Motivation:
I realized while staging for more changes that there are some inaccuracies in the docs (specifically, missing `highs`) and a lack of "how to use APPSI solvers in the legacy SolverFactory". 

## Changes proposed in this PR:
- Missing `highs` in future interface docs
- Small extra detail on APPSI page on how to use solvers in the legacy SolverFactory

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
