### PR TITLE
Pyomo.DoE: Handle edge case where the nominal value for a parameter is zero

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -214,6 +214,10 @@ class DesignOfExperiments:
         # (i.e., no model rebuilding for large models with sequential)
         self._built_scenarios = False
 
+        # Minimum step size for finite difference perturbations
+        # This is important if a parameter has a value of 0
+        self.min_step_size = 1e-6
+
     # Perform doe
     def run_doe(self, model=None, results_file=None):
         """
@@ -575,7 +579,7 @@ class DesignOfExperiments:
         # Loop over parameter values and grab correct columns for finite difference calculation
 
         for k, v in model.unknown_parameters.items():
-            curr_step = v * self.step
+            curr_step = max(v * self.step, self.min_step_size)
 
             if self.fd_formula == FiniteDifferenceStep.central:
                 col_1 = 2 * i
@@ -864,6 +868,8 @@ class DesignOfExperiments:
             param = m.parameter_scenarios[max(s1, s2)]
             param_loc = pyo.ComponentUID(param).find_component_on(m.scenario_blocks[0])
             param_val = m.scenario_blocks[0].unknown_parameters[param_loc]
+            
+            # How does this change if we enforce the minimum step size?
             param_diff = param_val * fd_step_mult * self.step
 
             if self.scale_nominal_param_value:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
- If a parameter has a nominal value of zero, we will get a divide by zero error when calling `compute_FIM`

## Changes proposed in this PR:
- Added a minimum step size for perturbation.

## TODO Before converting from draft
- [ ] Finish edits and debug
- [ ] Decide where to add check to throw error if we try to use parameter scaling and a parameter is zero
- [ ] Add tests to check this edge case include any new error message
- [ ] Update documenation (minor)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
