### PR TITLE
`calc_variable_from_constraint`: guard against expression overflow 

### DIFF
--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -459,3 +459,13 @@ class Test_calc_var(unittest.TestCase):
             calculate_variable_from_constraint(
                 m.x, m.c, diff_mode=differentiate.Modes.sympy
             )
+
+    def test_linea_search_overflow(self):
+        # This tests the example from #3540
+        m = ConcreteModel()
+        m.x = Var(initialize=5)
+        m.y = Var(initialize=1)
+        m.con = Constraint(expr=m.y == 10 ** (-m.x))
+
+        calculate_variable_from_constraint(m.x, m.con)
+        self.assertAlmostEqual(value(m.x), 0)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3540 .

## Summary/Motivation:
This adds additional guards to `calculate_variable_from_constraint()` to catch `OverflowError` exceptions when evaluating the constraint during the initial linear test and during the line search.

## Changes proposed in this PR:
- Guard against `OverflowError` exceptions during function evaluations
- Add test (from #3540)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
