### PR TITLE
Type check all `exception` arguments in component `__call__` implementations

### DIFF
--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -19,7 +19,8 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr import GetItemExpression
-from pyomo.core.expr.numvalue import value, _type_check_exception_arg
+from pyomo.core.expr.expr_common import _type_check_exception_arg
+from pyomo.core.expr.numvalue import value
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -19,7 +19,7 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr import GetItemExpression
-from pyomo.core.expr.numvalue import value
+from pyomo.core.expr.numvalue import value, _type_check_exception_arg
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
@@ -155,8 +155,9 @@ class BooleanVarData(ComponentData, BooleanValue):
     def clear(self):
         self.value = None
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of this variable."""
+        exception = _type_check_exception_arg(self, exception)
         return self.value
 
     @property

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -31,7 +31,6 @@ from pyomo.core.expr.numvalue import (
     native_numeric_types,
     native_logical_types,
     native_types,
-    _type_check_exception_arg,
 )
 from pyomo.core.expr import (
     ExpressionType,
@@ -39,6 +38,7 @@ from pyomo.core.expr import (
     InequalityExpression,
     RangedExpression,
 )
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.template_expr import templatize_constraint
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -31,6 +31,7 @@ from pyomo.core.expr.numvalue import (
     native_numeric_types,
     native_logical_types,
     native_types,
+    _type_check_exception_arg,
 )
 from pyomo.core.expr import (
     ExpressionType,
@@ -168,8 +169,9 @@ class ConstraintData(ActiveComponentData):
         if expr is not None:
             self.set_value(expr)
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the body of this constraint."""
+        exception = _type_check_exception_arg(self, exception)
         body = self.to_bounded_expression()[1]
         if body.__class__ not in native_numeric_types:
             body = value(self.body, exception=exception)

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -30,7 +30,7 @@ import pyomo.core.expr.numeric_expr as numeric_expr
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
-from pyomo.core.expr.numvalue import as_numeric
+from pyomo.core.expr.numvalue import as_numeric, _type_check_exception_arg
 from pyomo.core.base.initializer import Initializer
 
 logger = logging.getLogger('pyomo.core')
@@ -50,8 +50,9 @@ class NamedExpressionData(numeric_expr.NumericValue):
     PRECEDENCE = 0
     ASSOCIATIVITY = EXPR.OperatorAssociativity.NON_ASSOCIATIVE
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of this expression."""
+        exception = _type_check_exception_arg(self, exception)
         (arg,) = self.args
         if arg.__class__ in native_types:
             # Note: native_types includes NoneType
@@ -396,8 +397,9 @@ class ScalarExpression(ExpressionData, Expression):
     # construction
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Return expression on this expression."""
+        exception = _type_check_exception_arg(self, exception)
         if self._constructed:
             return super().__call__(exception)
         raise ValueError(

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -26,11 +26,12 @@ from pyomo.common.numeric_types import (
 )
 
 import pyomo.core.expr as EXPR
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 import pyomo.core.expr.numeric_expr as numeric_expr
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
-from pyomo.core.expr.numvalue import as_numeric, _type_check_exception_arg
+from pyomo.core.expr.numvalue import as_numeric
 from pyomo.core.base.initializer import Initializer
 
 logger = logging.getLogger('pyomo.core')

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -20,11 +20,11 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
 from pyomo.core.expr.numvalue import (
     native_types,
     native_logical_types,
-    _type_check_exception_arg,
 )
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -21,7 +21,11 @@ from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
-from pyomo.core.expr.numvalue import native_types, native_logical_types
+from pyomo.core.expr.numvalue import (
+    native_types,
+    native_logical_types,
+    _type_check_exception_arg,
+)
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
@@ -84,8 +88,9 @@ class LogicalConstraintData(ActiveComponentData):
         if expr is not None:
             self.set_value(expr)
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the body of this logical constraint."""
+        exception = _type_check_exception_arg(self, exception)
         if self.body is None:
             return None
         return self.body(exception=exception)

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -22,10 +22,7 @@ from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
-from pyomo.core.expr.numvalue import (
-    native_types,
-    native_logical_types,
-)
+from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -15,8 +15,9 @@ import weakref
 
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NOTSET
 from pyomo.core.base.set_types import Any
-from pyomo.core.expr.numvalue import value
+from pyomo.core.expr.numvalue import value, _type_check_exception_arg
 from pyomo.core.expr.numeric_expr import LinearExpression
 from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.constraint import IndexedConstraint, ConstraintData
@@ -130,8 +131,9 @@ class _MatrixConstraintData(ConstraintData):
     # possible
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the body of this constraint."""
+        exception = _type_check_exception_arg(self, exception)
         comp = self.parent_component()
         index = self._index
         data = comp._A_data

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -17,7 +17,8 @@ from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.core.base.set_types import Any
-from pyomo.core.expr.numvalue import value, _type_check_exception_arg
+from pyomo.core.expr.expr_common import _type_check_exception_arg
+from pyomo.core.expr.numvalue import value
 from pyomo.core.expr.numeric_expr import LinearExpression
 from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.constraint import IndexedConstraint, ConstraintData

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -22,7 +22,8 @@ from pyomo.common.modeling import NOTSET
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.expr.numvalue import value, _type_check_exception_arg
+from pyomo.core.expr.expr_common import _type_check_exception_arg
+from pyomo.core.expr.numvalue import value
 from pyomo.core.expr.template_expr import templatize_rule
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -22,7 +22,7 @@ from pyomo.common.modeling import NOTSET
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.expr.numvalue import value
+from pyomo.core.expr.numvalue import value, _type_check_exception_arg
 from pyomo.core.expr.template_expr import templatize_rule
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
@@ -418,7 +418,8 @@ class ScalarObjective(ObjectiveData, Objective):
     # construction
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
+        exception = _type_check_exception_arg(self, exception)
         if self._constructed:
             if len(self._data) == 0:
                 raise ValueError(

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -23,7 +23,8 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.common.numeric_types import native_types, value as expr_value
 from pyomo.common.timing import ConstructionTimer
-from pyomo.core.expr.numvalue import NumericValue, _type_check_exception_arg
+from pyomo.core.expr.expr_common import _type_check_exception_arg
+from pyomo.core.expr.numvalue import NumericValue
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -201,12 +201,22 @@ class ParamData(ComponentData, NumericValue):
             self._value = old_value
             raise
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """
         Return the value of this object.
         """
+        if exception is NOTSET:
+            raise_exception = True
+        elif type(exception) is not bool:
+            raise ValueError(
+                "Param '%s' was called with a non-boolean argument for "
+                "'exception': %s"
+                % (self.name, exception)
+            )
+        else:
+            raise_exception = exception
         if self._value is Param.NoValue:
-            if exception:
+            if raise_exception:
                 raise ValueError(
                     "Error evaluating Param value (%s):\n\tThe Param value is "
                     "currently set to an invalid value.  This is\n\ttypically "
@@ -929,10 +939,21 @@ class ScalarParam(ParamData, Param):
     # up both the Component and Data base classes.
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """
         Return the value of this parameter.
         """
+        if exception is NOTSET:
+            raise_exception = True
+        elif type(exception) is not bool:
+            raise ValueError(
+                "Param '%s' was called with a non-boolean argument for "
+                "'exception': %s"
+                % (self.name, exception)
+            )
+        else:
+            raise_exception = exception
+
         if self._constructed:
             if not self._data:
                 if self._mutable:
@@ -943,8 +964,8 @@ class ScalarParam(ParamData, Param):
                     # Immutable Param defaults never get added to the
                     # _data dict
                     return self[None]
-            return super(ScalarParam, self).__call__(exception=exception)
-        if exception:
+            return super(ScalarParam, self).__call__(exception=raise_exception)
+        if raise_exception:
             raise ValueError(
                 "Evaluating the numeric value of parameter '%s' before\n\t"
                 "the Param has been constructed (there is currently no "
@@ -976,9 +997,20 @@ class SimpleParam(metaclass=RenamedClass):
 
 
 class IndexedParam(Param):
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the parameter"""
-        if exception:
+        if exception is NOTSET:
+            raise_exception = True
+        elif type(exception) is not bool:
+            raise ValueError(
+                "IndexedParam '%s' was called with a non-boolean argument for "
+                "'exception': %s"
+                % (self.name, exception)
+            )
+        else:
+            raise_exception = exception
+
+        if raise_exception:
             raise TypeError(
                 'Cannot compute the value of an indexed Param (%s)' % (self.name,)
             )

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -210,8 +210,7 @@ class ParamData(ComponentData, NumericValue):
         elif type(exception) is not bool:
             raise ValueError(
                 "Param '%s' was called with a non-boolean argument for "
-                "'exception': %s"
-                % (self.name, exception)
+                "'exception': %s" % (self.name, exception)
             )
         else:
             raise_exception = exception
@@ -948,8 +947,7 @@ class ScalarParam(ParamData, Param):
         elif type(exception) is not bool:
             raise ValueError(
                 "Param '%s' was called with a non-boolean argument for "
-                "'exception': %s"
-                % (self.name, exception)
+                "'exception': %s" % (self.name, exception)
             )
         else:
             raise_exception = exception
@@ -1004,8 +1002,7 @@ class IndexedParam(Param):
         elif type(exception) is not bool:
             raise ValueError(
                 "IndexedParam '%s' was called with a non-boolean argument for "
-                "'exception': %s"
-                % (self.name, exception)
+                "'exception': %s" % (self.name, exception)
             )
         else:
             raise_exception = exception

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -113,13 +113,13 @@ import sys
 
 from pyomo.common.dependencies import pint as pint_module, pint_available
 from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import (
     NumericValue,
     nonpyomo_leaf_types,
     value,
     native_types,
     native_numeric_types,
-    _type_check_exception_arg,
 )
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.visitor import ExpressionValueVisitor

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -119,6 +119,7 @@ from pyomo.core.expr.numvalue import (
     value,
     native_types,
     native_numeric_types,
+    _type_check_exception_arg
 )
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.visitor import ExpressionValueVisitor
@@ -384,7 +385,7 @@ class _PyomoUnit(NumericValue):
         else:
             return _str
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Unit is treated as a constant value, and this method always returns 1.0
 
         Returns
@@ -392,6 +393,7 @@ class _PyomoUnit(NumericValue):
         : float
            Returns 1.0
         """
+        _type_check_exception_arg(self, exception)
         return 1.0
 
     @property

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -119,7 +119,7 @@ from pyomo.core.expr.numvalue import (
     value,
     native_types,
     native_numeric_types,
-    _type_check_exception_arg
+    _type_check_exception_arg,
 )
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.visitor import ExpressionValueVisitor

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -29,6 +29,7 @@ from pyomo.core.expr.numvalue import (
     value,
     is_potentially_variable,
     native_numeric_types,
+    _type_check_exception_arg
 )
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
@@ -197,8 +198,9 @@ class VarData(ComponentData, NumericValue):
     def value(self, val):
         self.set_value(val)
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of this variable."""
+        exception = _type_check_exception_arg(self, exception)
         return self._value
 
     @property

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -24,12 +24,12 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr import GetItemExpression
 from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import (
     NumericValue,
     value,
     is_potentially_variable,
     native_numeric_types,
-    _type_check_exception_arg,
 )
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -29,7 +29,7 @@ from pyomo.core.expr.numvalue import (
     value,
     is_potentially_variable,
     native_numeric_types,
-    _type_check_exception_arg
+    _type_check_exception_arg,
 )
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index

--- a/pyomo/core/expr/base.py
+++ b/pyomo/core/expr/base.py
@@ -15,10 +15,7 @@ from pyomo.common.dependencies import attempt_import
 from pyomo.common.numeric_types import native_types
 from pyomo.common.modeling import NOTSET
 from pyomo.core.pyomoobject import PyomoObject
-from pyomo.core.expr.expr_common import (
-    OperatorAssociativity,
-    _type_check_exception_arg,
-)
+from pyomo.core.expr.expr_common import OperatorAssociativity, _type_check_exception_arg
 
 visitor, _ = attempt_import('pyomo.core.expr.visitor')
 

--- a/pyomo/core/expr/base.py
+++ b/pyomo/core/expr/base.py
@@ -13,8 +13,12 @@ import enum
 
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.numeric_types import native_types
+from pyomo.common.modeling import NOTSET
 from pyomo.core.pyomoobject import PyomoObject
-from pyomo.core.expr.expr_common import OperatorAssociativity
+from pyomo.core.expr.expr_common import (
+    OperatorAssociativity,
+    _type_check_exception_arg,
+)
 
 visitor, _ = attempt_import('pyomo.core.expr.visitor')
 
@@ -100,7 +104,7 @@ class ExpressionBase(PyomoObject):
             f"Derived expression ({self.__class__}) failed to implement args()"
         )
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Evaluate the value of the expression tree.
 
         Parameters
@@ -115,6 +119,7 @@ class ExpressionBase(PyomoObject):
         The value of the expression or :const:`None`.
 
         """
+        exception = _type_check_exception_arg(self, exception)
         return visitor.evaluate_expression(self, exception)
 
     def __str__(self):

--- a/pyomo/core/expr/boolean_value.py
+++ b/pyomo/core/expr/boolean_value.py
@@ -13,6 +13,8 @@ import sys
 import logging
 
 from pyomo.common.deprecation import deprecated
+from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.expr.expr_common import _and, _or, _equiv, _inv, _xor, _impl
 from pyomo.core.pyomoobject import PyomoObject
@@ -296,8 +298,9 @@ class BooleanConstant(BooleanValue):
     def __bool__(self):
         return self.value
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Return the constant value"""
+        exception = _type_check_exception_arg(self, exception)
         return self.value
 
     def pprint(self, ostream=None, verbose=False):

--- a/pyomo/core/expr/expr_common.py
+++ b/pyomo/core/expr/expr_common.py
@@ -110,6 +110,7 @@ class clone_counter(nullcontext):
         """A property that returns the clone count value."""
         return clone_counter._count
 
+
 def _type_check_exception_arg(cls, exception):
     if exception is NOTSET:
         return True

--- a/pyomo/core/expr/expr_common.py
+++ b/pyomo/core/expr/expr_common.py
@@ -13,6 +13,7 @@ from contextlib import nullcontext
 
 from pyomo.common import enums
 from pyomo.common.deprecation import deprecated
+from pyomo.common.modeling import NOTSET
 
 TO_STRING_VERBOSE = False
 
@@ -108,3 +109,14 @@ class clone_counter(nullcontext):
     def count(self):
         """A property that returns the clone count value."""
         return clone_counter._count
+
+def _type_check_exception_arg(cls, exception):
+    if exception is NOTSET:
+        return True
+    elif type(exception) is not bool:
+        raise ValueError(
+            f"{cls.ctype.__name__} '{cls.name}' was called with a non-bool "
+            f"argument for 'exception': {exception}"
+        )
+    else:
+        return exception

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -437,15 +437,3 @@ _pyomo_constant_types.add(NumericConstant)
 
 # We use as_numeric() so that the constant is also in the cache
 ZeroConstant = as_numeric(0)
-
-
-def _type_check_exception_arg(cls, exception):
-    if exception is NOTSET:
-        return True
-    elif type(exception) is not bool:
-        raise ValueError(
-            f"{cls.ctype.__name__} '{cls.name}' was called with a non-bool "
-            f"argument for 'exception': {exception}"
-        )
-    else:
-        return exception

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -17,6 +17,7 @@ from pyomo.common.deprecation import (
     deprecation_warning,
     relocated_module_attribute,
 )
+from pyomo.common.modeling import NOTSET
 from pyomo.core.expr.expr_common import ExpressionType
 from pyomo.core.expr.numeric_expr import NumericValue
 
@@ -436,3 +437,15 @@ _pyomo_constant_types.add(NumericConstant)
 
 # We use as_numeric() so that the constant is also in the cache
 ZeroConstant = as_numeric(0)
+
+
+def _type_check_exception_arg(cls, exception):
+    if exception is NOTSET:
+        return True
+    elif type(exception) is not bool:
+        raise ValueError(
+            f"{cls.ctype.__name__} '{cls.name}' was called with a non-bool "
+            f"argument for 'exception': {exception}"
+        )
+    else:
+        return exception

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -18,7 +18,7 @@ from pyomo.common.deprecation import (
     relocated_module_attribute,
 )
 from pyomo.common.modeling import NOTSET
-from pyomo.core.expr.expr_common import ExpressionType
+from pyomo.core.expr.expr_common import ExpressionType, _type_check_exception_arg
 from pyomo.core.expr.numeric_expr import NumericValue
 
 # TODO: update Pyomo to import these objects from common.numeric_types
@@ -114,7 +114,8 @@ class NonNumericValue(PyomoObject):
     def __repr__(self):
         return repr(self.value)
 
-    def __call__(self, exception=None):
+    def __call__(self, exception=NOTSET):
+        exception = _type_check_exception_arg(self, exception)
         return self.value
 
     def is_constant(self):
@@ -423,8 +424,9 @@ class NumericConstant(NumericValue):
     def __str__(self):
         return str(self.value)
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Return the constant value"""
+        exception = _type_check_exception_arg(self, exception)
         return self.value
 
     def pprint(self, ostream=None, verbose=False):

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -229,6 +229,11 @@ class GetAttrExpression(ExpressionBase):
         #
         # TODO: deprecate (then remove) evaluating expressions by
         # "calling" them.
+        #
+        # [ESJ 3/25/25]: Note that since this always calls the ExpressionBase
+        # implementation of __call__ if 'exception' is specified, we need not
+        # check the type of the exception arg here--it will get checked in the
+        # base class.
         try:
             if not args:
                 if not kwargs:

--- a/pyomo/core/kernel/conic.py
+++ b/pyomo/core/kernel/conic.py
@@ -10,8 +10,10 @@
 #  ___________________________________________________________________________
 """Various conic constraint implementations."""
 
+from pyomo.common.modeling import NOTSET
 from pyomo.core.expr.numvalue import is_numeric_data
 from pyomo.core.expr import value, exp
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.kernel.block import block
 from pyomo.core.kernel.variable import IVariable, variable, variable_tuple
 from pyomo.core.kernel.constraint import (
@@ -133,7 +135,8 @@ class _ConicBase(IConstraint):
     # to avoid building the body expression, if possible
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
+        exception = _type_check_exception_arg(self, exception)
         try:
             # we wrap the result with value(...) as the
             # alpha term used by some of the constraints

--- a/pyomo/core/kernel/constraint.py
+++ b/pyomo/core/kernel/constraint.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+from pyomo.common.modeling import NOTSET
 from pyomo.core.expr.numvalue import (
     ZeroConstant,
     as_numeric,
@@ -16,7 +17,7 @@ from pyomo.core.expr.numvalue import (
     is_numeric_data,
     value,
 )
-from pyomo.core.expr.expr_common import ExpressionType
+from pyomo.core.expr.expr_common import ExpressionType, _type_check_exception_arg
 from pyomo.core.expr.relational_expr import (
     EqualityExpression,
     RangedExpression,
@@ -74,8 +75,9 @@ class IConstraint(ICategorizedObject):
     # Interface
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the body of this constraint."""
+        exception = _type_check_exception_arg(self, exception)
         if exception and (self.body is None):
             raise ValueError("constraint body is None")
         elif self.body is None:
@@ -798,7 +800,8 @@ class linear_constraint(_MutableBoundsConstraintMixin, IConstraint):
     # to avoid building the body expression
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
+        exception = _type_check_exception_arg(self, exception)
         try:
             return sum(
                 value(c, exception=exception) * v(exception=exception)

--- a/pyomo/core/kernel/expression.py
+++ b/pyomo/core/kernel/expression.py
@@ -12,6 +12,7 @@
 from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import NOTSET
 import pyomo.core.expr as EXPR
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.kernel.base import ICategorizedObject, _abstract_readwrite_property
 from pyomo.core.kernel.container_utils import define_simple_containers
 from pyomo.core.expr.numvalue import (
@@ -46,7 +47,7 @@ class IIdentityExpression(NumericValue):
     # Implement the NumericValue abstract methods
     #
 
-    def __call__(self, exception=False):
+    def __call__(self, exception=NOTSET):
         """Compute the value of this expression.
 
         Args:
@@ -61,6 +62,7 @@ class IIdentityExpression(NumericValue):
         Returns:
             numeric value or None
         """
+        exception = _type_check_exception_arg(self, exception)
         return value(self._expr, exception=exception)
 
     def is_fixed(self):

--- a/pyomo/core/kernel/matrix_constraint.py
+++ b/pyomo/core/kernel/matrix_constraint.py
@@ -15,6 +15,8 @@ from pyomo.common.dependencies import (
     scipy,
     scipy_available as has_scipy,
 )
+from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import NumericValue, value
 from pyomo.core.kernel.constraint import IConstraint, constraint_tuple
 
@@ -73,9 +75,10 @@ class _MatrixConstraintData(IConstraint):
     # to avoid building the body expression
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         # don't mask an exception in the terms
         # property method
+        exception = _type_check_exception_arg(self, exception)
         if self.parent.x is None:
             raise ValueError("No variable order has been assigned")
         try:
@@ -441,8 +444,9 @@ class matrix_constraint(constraint_tuple):
         assert not equality
         self._equality.fill(False)
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Compute the value of the body of this constraint"""
+        exception = _type_check_exception_arg(self, exception)
         if self.x is None:
             raise ValueError("No variable order has been assigned")
         values = numpy.array([v.value for v in self.x], dtype=float)

--- a/pyomo/core/kernel/parameter.py
+++ b/pyomo/core/kernel/parameter.py
@@ -9,6 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import is_numeric_data, NumericValue
 from pyomo.core.kernel.base import ICategorizedObject
 from pyomo.core.kernel.container_utils import define_simple_containers
@@ -19,7 +21,7 @@ class IParameter(ICategorizedObject, NumericValue):
 
     __slots__ = ()
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Computes the numeric value of this object."""
         raise NotImplementedError  # pragma:nocover
 
@@ -77,8 +79,9 @@ class parameter(IParameter):
     # Implement the IParameter abstract methods
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Computes the numeric value of this object."""
+        exception = _type_check_exception_arg(self, exception)
         return self.value
 
     #
@@ -116,7 +119,8 @@ class functional_value(IParameter):
     # Implement the IParameter abstract methods
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
+        exception = _type_check_exception_arg(self, exception)
         if self._fn is None:
             return None
         try:

--- a/pyomo/core/kernel/variable.py
+++ b/pyomo/core/kernel/variable.py
@@ -8,8 +8,9 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.core.staleflag import StaleFlagManager
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import NumericValue, is_numeric_data, value
 from pyomo.core.kernel.base import ICategorizedObject, _abstract_readwrite_property
 from pyomo.core.kernel.container_utils import define_simple_containers
@@ -123,13 +124,13 @@ class IVariable(ICategorizedObject, NumericValue):
     def ub(self, val):
         self.upper = val
 
-    def fix(self, value=NoArgumentGiven):
+    def fix(self, value=NOTSET):
         """
         Fix the variable. Sets the fixed indicator to
         :const:`True`. An optional value argument will
         update the variable's value before fixing.
         """
-        if value is not NoArgumentGiven:
+        if value is not NOTSET:
             self.value = value
 
         self.fixed = True
@@ -270,8 +271,9 @@ class IVariable(ICategorizedObject, NumericValue):
             return 0
         return 1
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """Return the value of this variable."""
+        exception = _type_check_exception_arg(self, exception)
         if exception and (self.value is None):
             raise ValueError("value is None")
         return self.value

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1632,21 +1632,21 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         with self.assertRaisesRegex(
             ValueError,
             r"Param 'p' was called with a non-boolean argument for 'exception': "
-            r"p \+ 2"
+            r"p \+ 2",
         ):
             m.p(m.p + 2)
 
         with self.assertRaisesRegex(
             ValueError,
             r"Param 'indexed\[1\]' was called with a non-boolean argument for "
-            r"'exception': 3.2"
+            r"'exception': 3.2",
         ):
             m.indexed[1](3.2)
 
         with self.assertRaisesRegex(
             ValueError,
             r"IndexedParam 'indexed' was called with a non-boolean argument for "
-            r"'exception': hi"
+            r"'exception': hi",
         ):
             m.indexed('hi')
 

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1631,24 +1631,17 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         m.indexed = Param([1, 2], initialize={1: 3, 2: 4}, mutable=True)
         with self.assertRaisesRegex(
             ValueError,
-            r"Param 'p' was called with a non-boolean argument for 'exception': "
+            r"Param 'p' was called with a non-bool argument for 'exception': "
             r"p \+ 2",
         ):
             m.p(m.p + 2)
 
         with self.assertRaisesRegex(
             ValueError,
-            r"Param 'indexed\[1\]' was called with a non-boolean argument for "
+            r"Param 'indexed\[1\]' was called with a non-bool argument for "
             r"'exception': 3.2",
         ):
             m.indexed[1](3.2)
-
-        with self.assertRaisesRegex(
-            ValueError,
-            r"IndexedParam 'indexed' was called with a non-boolean argument for "
-            r"'exception': hi",
-        ):
-            m.indexed('hi')
 
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1625,6 +1625,31 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             "     bb :     4\n",
         )
 
+    def test_invalid_exception_argument(self):
+        m = ConcreteModel()
+        m.p = Param(initialize=7, mutable=True)
+        m.indexed = Param([1, 2], initialize={1: 3, 2: 4}, mutable=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Param 'p' was called with a non-boolean argument for 'exception': "
+            r"p \+ 2"
+        ):
+            m.p(m.p + 2)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Param 'indexed\[1\]' was called with a non-boolean argument for "
+            r"'exception': 3.2"
+        ):
+            m.indexed[1](3.2)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"IndexedParam 'indexed' was called with a non-boolean argument for "
+            r"'exception': hi"
+        ):
+            m.indexed('hi')
+
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):
     def testMethod(self):

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -16,6 +16,8 @@ from weakref import ref as weakref_ref
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.numeric_types import value
+from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.expr_common import _type_check_exception_arg
 from pyomo.core.expr.numvalue import is_fixed, ZeroConstant
 from pyomo.core.base.set_types import Any
 from pyomo.core.base import SortComponents, Var
@@ -468,10 +470,11 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
     # possible
     #
 
-    def __call__(self, exception=True):
+    def __call__(self, exception=NOTSET):
         """
         Compute the value of the body of this constraint.
         """
+        exception = _type_check_exception_arg(self, exception)
         comp = self.parent_component()
         index = self.index()
         prows = comp._prows


### PR DESCRIPTION
## Fixes #2922

## Summary/Motivation:

Params and most other numeric- and Boolean-valued components are callable (to get the value), but they did not previously check that the `exception` argument was in fact a `bool`. This meant it was easy to make a typo missing a `*` character and silently rendering part of the expression constant (with the value of a Param, for example). This adds checks in the implementations of `__call__` that `exception` is a `bool`. I still think we should discuss deprecating call to evaluate entirely, but this is a much less invasive change that will raise an error for many typos that would otherwise create silently wrong models.

## Changes proposed in this PR:
- Checks type of `exception` argument in implementations of `__call__`
- Adds a test for the common Param-related typo

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
