### PR TITLE
Preemptively fix 404 AMPL links

### DIFF
--- a/pyomo/contrib/gjh/getGJH.py
+++ b/pyomo/contrib/gjh/getGJH.py
@@ -18,7 +18,7 @@ from pyomo.common.download import FileDownloader
 logger = logging.getLogger('pyomo.common')
 
 # These URLs were retrieved from
-#     https://ampl.com/resources/hooking-your-solver-to-ampl/
+#     https://dev.ampl.com/more/reports.html#hooking-solvers-to-ampl
 # All 32-bit downloads are used - 64-bit is available only for Linux
 urlmap = {
     'linux': 'https://netlib.org/ampl/student/linux/gjh.gz',

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -128,8 +128,7 @@ class ExternalFunction(Component):
         **ASL function libraries** (:class:`AMPLExternalFunction` interface)
 
         Pyomo can also call functions compiled as part of an AMPL
-        External Function library (see the `User-defined functions
-        <https://www.ampl.com/REFS/HOOKING/#userdefinedfuncs>`_ section
+        External Function library (see the `Imported functions` section
         in the `Hooking your solver to AMPL
         <https://www.ampl.com/REFS/hooking3.pdf>`_ report).  Links to
         these functions are declared by creating an


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
The URL validation is going to fail this week due to some AMPL links being moved/disappearing. This updates the links and appropriate language.

## Changes proposed in this PR:
- Replace 404 links with working ones

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
