### PR TITLE
Correct URLs to use https

### DIFF
--- a/doc/OnlineDocs/explanation/solvers/gdpopt.rst
+++ b/doc/OnlineDocs/explanation/solvers/gdpopt.rst
@@ -20,7 +20,7 @@ Three algorithms are available in GDPopt:
 
 Usage and implementation details for GDPopt can be found in the PSE 2018 paper
 (`Chen et al., 2018`_), or via its
-`preprint <http://egon.cheme.cmu.edu/Papers/Chen_Pyomo_GDP_PSE2018.pdf>`_.
+`preprint <https://egon.cheme.cmu.edu/Papers/Chen_Pyomo_GDP_PSE2018.pdf>`_.
 
 Credit for prototyping and development can be found in the ``GDPopt`` class documentation, below.
 

--- a/doc/OnlineDocs/explanation/solvers/mindtpy.rst
+++ b/doc/OnlineDocs/explanation/solvers/mindtpy.rst
@@ -17,10 +17,10 @@ The following algorithms are currently available in MindtPy:
 
 Usage and early implementation details for MindtPy can be found in the PSE 2018 paper Bernal et al.,
 (`ref <https://doi.org/10.1016/B978-0-444-64241-7.50144-0>`_,
-`preprint <http://egon.cheme.cmu.edu/Papers/Bernal_Chen_MindtPy_PSE2018Paper.pdf>`_).
+`preprint <https://egon.cheme.cmu.edu/Papers/Bernal_Chen_MindtPy_PSE2018Paper.pdf>`_).
 This solver implementation has been developed by `David Bernal <https://github.com/bernalde>`_
 and `Zedong Peng <https://github.com/ZedongPeng>`_ as part of research efforts at the `Bernal Research Group 
-<https://bernalde.github.io/>`_ and the `Grossmann Research Group <http://egon.cheme.cmu.edu/>`_
+<https://bernalde.github.io/>`_ and the `Grossmann Research Group <https://egon.cheme.cmu.edu/>`_
 at Purdue University and Carnegie Mellon University.
 
 .. _Duran & Grossmann, 1986: https://dx.doi.org/10.1007/BF02592064

--- a/examples/gdp/small_lit/ex1_Lee.py
+++ b/examples/gdp/small_lit/ex1_Lee.py
@@ -13,7 +13,7 @@
 Taken from Example 1 of the paper "New Algorithms for Nonlinear Generalized Disjunctive Programming" by Lee and Grossmann
 
 This GDP problem has one disjunction containing three terms, and exactly one of them must be true. The literature can be found here:
-http://egon.cheme.cmu.edu/Papers/LeeNewAlgo.pdf
+https://egon.cheme.cmu.edu/Papers/LeeNewAlgo.pdf
 
 """
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:
It looks like `egon.cheme.cmu.edu` now uses https, so our URL checker doesn't like the old URLs (even though they technically still work).

## Changes proposed in this PR:
- Update `egon.cheme.cmu.edu` urls to use `https`
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
