### PR TITLE
Pyomo.DoE: Allow user to define experiment cost to include in the objective

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -1246,11 +1246,14 @@ class DesignOfExperiments:
             )
             return m.determinant == det_perm
 
-        if self.extended_objective:
+        if self.experiment_cost_weight:
+            # If the experiment cost weight is provided, add it to the objective
+            # TODO: Add error checking that the experiment object computes an experiment cost
             model.extra_objective = pyo.Expression(
                 expr=self.experiment_cost_weight*model.scenario_blocks[0].experiment_cost
                 )
         else:
+            # If no experiment cost weight is provided, set it to 0
             model.extra_objective = 0
 
         if self.Cholesky_option and self.objective_option == ObjectiveLib.determinant:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
- For some MBDoE problems (especially dynamic with many degrees of freedom), the FIM-based objective can be "flat", i.e., there are many different experiment designs with very similar information content
- Thus, it is desirable for the user to be able to specify a second objective, e.g., experiment_cost, that can also be minimized

## Changes proposed in this PR:
- Extended interface to consider `experiment_cost`
- Allow user to specify weight for experiment cost component of the objective

## TODO Before Converting from Draft:
- [ ] Decide if this is a good approach, or should the experiment_cost be specified with suffixes?
- [ ] Do we want just one auxiliary objective (experiment cost) or to support many auxiliary objectives?
- [ ] Update documentation
- [ ] Create an example
- [ ] Add tests
- [ ] Add error checking
- [ ] Run black

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
