### PR TITLE
Standardize the usage of pyomo.environ imports

### DIFF
--- a/doc/OnlineDocs/explanation/solvers/persistent.rst
+++ b/doc/OnlineDocs/explanation/solvers/persistent.rst
@@ -24,16 +24,16 @@ Using Persistent Solvers
 The first step in using a persistent solver is to create a Pyomo model
 as usual.
 
->>> import pyomo.environ as pe
->>> m = pe.ConcreteModel()
->>> m.x = pe.Var()
->>> m.y = pe.Var()
->>> m.obj = pe.Objective(expr=m.x**2 + m.y**2)
->>> m.c = pe.Constraint(expr=m.y >= -2*m.x + 5)
+>>> import pyomo.environ as pyo
+>>> m = pyo.ConcreteModel()
+>>> m.x = pyo.Var()
+>>> m.y = pyo.Var()
+>>> m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+>>> m.c = pyo.Constraint(expr=m.y >= -2*m.x + 5)
 
 You can create an instance of a persistent solver through the SolverFactory.
 
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 
 This returns an instance of :py:class:`GurobiPersistent`. Now we need
 to tell the solver about our model.
@@ -48,7 +48,7 @@ variables and constraints. We can now solve the model.
 We can also add or remove variables, constraints, blocks, and
 objectives. For example,
 
->>> m.c2 = pe.Constraint(expr=m.y >= m.x)  # doctest: +SKIP
+>>> m.c2 = pyo.Constraint(expr=m.y >= m.x)  # doctest: +SKIP
 >>> opt.add_constraint(m.c2)  # doctest: +SKIP
 
 This tells the solver to add one new constraint but otherwise leave
@@ -69,29 +69,29 @@ code will run without error, but the solver will have an extra
 constraint. The solver will have both y >= -2*x + 5 and y <= x, which
 is not what was intended!
 
->>> m = pe.ConcreteModel()  # doctest: +SKIP
->>> m.x = pe.Var()  # doctest: +SKIP
->>> m.y = pe.Var()  # doctest: +SKIP
->>> m.c = pe.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> m = pyo.ConcreteModel()  # doctest: +SKIP
+>>> m.x = pyo.Var()  # doctest: +SKIP
+>>> m.y = pyo.Var()  # doctest: +SKIP
+>>> m.c = pyo.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 >>> opt.set_instance(m)  # doctest: +SKIP
 >>> # WRONG:
 >>> del m.c  # doctest: +SKIP
->>> m.c = pe.Constraint(expr=m.y <= m.x)  # doctest: +SKIP
+>>> m.c = pyo.Constraint(expr=m.y <= m.x)  # doctest: +SKIP
 >>> opt.add_constraint(m.c)  # doctest: +SKIP
 
 The correct way to do this is:
 
->>> m = pe.ConcreteModel()  # doctest: +SKIP
->>> m.x = pe.Var()  # doctest: +SKIP
->>> m.y = pe.Var()  # doctest: +SKIP
->>> m.c = pe.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> m = pyo.ConcreteModel()  # doctest: +SKIP
+>>> m.x = pyo.Var()  # doctest: +SKIP
+>>> m.y = pyo.Var()  # doctest: +SKIP
+>>> m.c = pyo.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 >>> opt.set_instance(m)  # doctest: +SKIP
 >>> # Correct:
 >>> opt.remove_constraint(m.c)  # doctest: +SKIP
 >>> del m.c  # doctest: +SKIP
->>> m.c = pe.Constraint(expr=m.y <= m.x)  # doctest: +SKIP
+>>> m.c = pyo.Constraint(expr=m.y <= m.x)  # doctest: +SKIP
 >>> opt.add_constraint(m.c)  # doctest: +SKIP
 
 .. warning:: Components removed from a pyomo model must be removed
@@ -100,14 +100,14 @@ The correct way to do this is:
 Additionally, unexpected behavior may result if a component is
 modified before being removed.
 
->>> m = pe.ConcreteModel()  # doctest: +SKIP
->>> m.b = pe.Block()  # doctest: +SKIP
->>> m.b.x = pe.Var()  # doctest: +SKIP
->>> m.b.y = pe.Var()  # doctest: +SKIP
->>> m.b.c = pe.Constraint(expr=m.b.y >= -2*m.b.x + 5)  # doctest: +SKIP
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> m = pyo.ConcreteModel()  # doctest: +SKIP
+>>> m.b = pyo.Block()  # doctest: +SKIP
+>>> m.b.x = pyo.Var()  # doctest: +SKIP
+>>> m.b.y = pyo.Var()  # doctest: +SKIP
+>>> m.b.c = pyo.Constraint(expr=m.b.y >= -2*m.b.x + 5)  # doctest: +SKIP
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 >>> opt.set_instance(m)  # doctest: +SKIP
->>> m.b.c2 = pe.Constraint(expr=m.b.y <= m.b.x)  # doctest: +SKIP
+>>> m.b.c2 = pyo.Constraint(expr=m.b.y <= m.b.x)  # doctest: +SKIP
 >>> # ERROR: The constraint referenced by m.b.c2 does not
 >>> # exist in the solver model.
 >>> opt.remove_block(m.b)  # doctest: +SKIP 
@@ -117,12 +117,12 @@ the solver instance, modify it with Pyomo, and then add it back to the
 solver instance. The only exception is with variables. Variables may
 be modified and then updated with with solver:
 
->>> m = pe.ConcreteModel()  # doctest: +SKIP
->>> m.x = pe.Var()  # doctest: +SKIP
->>> m.y = pe.Var()  # doctest: +SKIP
->>> m.obj = pe.Objective(expr=m.x**2 + m.y**2)  # doctest: +SKIP
->>> m.c = pe.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> m = pyo.ConcreteModel()  # doctest: +SKIP
+>>> m.x = pyo.Var()  # doctest: +SKIP
+>>> m.y = pyo.Var()  # doctest: +SKIP
+>>> m.obj = pyo.Objective(expr=m.x**2 + m.y**2)  # doctest: +SKIP
+>>> m.c = pyo.Constraint(expr=m.y >= -2*m.x + 5)  # doctest: +SKIP
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 >>> opt.set_instance(m)  # doctest: +SKIP
 >>> m.x.setlb(1.0)  # doctest: +SKIP
 >>> opt.update_var(m.x)  # doctest: +SKIP
@@ -160,13 +160,13 @@ Persistent Solver Performance
 In order to get the best performance out of the persistent solvers, use the
 "save_results" flag:
 
->>> import pyomo.environ as pe
->>> m = pe.ConcreteModel()
->>> m.x = pe.Var()
->>> m.y = pe.Var()
->>> m.obj = pe.Objective(expr=m.x**2 + m.y**2)
->>> m.c = pe.Constraint(expr=m.y >= -2*m.x + 5)
->>> opt = pe.SolverFactory('gurobi_persistent')  # doctest: +SKIP
+>>> import pyomo.environ as pyo
+>>> m = pyo.ConcreteModel()
+>>> m.x = pyo.Var()
+>>> m.y = pyo.Var()
+>>> m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+>>> m.c = pyo.Constraint(expr=m.y >= -2*m.x + 5)
+>>> opt = pyo.SolverFactory('gurobi_persistent')  # doctest: +SKIP
 >>> opt.set_instance(m)  # doctest: +SKIP
 >>> results = opt.solve(save_results=False)  # doctest: +SKIP
 

--- a/doc/OnlineDocs/explanation/solvers/pynumero/tutorial.nlp_interfaces.rst
+++ b/doc/OnlineDocs/explanation/solvers/pynumero/tutorial.nlp_interfaces.rst
@@ -10,7 +10,7 @@ Relevant imports
 .. doctest::
    :skipif: not numpy_available or not scipy_available or not asl_available
 
-   >>> import pyomo.environ as pe
+   >>> import pyomo.environ as pyo
    >>> from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
    >>> import numpy as np
 
@@ -19,12 +19,12 @@ Create a Pyomo model
 .. doctest::
    :skipif: not numpy_available or not scipy_available or not asl_available
 
-   >>> m = pe.ConcreteModel()
-   >>> m.x = pe.Var(bounds=(-5, None))
-   >>> m.y = pe.Var(initialize=2.5)
-   >>> m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-   >>> m.c1 = pe.Constraint(expr=m.y == (m.x - 1)**2)
-   >>> m.c2 = pe.Constraint(expr=m.y >= pe.exp(m.x))
+   >>> m = pyo.ConcreteModel()
+   >>> m.x = pyo.Var(bounds=(-5, None))
+   >>> m.y = pyo.Var(initialize=2.5)
+   >>> m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+   >>> m.c1 = pyo.Constraint(expr=m.y == (m.x - 1)**2)
+   >>> m.c2 = pyo.Constraint(expr=m.y >= pyo.exp(m.x))
 
 Create a :py:class:`pyomo.contrib.pynumero.interfaces.pyomo_nlp.PyomoNLP` instance
 

--- a/pyomo/contrib/alternative_solutions/shifted_lp.py
+++ b/pyomo/contrib/alternative_solutions/shifted_lp.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common.collections import ComponentMap
 from pyomo.gdp.util import clone_without_expression_components
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
@@ -115,11 +115,11 @@ def get_shifted_linear_model(model, block=None):
     shifted_lp = aos_utils._add_aos_block(block, name="_shifted_lp")
 
     # Replace original variables with shifted lower and upper variables
-    shifted_lp.var_lower = pe.Var(
-        new_vars.keys(), domain=pe.NonNegativeReals, bounds=var_range
+    shifted_lp.var_lower = pyo.Var(
+        new_vars.keys(), domain=pyo.NonNegativeReals, bounds=var_range
     )
-    shifted_lp.var_upper = pe.Var(
-        new_vars.keys(), domain=pe.NonNegativeReals, bounds=var_range
+    shifted_lp.var_upper = pyo.Var(
+        new_vars.keys(), domain=pyo.NonNegativeReals, bounds=var_range
     )
 
     # Link the shifted lower and upper variables
@@ -128,7 +128,7 @@ def get_shifted_linear_model(model, block=None):
             m.var_lower[var_index] + m.var_upper[var_index] == m.var_upper[var_index].ub
         )
 
-    shifted_lp.link_vars = pe.Constraint(new_vars.keys(), rule=link_vars_rule)
+    shifted_lp.link_vars = pyo.Constraint(new_vars.keys(), rule=link_vars_rule)
 
     # Map the lower and upper variables to the original variables and their
     # lower bounds. This will be used to substitute x with var_lower + x.lb.
@@ -149,7 +149,7 @@ def get_shifted_linear_model(model, block=None):
     c_fix_zeros = clone_without_expression_components(
         active_objective.expr, substitute=var_zeros
     )
-    shifted_lp.objective = pe.Objective(
+    shifted_lp.objective = pyo.Objective(
         expr=c_var_lower - c_fix_zeros + c_fix_lower,
         name=active_objective.name + "_shifted",
         sense=active_objective.sense,
@@ -161,7 +161,7 @@ def get_shifted_linear_model(model, block=None):
     constraint_map = ComponentMap()
     constraint_type = {}
     slacks = []
-    for constraint in model.component_data_objects(pe.Constraint, active=True):
+    for constraint in model.component_data_objects(pyo.Constraint, active=True):
         if constraint.parent_block() == shifted_lp:
             continue
         if constraint.equality:
@@ -189,10 +189,10 @@ def get_shifted_linear_model(model, block=None):
                 constraint_map[constraint] = constraint_name
                 constraint_type[constraint_name] = 1
                 slacks.append(constraint_name)
-    shifted_lp.constraint_index = pe.Set(initialize=new_constraints.keys())
-    shifted_lp.slack_index = pe.Set(initialize=slacks)
-    shifted_lp.slack_vars = pe.Var(shifted_lp.slack_index, domain=pe.NonNegativeReals)
-    shifted_lp.constraints = pe.Constraint(shifted_lp.constraint_index)
+    shifted_lp.constraint_index = pyo.Set(initialize=new_constraints.keys())
+    shifted_lp.slack_index = pyo.Set(initialize=slacks)
+    shifted_lp.slack_vars = pyo.Var(shifted_lp.slack_index, domain=pyo.NonNegativeReals)
+    shifted_lp.constraints = pyo.Constraint(shifted_lp.constraint_index)
 
     for constraint_name, constraint in new_constraints.items():
         # The c_fix_zeros calculation is used to find any constant terms that

--- a/pyomo/contrib/alternative_solutions/solnpool.py
+++ b/pyomo/contrib/alternative_solutions/solnpool.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import ApplicationError
 
-import pyomo.environ as pyo
 from pyomo.contrib import appsi
 import pyomo.contrib.alternative_solutions.aos_utils as aos_utils
 from pyomo.contrib.alternative_solutions import Solution

--- a/pyomo/contrib/alternative_solutions/solnpool.py
+++ b/pyomo/contrib/alternative_solutions/solnpool.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import ApplicationError
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib import appsi
 import pyomo.contrib.alternative_solutions.aos_utils as aos_utils
 from pyomo.contrib.alternative_solutions import Solution

--- a/pyomo/contrib/alternative_solutions/solution.py
+++ b/pyomo/contrib/alternative_solutions/solution.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 import json
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.contrib.alternative_solutions import aos_utils
 
@@ -66,11 +66,11 @@ class Solution:
             if is_fixed:
                 self.fixed_vars.add(var)
             if include_fixed or not is_fixed:
-                self.variables[var] = pe.value(var)
+                self.variables[var] = pyo.value(var)
 
         if objective is None:
             objective = aos_utils.get_active_objective(model)
-        self.objective = (objective, pe.value(objective))
+        self.objective = (objective, pyo.value(objective))
 
     @property
     def objective_value(self):

--- a/pyomo/contrib/alternative_solutions/tests/test_aos_utils.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_aos_utils.py
@@ -13,7 +13,7 @@ from pyomo.common import unittest
 
 from pyomo.common.dependencies import numpy as numpy, numpy_available
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 from pyomo.common.collections import ComponentSet
 
@@ -24,15 +24,15 @@ class TestAOSUtilsUnit(unittest.TestCase):
 
     def get_multiple_objective_model(self):
         """Create a simple model with three objectives."""
-        m = pe.ConcreteModel()
-        m.b1 = pe.Block()
-        m.b2 = pe.Block()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.b1.o = pe.Objective(expr=m.x)
-        m.b2.o = pe.Objective([0, 1])
-        m.b2.o[0] = pe.Objective(expr=m.y)
-        m.b2.o[1] = pe.Objective(expr=m.x + m.y)
+        m = pyo.ConcreteModel()
+        m.b1 = pyo.Block()
+        m.b2 = pyo.Block()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.b1.o = pyo.Objective(expr=m.x)
+        m.b2.o = pyo.Objective([0, 1])
+        m.b2.o[0] = pyo.Objective(expr=m.y)
+        m.b2.o[1] = pyo.Objective(expr=m.x + m.y)
         return m
 
     def test_multiple_objectives(self):
@@ -71,14 +71,14 @@ class TestAOSUtilsUnit(unittest.TestCase):
         block_name = "test_block"
         b = au._add_aos_block(m, block_name)
         self.assertEqual(b.name, block_name)
-        self.assertEqual(b.ctype, pe.Block)
+        self.assertEqual(b.ctype, pyo.Block)
 
-    def get_simple_model(self, sense=pe.minimize):
+    def get_simple_model(self, sense=pyo.minimize):
         """Create a simple 2d linear program with an objective."""
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.o = pe.Objective(expr=m.x + m.y, sense=sense)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.o = pyo.Objective(expr=m.x + m.y, sense=sense)
         return m
 
     def test_no_obj_constraint(self):
@@ -125,7 +125,7 @@ class TestAOSUtilsUnit(unittest.TestCase):
         Ensure that the correct relative and absolute objective constraints are
         added.
         """
-        m = self.get_simple_model(sense=pe.maximize)
+        m = self.get_simple_model(sense=pyo.maximize)
         cons = au._add_objective_constraint(m, m.o, -1, 0.3, 1)
         self.assertEqual(len(cons), 2)
         self.assertEqual(m.find_component("optimality_tol_rel"), cons[0])
@@ -140,7 +140,7 @@ class TestAOSUtilsUnit(unittest.TestCase):
         Ensure that the correct relative and absolute objective constraints are
         added.
         """
-        m = self.get_simple_model(sense=pe.maximize)
+        m = self.get_simple_model(sense=pyo.maximize)
         cons = au._add_objective_constraint(m, m.o, 20, 0.5, 11)
         self.assertEqual(len(cons), 2)
         self.assertEqual(m.find_component("optimality_tol_rel"), cons[0])
@@ -168,27 +168,27 @@ class TestAOSUtilsUnit(unittest.TestCase):
 
         indices = [0, 1, 2, 3]
 
-        m = pe.ConcreteModel()
+        m = pyo.ConcreteModel()
 
-        m.b1 = pe.Block()
-        m.b2 = pe.Block()
-        m.b1.sb1 = pe.Block()
-        m.b2.sb2 = pe.Block()
+        m.b1 = pyo.Block()
+        m.b2 = pyo.Block()
+        m.b1.sb1 = pyo.Block()
+        m.b2.sb2 = pyo.Block()
 
-        m.x = pe.Var(domain=pe.Reals)
-        m.b1.y = pe.Var(domain=pe.Binary)
-        m.b2.z = pe.Var(domain=pe.Integers)
+        m.x = pyo.Var(domain=pyo.Reals)
+        m.b1.y = pyo.Var(domain=pyo.Binary)
+        m.b2.z = pyo.Var(domain=pyo.Integers)
 
-        m.x_f = pe.Var(domain=pe.Reals)
-        m.b1.y_f = pe.Var(domain=pe.Binary)
-        m.b2.z_f = pe.Var(domain=pe.Integers)
+        m.x_f = pyo.Var(domain=pyo.Reals)
+        m.b1.y_f = pyo.Var(domain=pyo.Binary)
+        m.b2.z_f = pyo.Var(domain=pyo.Integers)
         m.x_f.fix(0)
         m.b1.y_f.fix(0)
         m.b2.z_f.fix(0)
 
-        m.b1.sb1.x_l = pe.Var(indices, domain=pe.Reals)
-        m.b1.sb1.y_l = pe.Var(indices, domain=pe.Binary)
-        m.b2.sb2.z_l = pe.Var(indices, domain=pe.Integers)
+        m.b1.sb1.x_l = pyo.Var(indices, domain=pyo.Reals)
+        m.b1.sb1.y_l = pyo.Var(indices, domain=pyo.Binary)
+        m.b2.sb2.z_l = pyo.Var(indices, domain=pyo.Integers)
 
         m.b1.sb1.x_l[3].fix(0)
         m.b1.sb1.y_l[3].fix(0)
@@ -201,10 +201,10 @@ class TestAOSUtilsUnit(unittest.TestCase):
             + [m.b2.sb2.z_l[i] for i in indices]
         )
 
-        m.con = pe.Constraint(expr=sum(v for v in vars_minus_x) <= 1)
-        m.b1.con = pe.Constraint(expr=m.b1.y <= 1)
-        m.b1.sb1.con = pe.Constraint(expr=m.b1.sb1.y_l[0] <= 1)
-        m.obj = pe.Objective(expr=m.x)
+        m.con = pyo.Constraint(expr=sum(v for v in vars_minus_x) <= 1)
+        m.b1.con = pyo.Constraint(expr=m.b1.y <= 1)
+        m.b1.sb1.con = pyo.Constraint(expr=m.b1.sb1.y_l[0] <= 1)
+        m.obj = pyo.Objective(expr=m.x)
 
         m.all_vars = ComponentSet([m.x] + vars_minus_x)
         m.unfixed_vars = ComponentSet([var for var in m.all_vars if not var.is_fixed()])

--- a/pyomo/contrib/alternative_solutions/tests/test_balas.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_balas.py
@@ -16,7 +16,7 @@ from pyomo.common.dependencies import numpy as numpy, numpy_available
 if numpy_available:
     from numpy.testing import assert_array_almost_equal
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common import unittest
 import pyomo.opt
 

--- a/pyomo/contrib/alternative_solutions/tests/test_balas.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_balas.py
@@ -16,7 +16,6 @@ from pyomo.common.dependencies import numpy as numpy, numpy_available
 if numpy_available:
     from numpy.testing import assert_array_almost_equal
 
-import pyomo.environ as pyo
 from pyomo.common import unittest
 import pyomo.opt
 

--- a/pyomo/contrib/alternative_solutions/tests/test_cases.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_cases.py
@@ -15,7 +15,7 @@ from collections import Counter
 
 from pyomo.common.dependencies import numpy as np
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
 """
 This script has collection of test cases that can be used to enumerate solutions.
@@ -24,7 +24,7 @@ That is, simple problems where the alternative solutions can be found manually.
 
 
 def _is_satisfied(constraint, feasibility_tol=1e-6):
-    value = pe.value(constraint.body)
+    value = pyo.value(constraint.body)
     if constraint.has_lb() and value < constraint.lb - feasibility_tol:
         return False
     if constraint.has_ub() and value > constraint.ub + feasibility_tol:
@@ -36,16 +36,16 @@ def get_2d_diamond_problem(discrete_x=False, discrete_y=False):
     """
     Simple 2d problem where the feasible is diamond-shaped.
     """
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.Integers if discrete_x else pe.Reals, bounds=(-10, 10))
-    m.y = pe.Var(within=pe.Integers if discrete_y else pe.Reals, bounds=(-10, 10))
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.Integers if discrete_x else pyo.Reals, bounds=(-10, 10))
+    m.y = pyo.Var(within=pyo.Integers if discrete_y else pyo.Reals, bounds=(-10, 10))
 
-    m.o = pe.Objective(expr=m.x + m.y, sense=pe.maximize)
+    m.o = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
 
-    m.c1 = pe.Constraint(expr=-4 / 5 * m.x - 4 <= m.y)
-    m.c2 = pe.Constraint(expr=5 / 9 * m.x - 5 <= m.y)
-    m.c3 = pe.Constraint(expr=2 / 9 * m.x + 2 >= m.y)
-    m.c4 = pe.Constraint(expr=-1 / 2 * m.x + 3 >= m.y)
+    m.c1 = pyo.Constraint(expr=-4 / 5 * m.x - 4 <= m.y)
+    m.c2 = pyo.Constraint(expr=5 / 9 * m.x - 5 <= m.y)
+    m.c3 = pyo.Constraint(expr=2 / 9 * m.x + 2 >= m.y)
+    m.c4 = pyo.Constraint(expr=-1 / 2 * m.x + 3 >= m.y)
 
     # Continuous exteme points and bounds
     m.extreme_points = {
@@ -55,7 +55,7 @@ def get_2d_diamond_problem(discrete_x=False, discrete_y=False):
         (7.578947368, -0.789473684),
     }
 
-    m.continuous_bounds = pe.ComponentMap()
+    m.continuous_bounds = pyo.ComponentMap()
     m.continuous_bounds[m.x] = (-5.869565217, 7.578947368)
     m.continuous_bounds[m.y] = (-4.590163934, 2.307692308)
 
@@ -70,7 +70,7 @@ def get_2d_diamond_problem(discrete_x=False, discrete_y=False):
         (7.578947368, -0.789473684),
     }
 
-    m.continuous_bounds_cut = pe.ComponentMap()
+    m.continuous_bounds_cut = pyo.ComponentMap()
     m.continuous_bounds_cut[m.x] = (-18 / 11, 7.578947368)
     m.continuous_bounds_cut[m.y] = (-45 / 14, 2.307692308)
 
@@ -106,7 +106,7 @@ def get_2d_diamond_problem(discrete_x=False, discrete_y=False):
                     y_upper_bound = y_value
                 feasible_sols.append(((x_value, y_value), x_value + y_value))
     m.discrete_feasible = sorted(feasible_sols, key=lambda sol: sol[1], reverse=True)
-    m.discrete_bounds = pe.ComponentMap()
+    m.discrete_bounds = pyo.ComponentMap()
     m.discrete_bounds[m.x] = (x_lower_bound, x_upper_bound)
     m.discrete_bounds[m.y] = (y_lower_bound, y_upper_bound)
 
@@ -117,8 +117,8 @@ def get_3d_polyhedron_problem():
     """
     Simple 3d polyhedron that is expressed using all types of linear constraints
     """
-    m = pe.ConcreteModel()
-    m.x = pe.Var([0, 1, 2], within=pe.Reals)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var([0, 1, 2], within=pyo.Reals)
     m.x[0].setlb(-1)
     m.x[0].setub(1)
     m.x[1].setlb(-2)
@@ -138,9 +138,9 @@ def get_3d_polyhedron_problem():
         elif i == 4:
             return m.x[0] + m.x[1] + m.x[2] == 4
 
-    m.c = pe.Constraint([i for i in range(5)], rule=_constraint_switch_rule)
+    m.c = pyo.Constraint([i for i in range(5)], rule=_constraint_switch_rule)
 
-    m.o = pe.Objective(expr=m.x[0] + m.x[2], sense=pe.maximize)
+    m.o = pyo.Objective(expr=m.x[0] + m.x[2], sense=pyo.maximize)
     return m
 
 
@@ -149,18 +149,18 @@ def get_2d_unbounded_problem():
     Simple 2d problem where the feasible region is unbounded, but the problem
     has an optimal solution.
     """
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.Reals)
-    m.y = pe.Var(within=pe.Reals)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.Reals)
+    m.y = pyo.Var(within=pyo.Reals)
 
-    m.o = pe.Objective(expr=m.y - m.x)
+    m.o = pyo.Objective(expr=m.y - m.x)
 
-    m.c1 = pe.Constraint(expr=m.x <= 4)
-    m.c2 = pe.Constraint(expr=m.y >= 2)
+    m.c1 = pyo.Constraint(expr=m.x <= 4)
+    m.c2 = pyo.Constraint(expr=m.y >= 2)
 
     m.extreme_points = {(4, 2)}
 
-    m.continuous_bounds = pe.ComponentMap()
+    m.continuous_bounds = pyo.ComponentMap()
     m.continuous_bounds[m.x] = (float("-inf"), 4)
     m.continuous_bounds[m.y] = (2, float("inf"))
     return m
@@ -171,16 +171,16 @@ def get_2d_degenerate_lp():
     Simple 2d problem that includes a redundant constraint such that three
     constraints are active at optimality.
     """
-    m = pe.ConcreteModel()
+    m = pyo.ConcreteModel()
 
-    m.x = pe.Var(within=pe.Reals, bounds=(-1, 3))
-    m.y = pe.Var(within=pe.Reals, bounds=(-3, 2))
+    m.x = pyo.Var(within=pyo.Reals, bounds=(-1, 3))
+    m.y = pyo.Var(within=pyo.Reals, bounds=(-3, 2))
 
-    m.obj = pe.Objective(expr=m.x + 2 * m.y, sense=pe.maximize)
+    m.obj = pyo.Objective(expr=m.x + 2 * m.y, sense=pyo.maximize)
 
-    m.con1 = pe.Constraint(expr=m.x + m.y <= 3)
-    m.con2 = pe.Constraint(expr=m.x + 2 * m.y <= 5)
-    m.con3 = pe.Constraint(expr=m.x + m.y >= -1)
+    m.con1 = pyo.Constraint(expr=m.x + m.y <= 3)
+    m.con2 = pyo.Constraint(expr=m.x + 2 * m.y <= 5)
+    m.con3 = pyo.Constraint(expr=m.x + m.y >= -1)
 
     return m
 
@@ -192,12 +192,12 @@ def get_triangle_ip():
     x + y == 5.  Alternative near-optimal have integer objective values from 0 to 4.
     """
     var_max = 5
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.NonNegativeIntegers, bounds=(0, var_max))
-    m.y = pe.Var(within=pe.NonNegativeIntegers, bounds=(0, var_max))
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.NonNegativeIntegers, bounds=(0, var_max))
+    m.y = pyo.Var(within=pyo.NonNegativeIntegers, bounds=(0, var_max))
 
-    m.o = pe.Objective(expr=m.x + m.y, sense=pe.maximize)
-    m.c = pe.Constraint(expr=m.x + m.y <= var_max)
+    m.o = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
+    m.c = pyo.Constraint(expr=m.x + m.y <= var_max)
 
     #
     # Enumerate all feasible solutions
@@ -223,18 +223,18 @@ def get_implied_bound_ip():
     facilitate testing cases where the impled bounds are tighter than the
     given bounds for the variable.
     """
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.NonNegativeIntegers, bounds=(0, 5))
-    m.y = pe.Var(within=pe.NonNegativeIntegers, bounds=(0, 5))
-    m.z = pe.Var(within=pe.NonNegativeIntegers, bounds=(0, 5))
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.NonNegativeIntegers, bounds=(0, 5))
+    m.y = pyo.Var(within=pyo.NonNegativeIntegers, bounds=(0, 5))
+    m.z = pyo.Var(within=pyo.NonNegativeIntegers, bounds=(0, 5))
 
-    m.o = pe.Objective(expr=m.x + m.z)
+    m.o = pyo.Objective(expr=m.x + m.z)
 
-    m.c1 = pe.Constraint(expr=m.x + m.y == 3)
-    m.c2 = pe.Constraint(expr=m.x + m.y + m.z <= 5)
-    m.c3 = pe.Constraint(expr=m.x + m.y + m.z >= 4)
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3)
+    m.c2 = pyo.Constraint(expr=m.x + m.y + m.z <= 5)
+    m.c3 = pyo.Constraint(expr=m.x + m.y + m.z >= 4)
 
-    m.var_bounds = pe.ComponentMap()
+    m.var_bounds = pyo.ComponentMap()
     m.var_bounds[m.x] = (0, 3)
     m.var_bounds[m.y] = (0, 3)
     m.var_bounds[m.z] = (1, 2)
@@ -261,17 +261,17 @@ def get_aos_test_knapsack(
     if capacity is None:
         capacity = sum(weights) * var_max * capacity_fraction
 
-    m = pe.ConcreteModel()
-    m.i = pe.RangeSet(0, num_vars - 1)
+    m = pyo.ConcreteModel()
+    m.i = pyo.RangeSet(0, num_vars - 1)
 
     if var_max == 1:
-        m.x = pe.Var(m.i, within=pe.Binary)
+        m.x = pyo.Var(m.i, within=pyo.Binary)
     else:
-        m.x = pe.Var(m.i, within=pe.NonNegativeIntegers, bounds=(0, var_max))
+        m.x = pyo.Var(m.i, within=pyo.NonNegativeIntegers, bounds=(0, var_max))
 
-    m.o = pe.Objective(expr=sum(values[i] * m.x[i] for i in m.i), sense=pe.maximize)
+    m.o = pyo.Objective(expr=sum(values[i] * m.x[i] for i in m.i), sense=pyo.maximize)
 
-    m.c = pe.Constraint(expr=sum(weights[i] * m.x[i] for i in m.i) <= capacity)
+    m.c = pyo.Constraint(expr=sum(weights[i] * m.x[i] for i in m.i) <= capacity)
 
     var_domain = range(var_max + 1)
     all_combos = product(var_domain, repeat=num_vars)
@@ -291,11 +291,11 @@ def get_pentagonal_lp():
     Pentagonal LP
     """
     var_max = 5
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.Reals, bounds=(0, 2 * var_max))
-    m.y = pe.Var(within=pe.Reals, bounds=(0, 2 * var_max))
-    m.z = pe.Var(within=pe.NonNegativeReals, bounds=(0, 2 * var_max))
-    m.o = pe.Objective(expr=m.z, sense=pe.minimize)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.Reals, bounds=(0, 2 * var_max))
+    m.y = pyo.Var(within=pyo.Reals, bounds=(0, 2 * var_max))
+    m.z = pyo.Var(within=pyo.NonNegativeReals, bounds=(0, 2 * var_max))
+    m.o = pyo.Objective(expr=m.z, sense=pyo.minimize)
 
     base_points = np.array(
         [
@@ -308,7 +308,7 @@ def get_pentagonal_lp():
     )
     apex_point = np.array([var_max, var_max, var_max])
 
-    m.c = pe.ConstraintList()
+    m.c = pyo.ConstraintList()
     for i in range(5):
         vec_1 = base_points[i] - apex_point
         vec_2 = base_points[(i + 1) % var_max] - base_points[i]
@@ -329,11 +329,11 @@ def get_pentagonal_pyramid_mip():
     a third continuous dimension.
     """
     var_max = 5
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.Integers, bounds=(-var_max, var_max))
-    m.y = pe.Var(within=pe.Integers, bounds=(-var_max, var_max))
-    m.z = pe.Var(within=pe.NonNegativeReals, bounds=(0, var_max))
-    m.o = pe.Objective(expr=m.z, sense=pe.maximize)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.Integers, bounds=(-var_max, var_max))
+    m.y = pyo.Var(within=pyo.Integers, bounds=(-var_max, var_max))
+    m.z = pyo.Var(within=pyo.NonNegativeReals, bounds=(0, var_max))
+    m.o = pyo.Objective(expr=m.z, sense=pyo.maximize)
 
     base_points = np.array(
         [
@@ -346,7 +346,7 @@ def get_pentagonal_pyramid_mip():
     )
     apex_point = np.array([0, 0, var_max])
 
-    m.c = pe.ConstraintList()
+    m.c = pyo.ConstraintList()
     for i in range(5):
         vec_1 = base_points[i] - apex_point
         vec_2 = base_points[(i + 1) % var_max] - base_points[i]
@@ -370,10 +370,10 @@ def get_indexed_pentagonal_pyramid_mip():
     a third continuous dimension.
     """
     var_max = 5
-    m = pe.ConcreteModel()
-    m.x = pe.Var([1, 2], within=pe.Integers, bounds=(-var_max, var_max))
-    m.z = pe.Var(within=pe.NonNegativeReals, bounds=(0, var_max))
-    m.o = pe.Objective(expr=m.z, sense=pe.maximize)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var([1, 2], within=pyo.Integers, bounds=(-var_max, var_max))
+    m.z = pyo.Var(within=pyo.NonNegativeReals, bounds=(0, var_max))
+    m.o = pyo.Objective(expr=m.z, sense=pyo.maximize)
     base_points = np.array(
         [
             [0, var_max, 0],
@@ -396,7 +396,7 @@ def get_indexed_pentagonal_pyramid_mip():
         )
         return expr >= 0
 
-    m.c = pe.Constraint([i for i in range(5)], rule=_con_rule)
+    m.c = pyo.Constraint([i for i in range(5)], rule=_con_rule)
     m.num_ranked_solns = [1, 4, 2, 8, 2, 12, 4, 16, 4, 20]
     return m
 
@@ -407,12 +407,12 @@ def get_bloated_pentagonal_pyramid_mip():
     a third continuous dimension. Bounds are artificially widened for obbt testing purposes
     """
     var_max = 5
-    m = pe.ConcreteModel()
-    m.x = pe.Var(within=pe.Integers, bounds=(-2 * var_max, 2 * var_max))
-    m.y = pe.Var(within=pe.Integers, bounds=(-2 * var_max, var_max))
-    m.z = pe.Var(within=pe.NonNegativeReals, bounds=(0, 2 * var_max))
-    m.var_bounds = pe.ComponentMap()
-    m.o = pe.Objective(expr=m.z, sense=pe.maximize)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(within=pyo.Integers, bounds=(-2 * var_max, 2 * var_max))
+    m.y = pyo.Var(within=pyo.Integers, bounds=(-2 * var_max, var_max))
+    m.z = pyo.Var(within=pyo.NonNegativeReals, bounds=(0, 2 * var_max))
+    m.var_bounds = pyo.ComponentMap()
+    m.o = pyo.Objective(expr=m.z, sense=pyo.maximize)
     base_points = np.array(
         [
             [0, var_max, 0],
@@ -424,7 +424,7 @@ def get_bloated_pentagonal_pyramid_mip():
     )
     apex_point = np.array([0, 0, var_max])
 
-    m.c = pe.ConstraintList()
+    m.c = pyo.ConstraintList()
     for i in range(5):
         vec_1 = base_points[i] - apex_point
         vec_2 = base_points[(i + 1) % var_max] - base_points[i]

--- a/pyomo/contrib/alternative_solutions/tests/test_lp_enum.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_lp_enum.py
@@ -11,7 +11,7 @@
 
 from pyomo.common.dependencies import numpy as numpy, numpy_available
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common import unittest
 import pyomo.opt
 
@@ -57,7 +57,7 @@ class TestLPEnum:
     def test_3d_polyhedron(self, mip_solver):
         m = tc.get_3d_polyhedron_problem()
         m.o.deactivate()
-        m.obj = pe.Objective(expr=m.x[0] + m.x[1] + m.x[2])
+        m.obj = pyo.Objective(expr=m.x[0] + m.x[1] + m.x[2])
 
         sols = lp_enum.enumerate_linear_solutions(m, solver=mip_solver)
         assert len(sols) == 2
@@ -67,7 +67,7 @@ class TestLPEnum:
     def test_3d_polyhedron(self, mip_solver):
         m = tc.get_3d_polyhedron_problem()
         m.o.deactivate()
-        m.obj = pe.Objective(expr=m.x[0] + 2 * m.x[1] + 3 * m.x[2])
+        m.obj = pyo.Objective(expr=m.x[0] + 2 * m.x[1] + 3 * m.x[2])
 
         sols = lp_enum.enumerate_linear_solutions(m, solver=mip_solver)
         assert len(sols) == 2
@@ -88,9 +88,9 @@ class TestLPEnum:
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_pentagonal_pyramid(self, mip_solver):
         n = tc.get_pentagonal_pyramid_mip()
-        n.o.sense = pe.minimize
-        n.x.domain = pe.Reals
-        n.y.domain = pe.Reals
+        n.o.sense = pyo.minimize
+        n.x.domain = pyo.Reals
+        n.y.domain = pyo.Reals
 
         sols = lp_enum.enumerate_linear_solutions(n, solver=mip_solver, tee=False)
         for s in sols:

--- a/pyomo/contrib/alternative_solutions/tests/test_lp_enum_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_lp_enum_solnpool.py
@@ -17,7 +17,7 @@ from pyomo.contrib.alternative_solutions import lp_enum
 from pyomo.contrib.alternative_solutions import lp_enum_solnpool
 from pyomo.opt import check_available_solvers
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
 # lp_enum_solnpool uses both 'gurobi' and 'appsi_gurobi'
 gurobi_available = len(check_available_solvers('gurobi', 'appsi_gurobi')) == 2
@@ -33,8 +33,8 @@ class TestLPEnumSolnpool(unittest.TestCase):
 
     def test_here(self):
         n = tc.get_pentagonal_pyramid_mip()
-        n.x.domain = pe.Reals
-        n.y.domain = pe.Reals
+        n.x.domain = pyo.Reals
+        n.y.domain = pyo.Reals
 
         try:
             sols = lp_enum_solnpool.enumerate_linear_solutions_soln_pool(n, tee=True)

--- a/pyomo/contrib/alternative_solutions/tests/test_obbt.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_obbt.py
@@ -16,7 +16,7 @@ from pyomo.common.dependencies import numpy as numpy, numpy_available
 if numpy_available:
     from numpy.testing import assert_array_almost_equal
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common import unittest
 
 import pyomo.opt
@@ -236,7 +236,7 @@ class TestOBBTUnit:
         Check that code catches cases where the problem is infeasible.
         """
         m = tc.get_2d_diamond_problem()
-        m.infeasible_constraint = pe.Constraint(expr=m.x >= 10)
+        m.infeasible_constraint = pyo.Constraint(expr=m.x >= 10)
         with unittest.pytest.raises(Exception):
             obbt_analysis_bounds_and_solutions(m, solver=mip_solver)
 

--- a/pyomo/contrib/alternative_solutions/tests/test_shifted_lp.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_shifted_lp.py
@@ -14,7 +14,7 @@ from pyomo.common.dependencies import numpy as numpy, numpy_available
 if numpy_available:
     from numpy.testing import assert_array_almost_equal
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.opt
 from pyomo.common import unittest
 
@@ -38,28 +38,28 @@ class TestShiftedIP:
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_mip_abs_objective(self, lp_solver):
         m = tc.get_indexed_pentagonal_pyramid_mip()
-        m.x.domain = pe.Reals
+        m.x.domain = pyo.Reals
 
-        opt = pe.SolverFactory(lp_solver)
+        opt = pyo.SolverFactory(lp_solver)
         old_results = opt.solve(m, tee=False)
-        old_obj = pe.value(m.o)
+        old_obj = pyo.value(m.o)
 
         new_model = shifted_lp.get_shifted_linear_model(m)
         new_results = opt.solve(new_model, tee=False)
-        new_obj = pe.value(new_model.objective)
+        new_obj = pyo.value(new_model.objective)
 
         assert old_obj == unittest.pytest.approx(new_obj)
 
     def test_polyhedron(self, lp_solver):
         m = tc.get_3d_polyhedron_problem()
 
-        opt = pe.SolverFactory(lp_solver)
+        opt = pyo.SolverFactory(lp_solver)
         old_results = opt.solve(m, tee=False)
-        old_obj = pe.value(m.o)
+        old_obj = pyo.value(m.o)
 
         new_model = shifted_lp.get_shifted_linear_model(m)
         new_results = opt.solve(new_model, tee=False)
-        new_obj = pe.value(new_model.objective)
+        new_obj = pyo.value(new_model.objective)
 
         assert old_obj == unittest.pytest.approx(new_obj)
 

--- a/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
@@ -17,7 +17,7 @@ from pyomo.contrib.alternative_solutions import gurobi_generate_solutions
 from pyomo.contrib.appsi.solvers import Gurobi
 
 import pyomo.contrib.alternative_solutions.tests.test_cases as tc
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
 gurobipy_available = Gurobi().available()
 

--- a/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
@@ -17,7 +17,6 @@ from pyomo.contrib.alternative_solutions import gurobi_generate_solutions
 from pyomo.contrib.appsi.solvers import Gurobi
 
 import pyomo.contrib.alternative_solutions.tests.test_cases as tc
-import pyomo.environ as pyo
 
 gurobipy_available = Gurobi().available()
 

--- a/pyomo/contrib/alternative_solutions/tests/test_solution.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_solution.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 import pyomo.opt
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 import pyomo.contrib.alternative_solutions.aos_utils as au
 from pyomo.contrib.alternative_solutions import Solution
@@ -26,18 +26,18 @@ class TestSolutionUnit(unittest.TestCase):
         Simple model with all variable types and fixed variables to test the
         Solution code.
         """
-        m = pe.ConcreteModel()
-        m.x = pe.Var(domain=pe.NonNegativeReals)
-        m.y = pe.Var(domain=pe.Binary)
-        m.z = pe.Var(domain=pe.NonNegativeIntegers)
-        m.f = pe.Var(domain=pe.Reals)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.NonNegativeReals)
+        m.y = pyo.Var(domain=pyo.Binary)
+        m.z = pyo.Var(domain=pyo.NonNegativeIntegers)
+        m.f = pyo.Var(domain=pyo.Reals)
 
         m.f.fix(1)
-        m.obj = pe.Objective(expr=m.x + m.y + m.z + m.f, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.x + m.y + m.z + m.f, sense=pyo.maximize)
 
-        m.con_x = pe.Constraint(expr=m.x <= 1.5)
-        m.con_y = pe.Constraint(expr=m.y <= 1)
-        m.con_z = pe.Constraint(expr=m.z <= 3)
+        m.con_x = pyo.Constraint(expr=m.x <= 1.5)
+        m.con_y = pyo.Constraint(expr=m.y <= 1)
+        m.con_z = pyo.Constraint(expr=m.z <= 3)
         return m
 
     @unittest.skipUnless(mip_available, "MIP solver not available")
@@ -47,7 +47,7 @@ class TestSolutionUnit(unittest.TestCase):
         data is returned.
         """
         model = self.get_model()
-        opt = pe.SolverFactory(mip_solver)
+        opt = pyo.SolverFactory(mip_solver)
         opt.solve(model)
         all_vars = au.get_model_variables(model, include_fixed=True)
 

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -334,7 +334,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid duals. Please '
                 'check the termination condition and ensure the solver returns duals '
-                'for the given problem type.'
+                'for the given problem typyo.'
             )
         if cons_to_load is None:
             duals = dict(self._duals)
@@ -351,7 +351,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid slacks. Please '
                 'check the termination condition and ensure the solver returns slacks '
-                'for the given problem type.'
+                'for the given problem typyo.'
             )
         if cons_to_load is None:
             slacks = dict(self._slacks)
@@ -368,7 +368,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid reduced costs. Please '
                 'check the termination condition and ensure the solver returns reduced '
-                'costs for the given problem type.'
+                'costs for the given problem typyo.'
             )
         if vars_to_load is None:
             rc = ComponentMap(self._reduced_costs.values())
@@ -402,11 +402,11 @@ class Results(object):
     -------
     Here is an example workflow:
 
-        >>> import pyomo.environ as pe
+        >>> import pyomo.environ as pyo
         >>> from pyomo.contrib import appsi
-        >>> m = pe.ConcreteModel()
-        >>> m.x = pe.Var()
-        >>> m.obj = pe.Objective(expr=m.x**2)
+        >>> m = pyo.ConcreteModel()
+        >>> m.x = pyo.Var()
+        >>> m.obj = pyo.Objective(expr=m.x**2)
         >>> opt = appsi.solvers.Ipopt()
         >>> opt.config.load_solution = False
         >>> results = opt.solve(m) #doctest:+SKIP

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -334,7 +334,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid duals. Please '
                 'check the termination condition and ensure the solver returns duals '
-                'for the given problem typyo.'
+                'for the given problem type.'
             )
         if cons_to_load is None:
             duals = dict(self._duals)
@@ -351,7 +351,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid slacks. Please '
                 'check the termination condition and ensure the solver returns slacks '
-                'for the given problem typyo.'
+                'for the given problem type.'
             )
         if cons_to_load is None:
             slacks = dict(self._slacks)
@@ -368,7 +368,7 @@ class SolutionLoader(SolutionLoaderBase):
             raise RuntimeError(
                 'Solution loader does not currently have valid reduced costs. Please '
                 'check the termination condition and ensure the solver returns reduced '
-                'costs for the given problem typyo.'
+                'costs for the given problem type.'
             )
         if vars_to_load is None:
             rc = ComponentMap(self._reduced_costs.values())

--- a/pyomo/contrib/appsi/examples/getting_started.py
+++ b/pyomo/contrib/appsi/examples/getting_started.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib import appsi
 from pyomo.common.timing import HierarchicalTimer
 
@@ -18,14 +18,14 @@ def main(plot=True, n_points=200):
     import numpy as np
 
     # create a Pyomo model
-    m = pe.ConcreteModel()
-    m.x = pe.Var()
-    m.y = pe.Var()
-    m.p = pe.Param(initialize=1, mutable=True)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.p = pyo.Param(initialize=1, mutable=True)
 
-    m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-    m.c1 = pe.Constraint(expr=m.y >= (m.x + 1) ** 2)
-    m.c2 = pe.Constraint(expr=m.y >= (m.x - m.p) ** 2)
+    m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+    m.c1 = pyo.Constraint(expr=m.y >= (m.x + 1) ** 2)
+    m.c2 = pyo.Constraint(expr=m.y >= (m.x - m.p) ** 2)
 
     opt = appsi.solvers.Cplex()  # create an APPSI solver interface
     opt.config.load_solution = False  # modify the config options

--- a/pyomo/contrib/appsi/examples/tests/test_examples.py
+++ b/pyomo/contrib/appsi/examples/tests/test_examples.py
@@ -11,7 +11,6 @@
 
 from pyomo.contrib.appsi.examples import getting_started
 import pyomo.common.unittest as unittest
-import pyomo.environ as pyo
 from pyomo.contrib.appsi.cmodel import cmodel_available
 from pyomo.contrib import appsi
 

--- a/pyomo/contrib/appsi/examples/tests/test_examples.py
+++ b/pyomo/contrib/appsi/examples/tests/test_examples.py
@@ -11,7 +11,7 @@
 
 from pyomo.contrib.appsi.examples import getting_started
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib.appsi.cmodel import cmodel_available
 from pyomo.contrib import appsi
 

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -1377,15 +1377,15 @@ class Gurobi(PersistentBase, PersistentSolver):
             as an MILP using extended cutting planes in callbacks.
 
                 >>> from gurobipy import GRB # doctest:+SKIP
-                >>> import pyomo.environ as pe
+                >>> import pyomo.environ as pyo
                 >>> from pyomo.core.expr.taylor_series import taylor_series_expansion
                 >>> from pyomo.contrib import appsi
                 >>>
-                >>> m = pe.ConcreteModel()
-                >>> m.x = pe.Var(bounds=(0, 4))
-                >>> m.y = pe.Var(within=pe.Integers, bounds=(0, None))
-                >>> m.obj = pe.Objective(expr=2*m.x + m.y)
-                >>> m.cons = pe.ConstraintList()  # for the cutting planes
+                >>> m = pyo.ConcreteModel()
+                >>> m.x = pyo.Var(bounds=(0, 4))
+                >>> m.y = pyo.Var(within=pyo.Integers, bounds=(0, None))
+                >>> m.obj = pyo.Objective(expr=2*m.x + m.y)
+                >>> m.cons = pyo.ConstraintList()  # for the cutting planes
                 >>>
                 >>> def _add_cut(xval):
                 ...     # a function to generate the cut

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -11,7 +11,7 @@
 
 from pyomo.common.errors import PyomoException
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib.appsi.solvers.gurobi import Gurobi
 from pyomo.contrib.appsi.base import TerminationCondition
 from pyomo.core.expr.numeric_expr import LinearExpression
@@ -89,17 +89,17 @@ def create_pmedian_model():
         (10, 6): 1.9115931008709737,
     }
 
-    model = pe.ConcreteModel()
-    model.N = pe.Param(initialize=10)
-    model.Locations = pe.RangeSet(1, model.N)
-    model.P = pe.Param(initialize=3)
-    model.M = pe.Param(initialize=6)
-    model.Customers = pe.RangeSet(1, model.M)
-    model.d = pe.Param(
-        model.Locations, model.Customers, initialize=d_dict, within=pe.Reals
+    model = pyo.ConcreteModel()
+    model.N = pyo.Param(initialize=10)
+    model.Locations = pyo.RangeSet(1, model.N)
+    model.P = pyo.Param(initialize=3)
+    model.M = pyo.Param(initialize=6)
+    model.Customers = pyo.RangeSet(1, model.M)
+    model.d = pyo.Param(
+        model.Locations, model.Customers, initialize=d_dict, within=pyo.Reals
     )
-    model.x = pe.Var(model.Locations, model.Customers, bounds=(0.0, 1.0))
-    model.y = pe.Var(model.Locations, within=pe.Binary)
+    model.x = pyo.Var(model.Locations, model.Customers, bounds=(0.0, 1.0))
+    model.y = pyo.Var(model.Locations, within=pyo.Binary)
 
     def rule(model):
         return sum(
@@ -108,39 +108,39 @@ def create_pmedian_model():
             for m in model.Customers
         )
 
-    model.obj = pe.Objective(rule=rule)
+    model.obj = pyo.Objective(rule=rule)
 
     def rule(model, m):
         return (sum(model.x[n, m] for n in model.Locations), 1.0)
 
-    model.single_x = pe.Constraint(model.Customers, rule=rule)
+    model.single_x = pyo.Constraint(model.Customers, rule=rule)
 
     def rule(model, n, m):
         return (None, model.x[n, m] - model.y[n], 0.0)
 
-    model.bound_y = pe.Constraint(model.Locations, model.Customers, rule=rule)
+    model.bound_y = pyo.Constraint(model.Locations, model.Customers, rule=rule)
 
     def rule(model):
         return (sum(model.y[n] for n in model.Locations) - model.P, 0.0)
 
-    model.num_facilities = pe.Constraint(rule=rule)
+    model.num_facilities = pyo.Constraint(rule=rule)
 
     return model
 
 
 class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
     def setUp(self):
-        self.m = pe.ConcreteModel()
+        self.m = pyo.ConcreteModel()
         m = self.m
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.p1 = pe.Param(mutable=True)
-        m.p2 = pe.Param(mutable=True)
-        m.p3 = pe.Param(mutable=True)
-        m.p4 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c1 = pe.Constraint(expr=m.y - m.p1 * m.x >= m.p2)
-        m.c2 = pe.Constraint(expr=m.y - m.p3 * m.x >= m.p4)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.p1 = pyo.Param(mutable=True)
+        m.p2 = pyo.Param(mutable=True)
+        m.p3 = pyo.Param(mutable=True)
+        m.p4 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c1 = pyo.Constraint(expr=m.y - m.p1 * m.x >= m.p2)
+        m.c2 = pyo.Constraint(expr=m.y - m.p3 * m.x >= m.p4)
 
     def get_solution(self):
         try:
@@ -201,12 +201,12 @@ class TestGurobiPersistent(unittest.TestCase):
         #
         # Update: as of Gurobi 11, this test no longer tests the
         # intended behavior (the solver has improved)
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-5, 5))
-        m.y = pe.Var(bounds=(-5, 5))
-        m.obj = pe.Objective(expr=-m.x**2 - m.y)
-        m.c1 = pe.Constraint(expr=m.y <= -2 * m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-5, 5))
+        m.y = pyo.Var(bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pyo.Constraint(expr=m.y <= -2 * m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 2)
         opt = Gurobi()
         opt.gurobi_options['nonconvex'] = 2
         opt.gurobi_options['BestBdStop'] = -8
@@ -228,12 +228,12 @@ class TestGurobiPersistent(unittest.TestCase):
         #
         # Update: as of Gurobi 11, this test no longer tests the
         # intended behavior (the solver has improved)
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-5, 5))
-        m.y = pe.Var(bounds=(-5, 5))
-        m.obj = pe.Objective(expr=-m.x**2 - m.y)
-        m.c1 = pe.Constraint(expr=m.y <= -2 * m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-5, 5))
+        m.y = pyo.Var(bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pyo.Constraint(expr=m.y <= -2 * m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 2)
         opt = Gurobi()
         opt.gurobi_options['nonconvex'] = 2
         opt.gurobi_options['MIPGap'] = 0.5
@@ -245,12 +245,12 @@ class TestGurobiPersistent(unittest.TestCase):
             self.assertAlmostEqual(res.best_objective_bound, -4)
 
     def test_range_constraints(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.xl = pe.Param(initialize=-1, mutable=True)
-        m.xu = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Constraint(expr=pe.inequality(m.xl, m.x, m.xu))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.xl = pyo.Param(initialize=-1, mutable=True)
+        m.xu = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Constraint(expr=pyo.inequality(m.xl, m.x, m.xu))
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = Gurobi()
         opt.set_instance(m)
@@ -262,7 +262,7 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -3)
 
         del m.obj
-        m.obj = pe.Objective(expr=m.x, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.x, sense=pyo.maximize)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 1)
@@ -272,14 +272,14 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 3)
 
     def test_quadratic_constraint_with_params(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.con = pe.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.con = pyo.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
 
         opt = Gurobi()
         res = opt.solve(m)
@@ -298,12 +298,12 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_quadratic_objective(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.a * m.x**2 + m.b * m.x + m.c)
 
         opt = Gurobi()
         res = opt.solve(m)
@@ -324,9 +324,9 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_var_bounds(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = Gurobi()
         res = opt.solve(m)
@@ -337,7 +337,7 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -3)
 
         del m.obj
-        m.obj = pe.Objective(expr=m.x, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.x, sense=pyo.maximize)
 
         opt = Gurobi()
         res = opt.solve(m)
@@ -348,14 +348,14 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 3)
 
     def test_fixed_var(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.con = pe.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.con = pyo.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
 
         m.x.fix(1)
         opt = Gurobi()
@@ -376,10 +376,10 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_linear_constraint_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
 
         opt = Gurobi()
         opt.set_instance(m)
@@ -387,19 +387,19 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertEqual(opt.get_linear_constraint_attr(m.c, 'Lazy'), 1)
 
     def test_quadratic_constraint_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c = pe.Constraint(expr=m.y >= m.x**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c = pyo.Constraint(expr=m.y >= m.x**2)
 
         opt = Gurobi()
         opt.set_instance(m)
         self.assertEqual(opt.get_quadratic_constraint_attr(m.c, 'QCRHS'), 0)
 
     def test_var_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = Gurobi()
         opt.set_instance(m)
@@ -407,11 +407,11 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertEqual(opt.get_var_attr(m.x, 'Start'), 1)
 
     def test_callback(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(0, 4))
-        m.y = pe.Var(within=pe.Integers, bounds=(0, None))
-        m.obj = pe.Objective(expr=2 * m.x + m.y)
-        m.cons = pe.ConstraintList()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(0, 4))
+        m.y = pyo.Var(within=pyo.Integers, bounds=(0, None))
+        m.obj = pyo.Objective(expr=2 * m.x + m.y)
+        m.cons = pyo.ConstraintList()
 
         def _add_cut(xval):
             m.x.value = xval
@@ -439,11 +439,11 @@ class TestGurobiPersistent(unittest.TestCase):
     def test_nonconvex(self):
         if gurobipy.GRB.VERSION_MAJOR < 9:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.y == (m.x - 1) ** 2 - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.y == (m.x - 1) ** 2 - 2)
         opt = Gurobi()
         opt.gurobi_options['nonconvex'] = 2
         opt.solve(m)
@@ -453,12 +453,12 @@ class TestGurobiPersistent(unittest.TestCase):
     def test_nonconvex2(self):
         if gurobipy.GRB.VERSION_MAJOR < 9:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=0 <= -m.y + (m.x - 1) ** 2 - 2)
-        m.c2 = pe.Constraint(expr=0 >= -m.y + (m.x - 1) ** 2 - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=0 <= -m.y + (m.x - 1) ** 2 - 2)
+        m.c2 = pyo.Constraint(expr=0 >= -m.y + (m.x - 1) ** 2 - 2)
         opt = Gurobi()
         opt.gurobi_options['nonconvex'] = 2
         opt.solve(m)
@@ -474,11 +474,11 @@ class TestGurobiPersistent(unittest.TestCase):
         num_solutions = opt.get_model_attr('SolCount')
         self.assertEqual(num_solutions, 3)
         res.solution_loader.load_vars(solution_number=0)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.431184939357673)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.431184939357673)
         res.solution_loader.load_vars(solution_number=1)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.584793218502477)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.584793218502477)
         res.solution_loader.load_vars(solution_number=2)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.592304628123309)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.592304628123309)
 
     def test_zero_time_limit(self):
         m = create_pmedian_model()
@@ -510,11 +510,11 @@ class TestManualModel(unittest.TestCase):
         self.opt = opt
 
     def test_basics(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= 2 * m.x + 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= 2 * m.x + 1)
 
         opt = self.opt
         opt.set_instance(m)
@@ -531,7 +531,7 @@ class TestManualModel(unittest.TestCase):
         duals = opt.get_duals()
         self.assertAlmostEqual(duals[m.c1], -0.4)
 
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
         opt.add_constraints([m.c2])
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
         self.assertEqual(opt.get_model_attr('NumConstrs'), 2)
@@ -575,7 +575,7 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_var_attr(m.x, 'LB'), -5)
         self.assertEqual(opt.get_var_attr(m.x, 'UB'), 5)
 
-        m.c2 = pe.Constraint(expr=m.y >= m.x**2)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x**2)
         opt.add_constraints([m.c2])
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
         self.assertEqual(opt.get_model_attr('NumConstrs'), 1)
@@ -587,7 +587,7 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_model_attr('NumConstrs'), 1)
         self.assertEqual(opt.get_model_attr('NumQConstrs'), 0)
 
-        m.z = pe.Var()
+        m.z = pyo.Var()
         opt.add_variables([m.z])
         self.assertEqual(opt.get_model_attr('NumVars'), 3)
         opt.remove_variables([m.z])
@@ -595,12 +595,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
 
     def test_update1(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x**2 + m.y**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x**2 + m.y**2)
 
         opt = self.opt
         opt.set_instance(m)
@@ -616,12 +616,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
     def test_update2(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c2 = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c2 = pyo.Constraint(expr=m.x + m.y == 1)
 
         opt = self.opt
         opt.config.symbolic_solver_labels = True
@@ -638,18 +638,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
     def test_update3(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x**2 + m.y**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x**2 + m.y**2)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
-        m.c2 = pe.Constraint(expr=m.y >= m.x**2)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x**2)
         opt.add_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
         opt.remove_constraints([m.c2])
@@ -657,18 +657,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
     def test_update4(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x + m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x + m.y)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
-        m.c2 = pe.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x)
         opt.add_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
         opt.remove_constraints([m.c2])
@@ -676,12 +676,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
     def test_update5(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
         opt = self.opt
         opt.set_instance(m)
@@ -697,18 +697,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
     def test_update6(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
-        m.c2 = pe.SOSConstraint(var=m.x, sos=2)
+        m.c2 = pyo.SOSConstraint(var=m.x, sos=2)
         opt.add_sos_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
         opt.remove_sos_constraints([m.c2])
@@ -716,9 +716,9 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
     def test_update7(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
 
         opt = self.opt
         orig_only_child_vars = opt._only_child_vars

--- a/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tee import capture_output
@@ -28,16 +28,16 @@ if not opt.available():
 
 class TestBugs(unittest.TestCase):
     def test_mutable_params_with_remove_cons(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var()
 
-        m.p1 = pe.Param(mutable=True)
-        m.p2 = pe.Param(mutable=True)
+        m.p1 = pyo.Param(mutable=True)
+        m.p2 = pyo.Param(mutable=True)
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x + m.p1)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + m.p2)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x + m.p1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + m.p2)
 
         m.p1.value = 1
         m.p2.value = 1
@@ -52,19 +52,19 @@ class TestBugs(unittest.TestCase):
         self.assertAlmostEqual(res.best_feasible_objective, -8)
 
     def test_mutable_params_with_remove_vars(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
 
-        m.p1 = pe.Param(mutable=True)
-        m.p2 = pe.Param(mutable=True)
+        m.p1 = pyo.Param(mutable=True)
+        m.p2 = pyo.Param(mutable=True)
 
         m.y.setlb(m.p1)
         m.y.setub(m.p2)
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
 
         m.p1.value = -10
         m.p2.value = 10
@@ -83,16 +83,16 @@ class TestBugs(unittest.TestCase):
     def test_fix_and_unfix(self):
         # Tests issue https://github.com/Pyomo/pyomo/issues/3127
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var(domain=pe.Binary)
-        m.y = pe.Var(domain=pe.Binary)
-        m.fx = pe.Var(domain=pe.NonNegativeReals)
-        m.fy = pe.Var(domain=pe.NonNegativeReals)
-        m.c1 = pe.Constraint(expr=m.fx <= m.x)
-        m.c2 = pe.Constraint(expr=m.fy <= m.y)
-        m.c3 = pe.Constraint(expr=m.x + m.y <= 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.Binary)
+        m.y = pyo.Var(domain=pyo.Binary)
+        m.fx = pyo.Var(domain=pyo.NonNegativeReals)
+        m.fy = pyo.Var(domain=pyo.NonNegativeReals)
+        m.c1 = pyo.Constraint(expr=m.fx <= m.x)
+        m.c2 = pyo.Constraint(expr=m.fy <= m.y)
+        m.c3 = pyo.Constraint(expr=m.x + m.y <= 1)
 
-        m.obj = pe.Objective(expr=m.fx * 0.5 + m.fy * 0.4, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.fx * 0.5 + m.fy * 0.4, sense=pyo.maximize)
 
         opt = Highs()
 
@@ -124,13 +124,13 @@ class TestBugs(unittest.TestCase):
         # first time that a model is instantiated.  We need to test this
         # in a subprocess to trigger that output.
         model = [
-            'import pyomo.environ as pe',
-            'm = pe.ConcreteModel()',
-            'm.x = pe.Var(domain=pe.NonNegativeReals)',
-            'm.y = pe.Var(domain=pe.NonNegativeReals)',
-            'm.obj = pe.Objective(expr=m.x + m.y, sense=pe.maximize)',
-            'm.c1 = pe.Constraint(expr=m.x <= 10)',
-            'm.c2 = pe.Constraint(expr=m.y <= 5)',
+            'import pyomo.environ as pyo',
+            'm = pyo.ConcreteModel()',
+            'm.x = pyo.Var(domain=pyo.NonNegativeReals)',
+            'm.y = pyo.Var(domain=pyo.NonNegativeReals)',
+            'm.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)',
+            'm.c1 = pyo.Constraint(expr=m.x <= 10)',
+            'm.c2 = pyo.Constraint(expr=m.y <= 5)',
             'from pyomo.contrib.appsi.solvers.highs import Highs',
             'result = Highs().solve(m)',
             'print(m.x.value, m.y.value)',
@@ -157,21 +157,21 @@ class TestBugs(unittest.TestCase):
         self.assertEqual(ref, OUT.getvalue()[-len(ref) :])
 
     def test_warm_start(self):
-        m = pe.ConcreteModel()
+        m = pyo.ConcreteModel()
 
         # decision variables
-        m.x1 = pe.Var(domain=pe.Integers, name="x1", bounds=(0, 10))
-        m.x2 = pe.Var(domain=pe.Reals, name="x2", bounds=(0, 10))
-        m.x3 = pe.Var(domain=pe.Binary, name="x3")
+        m.x1 = pyo.Var(domain=pyo.Integers, name="x1", bounds=(0, 10))
+        m.x2 = pyo.Var(domain=pyo.Reals, name="x2", bounds=(0, 10))
+        m.x3 = pyo.Var(domain=pyo.Binary, name="x3")
 
         # objective function
-        m.OBJ = pe.Objective(expr=(3 * m.x1 + 2 * m.x2 + 4 * m.x3), sense=pe.maximize)
+        m.OBJ = pyo.Objective(expr=(3 * m.x1 + 2 * m.x2 + 4 * m.x3), sense=pyo.maximize)
 
         # constraints
-        m.C1 = pe.Constraint(expr=m.x1 + m.x2 <= 9)
-        m.C2 = pe.Constraint(expr=3 * m.x1 + m.x2 <= 18)
-        m.C3 = pe.Constraint(expr=m.x1 <= 7)
-        m.C4 = pe.Constraint(expr=m.x2 <= 6)
+        m.C1 = pyo.Constraint(expr=m.x1 + m.x2 <= 9)
+        m.C2 = pyo.Constraint(expr=3 * m.x1 + m.x2 <= 18)
+        m.C3 = pyo.Constraint(expr=m.x1 <= 7)
+        m.C4 = pyo.Constraint(expr=m.x2 <= 6)
 
         # MIP start
         m.x1 = 4
@@ -180,6 +180,6 @@ class TestBugs(unittest.TestCase):
 
         # solving process
         with capture_output() as output:
-            pe.SolverFactory("appsi_highs").solve(m, tee=True, warmstart=True)
+            pyo.SolverFactory("appsi_highs").solve(m, tee=True, warmstart=True)
         log = output.getvalue()
         self.assertIn("MIP start solution is feasible, objective value is 25", log)

--- a/pyomo/contrib/appsi/solvers/tests/test_ipopt_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_ipopt_persistent.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 from pyomo.contrib.appsi.cmodel import cmodel_available
 from pyomo.common.gsl import find_GSL
@@ -22,37 +22,37 @@ class TestIpoptPersistent(unittest.TestCase):
         if not DLL:
             self.skipTest('Could not find the amplgls.dll library')
 
-        opt = pe.SolverFactory('appsi_ipopt')
+        opt = pyo.SolverFactory('appsi_ipopt')
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.hypot = pe.ExternalFunction(library=DLL, function='gsl_hypot')
-        m.x = pe.Var(bounds=(-10, 10), initialize=2)
-        m.y = pe.Var(initialize=2)
+        m = pyo.ConcreteModel()
+        m.hypot = pyo.ExternalFunction(library=DLL, function='gsl_hypot')
+        m.x = pyo.Var(bounds=(-10, 10), initialize=2)
+        m.y = pyo.Var(initialize=2)
         e = 2 * m.hypot(m.x, m.x * m.y)
-        m.c = pe.Constraint(expr=e == 2.82843)
-        m.obj = pe.Objective(expr=m.x)
+        m.c = pyo.Constraint(expr=e == 2.82843)
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
-        pe.assert_optimal_termination(res)
-        self.assertAlmostEqual(pe.value(m.c.body) - pe.value(m.c.lower), 0)
+        pyo.assert_optimal_termination(res)
+        self.assertAlmostEqual(pyo.value(m.c.body) - pyo.value(m.c.lower), 0)
 
     def test_external_function_in_objective(self):
         DLL = find_GSL()
         if not DLL:
             self.skipTest('Could not find the amplgls.dll library')
 
-        opt = pe.SolverFactory('appsi_ipopt')
+        opt = pyo.SolverFactory('appsi_ipopt')
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.hypot = pe.ExternalFunction(library=DLL, function='gsl_hypot')
-        m.x = pe.Var(bounds=(1, 10), initialize=2)
-        m.y = pe.Var(bounds=(1, 10), initialize=2)
+        m = pyo.ConcreteModel()
+        m.hypot = pyo.ExternalFunction(library=DLL, function='gsl_hypot')
+        m.x = pyo.Var(bounds=(1, 10), initialize=2)
+        m.y = pyo.Var(bounds=(1, 10), initialize=2)
         e = 2 * m.hypot(m.x, m.x * m.y)
-        m.obj = pe.Objective(expr=e)
+        m.obj = pyo.Objective(expr=e)
         res = opt.solve(m)
-        pe.assert_optimal_termination(res)
+        pyo.assert_optimal_termination(res)
         self.assertAlmostEqual(m.x.value, 1)
         self.assertAlmostEqual(m.y.value, 1)

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.common.dependencies import attempt_import
 import pyomo.common.unittest as unittest
 
@@ -110,17 +110,17 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(2, None))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(2, None))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 2)
 
         del m.x
         del m.obj
-        m.x = pe.Var(bounds=(2, None))
-        m.obj = pe.Objective(expr=m.x)
+        m.x = pyo.Var(bounds=(2, None))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 2)
@@ -132,13 +132,13 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x)
         m.x.value = 1
         m.y.value = 1
         m.z.value = 1
@@ -177,17 +177,17 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.x)
-        m.c = pe.Constraint(expr=(-1, m.x, 1))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x)
+        m.c = pyo.Constraint(expr=(-1, m.x, 1))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, -1)
         if opt_class != MAiNGO:
             duals = opt.get_duals()
             self.assertAlmostEqual(duals[m.c], 1)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 1)
@@ -202,10 +202,10 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.y = pe.Var(bounds=(-2, 2))
-        m.obj = pe.Objective(expr=3 * m.x + 4 * m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.y = pyo.Var(bounds=(-2, 2))
+        m.obj = pyo.Objective(expr=3 * m.x + 4 * m.y)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, -1)
@@ -222,16 +222,16 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, -1)
         if opt_class != MAiNGO:
             rc = opt.get_reduced_costs()
             self.assertAlmostEqual(rc[m.x], 1)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 1)
@@ -246,16 +246,16 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -285,16 +285,16 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(initialize=-1)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(initialize=-1)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
 
         params_to_test = [(1, 2, 1), (1, 2, 1), (1, 3, 1)]
         for a1, b1, b2 in params_to_test:
@@ -320,16 +320,16 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y == m.a1 * m.x + m.b1)
-        m.c2 = pe.Constraint(expr=m.y == m.a2 * m.x + m.b2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y == m.a1 * m.x + m.b1)
+        m.c2 = pyo.Constraint(expr=m.y == m.a2 * m.x + m.b2)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -355,22 +355,22 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
         e = LinearExpression(
             constant=m.b1, linear_coefs=[-1, m.a1], linear_vars=[m.y, m.x]
         )
-        m.c1 = pe.Constraint(expr=e == 0)
+        m.c1 = pyo.Constraint(expr=e == 0)
         e = LinearExpression(
             constant=m.b2, linear_coefs=[-1, m.a2], linear_vars=[m.y, m.x]
         )
-        m.c2 = pe.Constraint(expr=e == 0)
+        m.c2 = pyo.Constraint(expr=e == 0)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -391,15 +391,15 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.c1 = pe.Constraint(expr=m.y == m.a1 * m.x + m.b1)
-        m.c2 = pe.Constraint(expr=m.y == m.a2 * m.x + m.b2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.c1 = pyo.Constraint(expr=m.y == m.a1 * m.x + m.b1)
+        m.c2 = pyo.Constraint(expr=m.y == m.a2 * m.x + m.b2)
         opt.config.stream_solver = True
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
@@ -426,18 +426,18 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
         a1 = -1
         a2 = 1
         b1 = 1
         b2 = 2
         a3 = 1
         b3 = 3
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-        m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+        m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
@@ -449,7 +449,7 @@ class TestSolvers(unittest.TestCase):
             self.assertAlmostEqual(duals[m.c1], -(1 + a1 / (a2 - a1)))
             self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
-        m.c3 = pe.Constraint(expr=m.y >= a3 * m.x + b3)
+        m.c3 = pyo.Constraint(expr=m.y >= a3 * m.x + b3)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, (b3 - b1) / (a1 - a3))
@@ -481,12 +481,12 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 1)
         with self.assertRaises(Exception):
             res = opt.solve(m)
         opt.config.load_solution = False
@@ -526,12 +526,12 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y - m.x >= 0)
-        m.c2 = pe.Constraint(expr=m.y + m.x - 2 >= 0)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y - m.x >= 0)
+        m.c2 = pyo.Constraint(expr=m.y + m.x - 2 >= 0)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 1)
@@ -552,13 +552,13 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=-1, mutable=True)
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=-1, mutable=True)
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.41024548525899274, 4)
@@ -576,15 +576,15 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=-1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.d = pe.Param(initialize=1, mutable=True)
-        m.obj = pe.Objective(expr=m.x**2 + m.c * m.y**2 + m.d * m.x)
-        m.ccon = pe.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=-1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.d = pyo.Param(initialize=1, mutable=True)
+        m.obj = pyo.Objective(expr=m.x**2 + m.c * m.y**2 + m.d * m.x)
+        m.ccon = pyo.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.2719178742733325, 4)
@@ -605,17 +605,17 @@ class TestSolvers(unittest.TestCase):
             opt.update_config.treat_fixed_vars_as_params = treat_fixed_vars_as_params
             if not opt.available():
                 raise unittest.SkipTest
-            m = pe.ConcreteModel()
-            m.x = pe.Var()
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var()
             m.x.fix(0)
-            m.y = pe.Var()
+            m.y = pyo.Var()
             a1 = 1
             a2 = -1
             b1 = 1
             b2 = 2
-            m.obj = pe.Objective(expr=m.y)
-            m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-            m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+            m.obj = pyo.Objective(expr=m.y)
+            m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+            m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
             res = opt.solve(m)
             self.assertAlmostEqual(m.x.value, 0)
             self.assertAlmostEqual(m.y.value, 2)
@@ -644,17 +644,17 @@ class TestSolvers(unittest.TestCase):
         opt.update_config.treat_fixed_vars_as_params = True
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         m.x.fix(0)
-        m.y = pe.Var()
+        m.y = pyo.Var()
         a1 = 1
         a2 = -1
         b1 = 1
         b2 = 2
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-        m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+        m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 2)
@@ -683,11 +683,11 @@ class TestSolvers(unittest.TestCase):
         opt.update_config.treat_fixed_vars_as_params = True
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c1 = pe.Constraint(expr=m.x == 2 / m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c1 = pyo.Constraint(expr=m.x == 2 / m.y)
         m.y.fix(1)
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 2)
@@ -700,11 +700,11 @@ class TestSolvers(unittest.TestCase):
         opt.update_config.treat_fixed_vars_as_params = True
         if not opt.available() or opt_class == MAiNGO:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.x == 2 / m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.x == 2 / m.y)
         m.y.fix(1)
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 2)
@@ -724,18 +724,18 @@ class TestSolvers(unittest.TestCase):
             import numpy as np
         except:
             raise unittest.SkipTest('numpy is not available')
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(initialize=0, mutable=True)
-        m.a2 = pe.Param(initialize=0, mutable=True)
-        m.b1 = pe.Param(initialize=0, mutable=True)
-        m.b2 = pe.Param(initialize=0, mutable=True)
-        m.c1 = pe.Param(initialize=0, mutable=True)
-        m.c2 = pe.Param(initialize=0, mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.con1 = pe.Constraint(expr=(m.b1, m.y - m.a1 * m.x, m.c1))
-        m.con2 = pe.Constraint(expr=(m.b2, m.y - m.a2 * m.x, m.c2))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(initialize=0, mutable=True)
+        m.a2 = pyo.Param(initialize=0, mutable=True)
+        m.b1 = pyo.Param(initialize=0, mutable=True)
+        m.b2 = pyo.Param(initialize=0, mutable=True)
+        m.c1 = pyo.Param(initialize=0, mutable=True)
+        m.c2 = pyo.Param(initialize=0, mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.con1 = pyo.Constraint(expr=(m.b1, m.y - m.a1 * m.x, m.c1))
+        m.con2 = pyo.Constraint(expr=(m.b2, m.y - m.a2 * m.x, m.c2))
 
         np.random.seed(0)
         params_to_test = [
@@ -746,7 +746,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.minimize,
+                pyo.minimize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -755,7 +755,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.maximize,
+                pyo.maximize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -764,7 +764,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.minimize,
+                pyo.minimize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -773,7 +773,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.maximize,
+                pyo.maximize,
             ),
         ]
         for a1, a2, b1, b2, c1, c2, sense in params_to_test:
@@ -786,7 +786,7 @@ class TestSolvers(unittest.TestCase):
             m.obj.sense = sense
             res: Results = opt.solve(m)
             self.assertEqual(res.termination_condition, TerminationCondition.optimal)
-            if sense is pe.minimize:
+            if sense is pyo.minimize:
                 self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2), 6)
                 self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1, 6)
                 self.assertAlmostEqual(res.best_feasible_objective, m.y.value, 6)
@@ -812,9 +812,9 @@ class TestSolvers(unittest.TestCase):
         opt = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.y = pe.Var(bounds=(-1, None))
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.y = pyo.Var(bounds=(-1, None))
+        m.obj = pyo.Objective(expr=m.y)
         opt.update_config.update_params = False
         opt.update_config.update_vars = False
         opt.update_config.update_constraints = False
@@ -827,13 +827,13 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         opt.load_vars()
         self.assertAlmostEqual(m.y.value, -1)
-        m.x = pe.Var()
+        m.x = pyo.Var()
         a1 = 1
         a2 = -1
         b1 = 2
         b2 = 1
-        m.c1 = pe.Constraint(expr=(0, m.y - a1 * m.x - b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + a2 * m.x + b2, 0))
+        m.c1 = pyo.Constraint(expr=(0, m.y - a1 * m.x - b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + a2 * m.x + b2, 0))
         if only_child_vars:
             opt.add_variables([m.x])
         opt.add_constraints([m.c1, m.c2])
@@ -859,11 +859,11 @@ class TestSolvers(unittest.TestCase):
         opt = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= pe.exp(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= pyo.exp(m.x))
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, -0.42630274815985264, 6)
         self.assertAlmostEqual(m.y.value, 0.6529186341994245, 6)
@@ -873,11 +873,11 @@ class TestSolvers(unittest.TestCase):
         opt = opt_class(only_child_vars=only_child_vars)
         if not opt.available() or opt_class == MAiNGO:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(initialize=1)
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y <= pe.log(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1)
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y <= pyo.log(m.x))
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.6529186341994245)
         self.assertAlmostEqual(m.y.value, -0.42630274815985264)
@@ -889,18 +889,18 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
         a1 = 1
         b1 = 3
         a2 = -2
         b2 = 1
-        m.c1 = pe.Constraint(
+        m.c1 = pyo.Constraint(
             expr=(numpy.float64(0), m.y - numpy.int64(1) * m.x - numpy.float32(3), None)
         )
-        m.c2 = pe.Constraint(
+        m.c2 = pyo.Constraint(
             expr=(
                 None,
                 -m.y + numpy.int32(-2) * m.x + numpy.float64(1),
@@ -919,12 +919,12 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.y = pe.Var()
-        m.p = pe.Param(mutable=True)
+        m = pyo.ConcreteModel()
+        m.y = pyo.Var()
+        m.p = pyo.Param(mutable=True)
         m.y.setlb(m.p)
         m.p.value = 1
-        m.obj = pe.Objective(expr=m.y)
+        m.obj = pyo.Objective(expr=m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 1)
         m.p.value = -1
@@ -932,7 +932,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, -1)
         m.y.setlb(None)
         m.y.setub(m.p)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         m.p.value = 5
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 5)
@@ -941,7 +941,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 4)
         m.y.setub(None)
         m.y.setlb(m.p)
-        m.obj.sense = pe.minimize
+        m.obj.sense = pyo.minimize
         m.p.value = 3
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 3)
@@ -954,13 +954,13 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.p = pe.Param(mutable=False, initialize=1)
-        m.q = pe.Param([1, 2], mutable=False, initialize=10)
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.p = pyo.Param(mutable=False, initialize=1)
+        m.q = pyo.Param([1, 2], mutable=False, initialize=10)
+        m.y = pyo.Var()
         m.y.setlb(m.p)
         m.y.setub(m.q[1])
-        m.obj = pe.Objective(expr=m.y)
+        m.obj = pyo.Objective(expr=m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 1)
         m.y.setlb(m.q[2])
@@ -974,12 +974,12 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(1, None))
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.x, None))
-        m.c2 = pe.Constraint(expr=(0, m.y - m.x + 1, None))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(1, None))
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.x, None))
+        m.c2 = pyo.Constraint(expr=(0, m.y - m.x + 1, None))
         opt.config.load_solution = False
         res = opt.solve(m)
         self.assertIsNone(m.x.value)
@@ -1034,10 +1034,10 @@ class TestSolvers(unittest.TestCase):
             raise unittest.SkipTest
 
         N = 30
-        m = pe.ConcreteModel()
-        m.jobs = pe.Set(initialize=list(range(N)))
-        m.tasks = pe.Set(initialize=list(range(N)))
-        m.x = pe.Var(m.jobs, m.tasks, bounds=(0, 1))
+        m = pyo.ConcreteModel()
+        m.jobs = pyo.Set(initialize=list(range(N)))
+        m.tasks = pyo.Set(initialize=list(range(N)))
+        m.x = pyo.Var(m.jobs, m.tasks, bounds=(0, 1))
 
         random.seed(0)
         coefs = list()
@@ -1049,10 +1049,10 @@ class TestSolvers(unittest.TestCase):
         obj_expr = LinearExpression(
             linear_coefs=coefs, linear_vars=lin_vars, constant=0
         )
-        m.obj = pe.Objective(expr=obj_expr, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=obj_expr, sense=pyo.maximize)
 
-        m.c1 = pe.Constraint(m.jobs)
-        m.c2 = pe.Constraint(m.tasks)
+        m.c1 = pyo.Constraint(m.jobs)
+        m.c2 = pyo.Constraint(m.tasks)
         for j in m.jobs:
             expr = LinearExpression(
                 linear_coefs=[1] * N,
@@ -1090,21 +1090,21 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c1 = pe.Constraint(expr=m.y >= m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c1 = pyo.Constraint(expr=m.y >= m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
+        m.obj = pyo.Objective(expr=m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
-        m.obj = pe.Objective(expr=2 * m.y)
+        m.obj = pyo.Objective(expr=2 * m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 2)
         m.obj.expr = 3 * m.y
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 3)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         opt.config.load_solution = False
         res = opt.solve(m)
         if opt_class != MAiNGO:
@@ -1115,9 +1115,9 @@ class TestSolvers(unittest.TestCase):
                     TerminationCondition.infeasibleOrUnbounded,
                 },
             )
-        m.obj.sense = pe.minimize
+        m.obj.sense = pyo.minimize
         opt.config.load_solution = True
-        m.obj = pe.Objective(expr=m.x * m.y)
+        m.obj = pyo.Objective(expr=m.x * m.y)
         m.x.fix(2)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 6, 6)
@@ -1133,8 +1133,8 @@ class TestSolvers(unittest.TestCase):
         m.y.unfix()
         m.x.setlb(None)
         m.x.setub(None)
-        m.e = pe.Expression(expr=2)
-        m.obj = pe.Objective(expr=m.e * m.y)
+        m.e = pyo.Expression(expr=2)
+        m.obj = pyo.Objective(expr=m.e * m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 2)
         m.e.expr = 3
@@ -1152,9 +1152,9 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(1, None), domain=pe.NonNegativeReals)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(1, None), domain=pyo.NonNegativeReals)
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
         m.x.setlb(-1)
@@ -1164,10 +1164,10 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
         m.x.setlb(-1)
-        m.x.domain = pe.Reals
+        m.x.domain = pyo.Reals
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, -1)
-        m.x.domain = pe.NonNegativeReals
+        m.x.domain = pyo.NonNegativeReals
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 0)
 
@@ -1178,19 +1178,19 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, None), domain=pe.NonNegativeIntegers)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, None), domain=pyo.NonNegativeIntegers)
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 0)
         m.x.setlb(0.5)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
         m.x.setlb(-5.5)
-        m.x.domain = pe.Integers
+        m.x.domain = pyo.Integers
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, -5)
-        m.x.domain = pe.Binary
+        m.x.domain = pyo.Binary
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 0)
         m.x.setlb(0.5)
@@ -1204,11 +1204,11 @@ class TestSolvers(unittest.TestCase):
         opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
         if not opt.available():
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var(domain=pe.Binary)
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c = pe.Constraint(expr=m.y >= m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.Binary)
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c = pyo.Constraint(expr=m.y >= m.x)
         m.x.fix(0)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 0, 5)
@@ -1233,18 +1233,18 @@ class TestSolvers(unittest.TestCase):
         if not opt.available():
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var(bounds=(-10, 10))
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var(bounds=(-10, 10))
+        m.obj = pyo.Objective(expr=m.y)
         m.d1 = gdp.Disjunct()
-        m.d1.c1 = pe.Constraint(expr=m.y >= m.x + 2)
-        m.d1.c2 = pe.Constraint(expr=m.y >= -m.x + 2)
+        m.d1.c1 = pyo.Constraint(expr=m.y >= m.x + 2)
+        m.d1.c2 = pyo.Constraint(expr=m.y >= -m.x + 2)
         m.d2 = gdp.Disjunct()
-        m.d2.c1 = pe.Constraint(expr=m.y >= m.x + 1)
-        m.d2.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.d2.c1 = pyo.Constraint(expr=m.y >= m.x + 1)
+        m.d2.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
         m.disjunction = gdp.Disjunction(expr=[m.d2, m.d1])
-        pe.TransformationFactory("gdp.bigm").apply_to(m)
+        pyo.TransformationFactory("gdp.bigm").apply_to(m)
 
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1, 6)
@@ -1264,13 +1264,13 @@ class TestSolvers(unittest.TestCase):
         if not opt.available():
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.b = pe.Block()
-        m.b.obj = pe.Objective(expr=m.y)
-        m.b.c1 = pe.Constraint(expr=m.y >= m.x + 2)
-        m.b.c2 = pe.Constraint(expr=m.y >= -m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.b = pyo.Block()
+        m.b.obj = pyo.Objective(expr=m.y)
+        m.b.c1 = pyo.Constraint(expr=m.y >= m.x + 2)
+        m.b.c2 = pyo.Constraint(expr=m.y >= -m.x)
 
         res = opt.solve(m.b)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
@@ -1291,16 +1291,16 @@ class TestSolvers(unittest.TestCase):
         if not opt.available():
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x)
-        m.c3 = pe.Constraint(expr=m.y >= m.z + 1)
-        m.c4 = pe.Constraint(expr=m.y >= -m.z + 1)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x)
+        m.c3 = pyo.Constraint(expr=m.y >= m.z + 1)
+        m.c4 = pyo.Constraint(expr=m.y >= -m.z + 1)
 
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
@@ -1326,13 +1326,13 @@ class TestSolvers(unittest.TestCase):
         if not opt.available():
             raise unittest.SkipTest
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(3, 7))
-        m.y = pe.Var(bounds=(-10, 10))
-        m.p = pe.Param(mutable=True, initialize=0)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(3, 7))
+        m.y = pyo.Var(bounds=(-10, 10))
+        m.p = pyo.Param(mutable=True, initialize=0)
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c = pe.Constraint(expr=m.y >= m.p * m.x)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c = pyo.Constraint(expr=m.y >= m.p * m.x)
 
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
@@ -1355,11 +1355,11 @@ class TestSolvers(unittest.TestCase):
                 raise unittest.SkipTest
             opt.update_config.treat_fixed_vars_as_params = fixed_var_option
 
-            m = pe.ConcreteModel()
-            m.x = pe.Var(bounds=(-10, 10))
-            m.y = pe.Var()
-            m.obj = pe.Objective(expr=3 * m.y - m.x)
-            m.c = pe.Constraint(expr=m.y >= m.x)
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var(bounds=(-10, 10))
+            m.y = pyo.Var()
+            m.obj = pyo.Objective(expr=3 * m.y - m.x)
+            m.c = pyo.Constraint(expr=m.y >= m.x)
 
             m.x.fix(1)
             res = opt.solve(m)
@@ -1376,21 +1376,21 @@ class TestSolvers(unittest.TestCase):
 class TestLegacySolverInterface(unittest.TestCase):
     @parameterized.expand(input=all_solvers)
     def test_param_updates(self, name: str, opt_class: Type[PersistentSolver]):
-        opt = pe.SolverFactory('appsi_' + name)
+        opt = pyo.SolverFactory('appsi_' + name)
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
         if opt_class != MAiNGO:
-            m.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+            m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -1399,7 +1399,7 @@ class TestLegacySolverInterface(unittest.TestCase):
             m.b1.value = b1
             m.b2.value = b2
             res = opt.solve(m)
-            pe.assert_optimal_termination(res)
+            pyo.assert_optimal_termination(res)
             self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
             self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1)
             if opt_class != MAiNGO:
@@ -1408,17 +1408,17 @@ class TestLegacySolverInterface(unittest.TestCase):
 
     @parameterized.expand(input=all_solvers)
     def test_load_solutions(self, name: str, opt_class: Type[PersistentSolver]):
-        opt = pe.SolverFactory('appsi_' + name)
+        opt = pyo.SolverFactory('appsi_' + name)
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.x)
-        m.c = pe.Constraint(expr=(-1, m.x, 1))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x)
+        m.c = pyo.Constraint(expr=(-1, m.x, 1))
         if opt_class != MAiNGO:
-            m.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+            m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
         res = opt.solve(m, load_solutions=False)
-        pe.assert_optimal_termination(res)
+        pyo.assert_optimal_termination(res)
         self.assertIsNone(m.x.value)
         if opt_class != MAiNGO:
             self.assertNotIn(m.c, m.dual)

--- a/pyomo/contrib/appsi/solvers/tests/test_wntr_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_wntr_persistent.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 from pyomo.contrib.appsi.base import TerminationCondition, Results, PersistentSolver
 from pyomo.contrib.appsi.solvers.wntr import Wntr, wntr_available
@@ -22,10 +22,10 @@ _default_wntr_options = dict(TOL=1e-8)
 @unittest.skipUnless(wntr_available, 'wntr is not available')
 class TestWntrPersistent(unittest.TestCase):
     def test_param_updates(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.p = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Constraint(expr=m.x == m.p)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.p = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Constraint(expr=m.x == m.p)
         opt = Wntr()
         opt.wntr_options.update(_default_wntr_options)
         res = opt.solve(m)
@@ -38,11 +38,11 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 2)
 
     def test_remove_add_constraint(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c1 = pe.Constraint(expr=m.y == (m.x - 1) ** 2)
-        m.c2 = pe.Constraint(expr=m.y == pe.exp(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c1 = pyo.Constraint(expr=m.y == (m.x - 1) ** 2)
+        m.c2 = pyo.Constraint(expr=m.y == pyo.exp(m.x))
         opt = Wntr()
         opt.config.symbolic_solver_labels = True
         opt.wntr_options.update(_default_wntr_options)
@@ -52,7 +52,7 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 1)
 
         del m.c2
-        m.c2 = pe.Constraint(expr=m.y == pe.log(m.x))
+        m.c2 = pyo.Constraint(expr=m.y == pyo.log(m.x))
         m.x.value = 0.5
         m.y.value = 0.5
         res = opt.solve(m)
@@ -61,10 +61,10 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 0)
 
     def test_fixed_var(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c1 = pe.Constraint(expr=m.y == (m.x - 1) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c1 = pyo.Constraint(expr=m.y == (m.x - 1) ** 2)
         m.x.fix(0.5)
         opt = Wntr()
         opt.wntr_options.update(_default_wntr_options)
@@ -74,7 +74,7 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 0.25)
 
         m.x.unfix()
-        m.c2 = pe.Constraint(expr=m.y == pe.exp(m.x))
+        m.c2 = pyo.Constraint(expr=m.y == pyo.exp(m.x))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 0)
@@ -88,15 +88,15 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 0.25)
 
     def test_remove_variables_params(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
         m.z.fix(0)
-        m.px = pe.Param(mutable=True, initialize=1)
-        m.py = pe.Param(mutable=True, initialize=1)
-        m.c1 = pe.Constraint(expr=m.x == m.px)
-        m.c2 = pe.Constraint(expr=m.y == m.py)
+        m.px = pyo.Param(mutable=True, initialize=1)
+        m.py = pyo.Param(mutable=True, initialize=1)
+        m.c1 = pyo.Constraint(expr=m.x == m.px)
+        m.c2 = pyo.Constraint(expr=m.y == m.py)
         opt = Wntr()
         opt.wntr_options.update(_default_wntr_options)
         res = opt.solve(m)
@@ -122,11 +122,11 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 3)
 
     def test_get_primals(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c1 = pe.Constraint(expr=m.y == (m.x - 1) ** 2)
-        m.c2 = pe.Constraint(expr=m.y == pe.exp(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c1 = pyo.Constraint(expr=m.y == (m.x - 1) ** 2)
+        m.c2 = pyo.Constraint(expr=m.y == pyo.exp(m.x))
         opt = Wntr()
         opt.config.load_solution = False
         opt.wntr_options.update(_default_wntr_options)
@@ -139,9 +139,9 @@ class TestWntrPersistent(unittest.TestCase):
         self.assertAlmostEqual(primals[m.y], 1)
 
     def test_operators(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(initialize=1)
-        m.c1 = pe.Constraint(expr=2 / m.x == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1)
+        m.c1 = pyo.Constraint(expr=2 / m.x == 1)
         opt = Wntr()
         opt.wntr_options.update(_default_wntr_options)
         res = opt.solve(m)
@@ -150,44 +150,44 @@ class TestWntrPersistent(unittest.TestCase):
 
         del m.c1
         m.x.value = 0
-        m.c1 = pe.Constraint(expr=pe.sin(m.x) == math.sin(math.pi / 4))
+        m.c1 = pyo.Constraint(expr=pyo.sin(m.x) == math.sin(math.pi / 4))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, math.pi / 4)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.cos(m.x) == 0)
+        m.c1 = pyo.Constraint(expr=pyo.cos(m.x) == 0)
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, math.pi / 2)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.tan(m.x) == 1)
+        m.c1 = pyo.Constraint(expr=pyo.tan(m.x) == 1)
         m.x.value = 0
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, math.pi / 4)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.asin(m.x) == math.asin(0.5))
+        m.c1 = pyo.Constraint(expr=pyo.asin(m.x) == math.asin(0.5))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 0.5)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.acos(m.x) == math.acos(0.6))
+        m.c1 = pyo.Constraint(expr=pyo.acos(m.x) == math.acos(0.6))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 0.6)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.atan(m.x) == math.atan(0.5))
+        m.c1 = pyo.Constraint(expr=pyo.atan(m.x) == math.atan(0.5))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 0.5)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=pe.sqrt(m.x) == math.sqrt(0.6))
+        m.c1 = pyo.Constraint(expr=pyo.sqrt(m.x) == math.sqrt(0.6))
         res = opt.solve(m)
         self.assertEqual(res.termination_condition, TerminationCondition.optimal)
         self.assertAlmostEqual(m.x.value, 0.6)

--- a/pyomo/contrib/appsi/tests/test_base.py
+++ b/pyomo/contrib/appsi/tests/test_base.py
@@ -11,7 +11,7 @@
 
 from pyomo.common import unittest
 from pyomo.contrib import appsi
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.core.base.var import ScalarVar
 
 
@@ -42,11 +42,11 @@ class TestResults(unittest.TestCase):
             res.solution_loader.get_slacks()
 
     def test_results(self):
-        m = pe.ConcreteModel()
+        m = pyo.ConcreteModel()
         m.x = ScalarVar()
         m.y = ScalarVar()
-        m.c1 = pe.Constraint(expr=m.x == 1)
-        m.c2 = pe.Constraint(expr=m.y == 2)
+        m.c1 = pyo.Constraint(expr=m.x == 1)
+        m.c2 = pyo.Constraint(expr=m.y == 2)
 
         primals = dict()
         primals[id(m.x)] = (m.x, 1)

--- a/pyomo/contrib/appsi/utils/tests/test_collect_vars_and_named_exprs.py
+++ b/pyomo/contrib/appsi/utils/tests/test_collect_vars_and_named_exprs.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 from pyomo.common import unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib.appsi.utils import collect_vars_and_named_exprs
 from pyomo.contrib.appsi.cmodel import cmodel, cmodel_available
 from typing import Callable
@@ -19,11 +19,11 @@ from pyomo.common.gsl import find_GSL
 
 class TestCollectVarsAndNamedExpressions(unittest.TestCase):
     def basics_helper(self, collector: Callable, *args):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.E = pe.Expression(expr=2 * m.z + 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.E = pyo.Expression(expr=2 * m.z + 1)
         m.y.fix(3)
         e = m.x * m.y + m.x * m.E
         named_exprs, var_list, fixed_vars, external_funcs = collector(e, *args)
@@ -44,13 +44,13 @@ class TestCollectVarsAndNamedExpressions(unittest.TestCase):
         if not DLL:
             self.skipTest('Could not find amplgsl.dll library')
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.hypot = pe.ExternalFunction(library=DLL, function='gsl_hypot')
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.hypot = pyo.ExternalFunction(library=DLL, function='gsl_hypot')
         func = m.hypot(m.x, m.x * m.y)
-        m.E = pe.Expression(expr=2 * func)
+        m.E = pyo.Expression(expr=2 * func)
         m.y.fix(3)
         e = m.z + m.x * m.E
         named_exprs, var_list, fixed_vars, external_funcs = collector(e, *args)

--- a/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
+++ b/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
@@ -11,7 +11,7 @@
 
 import pyomo.common.unittest as unittest
 from pyomo.common.tempfiles import TempfileManager
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib import appsi
 from pyomo.contrib.appsi.cmodel import cmodel_available
 import os
@@ -20,12 +20,12 @@ import os
 @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestNLWriter(unittest.TestCase):
     def test_all_vars_fixed(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= pe.exp(m.x))
-        m.c2 = pe.Constraint(expr=m.y >= (m.x - 1) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= pyo.exp(m.x))
+        m.c2 = pyo.Constraint(expr=m.y >= (m.x - 1) ** 2)
         m.x.fix(1)
         m.y.fix(2)
         writer = appsi.writers.NLWriter()
@@ -46,11 +46,11 @@ class TestNLWriter(unittest.TestCase):
                     self.assertTrue(line.startswith(correct_lines[ndx]))
 
     def test_header_1(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -66,11 +66,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_2(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y)
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y)
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -86,11 +86,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_3(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -106,11 +106,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_4(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y)
-        m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -126,11 +126,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_5(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -146,11 +146,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_6(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y)
-        m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -166,11 +166,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_7(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c = pyo.Constraint(expr=m.x + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -186,11 +186,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_8(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -206,11 +206,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_9(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y**2)
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y**2)
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -226,11 +226,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_10(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y**2)
-        m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y**2)
+        m.c = pyo.Constraint(expr=m.x + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -246,11 +246,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_11(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y**2)
-        m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y**2)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -266,11 +266,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_12(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y**2)
-        m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y**2)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -286,11 +286,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_13(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y)
-        m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y)
+        m.c = pyo.Constraint(expr=m.x + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -306,11 +306,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_14(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -326,11 +326,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_15(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.x + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',
@@ -346,11 +346,11 @@ class TestNLWriter(unittest.TestCase):
         self._write_and_check_header(m, correct_lines)
 
     def test_header_16(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.x**2 + m.y**2 == 1)
         correct_lines = [
             'g3 1 1 0',
             '2 1 1 0 1',

--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -69,13 +69,13 @@ on either x or y.
 
 .. testcode::
 
-   import pyomo.environ as pe
-   m = pe.ConcreteModel()
-   m.x = pe.Var(bounds=(-1,1))
-   m.y = pe.Var(bounds=(-2,2))
-   m.z = pe.Var()
+   import pyomo.environ as pyo
+   m = pyo.ConcreteModel()
+   m.x = pyo.Var(bounds=(-1,1))
+   m.y = pyo.Var(bounds=(-2,2))
+   m.z = pyo.Var()
    from pyomo.contrib.fbbt.fbbt import fbbt
-   m.c = pe.Constraint(expr=m.x*m.y + m.z == 1)
+   m.c = pyo.Constraint(expr=m.x*m.y + m.z == 1)
    fbbt(m)
    print(f"z bounds = {m.z.bounds}")
 
@@ -1298,13 +1298,13 @@ def _fbbt_con(con, config):
     in the constraint based on the bounds of the constraint and the bounds of the other variables in the constraint.
     For example:
 
-    >>> import pyomo.environ as pe
+    >>> import pyomo.environ as pyo
     >>> from pyomo.contrib.fbbt.fbbt import fbbt
-    >>> m = pe.ConcreteModel()
-    >>> m.x = pe.Var(bounds=(-1,1))
-    >>> m.y = pe.Var(bounds=(-2,2))
-    >>> m.z = pe.Var()
-    >>> m.c = pe.Constraint(expr=m.x*m.y + m.z == 1)
+    >>> m = pyo.ConcreteModel()
+    >>> m.x = pyo.Var(bounds=(-1,1))
+    >>> m.y = pyo.Var(bounds=(-2,2))
+    >>> m.z = pyo.Var()
+    >>> m.c = pyo.Constraint(expr=m.x*m.y + m.z == 1)
     >>> fbbt(m.c)
     >>> print(m.z.lb, m.z.ub)
     -1.0 3.0

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.core.base import ConcreteModel, Var, Constraint, Objective
 from pyomo.common.dependencies import attempt_import
 

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -10,7 +10,6 @@
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
-import pyomo.environ as pyo
 from pyomo.core.base import ConcreteModel, Var, Constraint, Objective
 from pyomo.common.dependencies import attempt_import
 

--- a/pyomo/contrib/pynumero/examples/external_grey_box/external_with_objective.py
+++ b/pyomo/contrib/pynumero/examples/external_grey_box/external_with_objective.py
@@ -12,7 +12,7 @@
 import math
 import numpy as np
 from scipy.sparse import coo_matrix
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib.pynumero.interfaces.external_grey_box import (
     ExternalGreyBoxModel,
     ExternalGreyBoxBlock,
@@ -107,15 +107,15 @@ class ConstrainedWithHessian(Constrained):
 
 
 def solve_unconstrained():
-    m = pe.ConcreteModel()
-    m.z = pe.Var()
+    m = pyo.ConcreteModel()
+    m.z = pyo.Var()
     m.grey_box = ExternalGreyBoxBlock(external_model=Unconstrained())
-    m.c = pe.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
+    m.c = pyo.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
 
-    opt = pe.SolverFactory('cyipopt')
+    opt = pyo.SolverFactory('cyipopt')
     opt.config.options['hessian_approximation'] = 'limited-memory'
     res = opt.solve(m, tee=True)
-    pe.assert_optimal_termination(res)
+    pyo.assert_optimal_termination(res)
     x = m.grey_box.inputs['x'].value
     y = m.grey_box.inputs['y'].value
     assert math.isclose(x, -2)
@@ -124,15 +124,15 @@ def solve_unconstrained():
 
 
 def solve_constrained():
-    m = pe.ConcreteModel()
-    m.z = pe.Var()
+    m = pyo.ConcreteModel()
+    m.z = pyo.Var()
     m.grey_box = ExternalGreyBoxBlock(external_model=Constrained())
-    m.c2 = pe.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
+    m.c2 = pyo.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
 
-    opt = pe.SolverFactory('cyipopt')
+    opt = pyo.SolverFactory('cyipopt')
     opt.config.options['hessian_approximation'] = 'limited-memory'
     res = opt.solve(m, tee=True)
-    pe.assert_optimal_termination(res)
+    pyo.assert_optimal_termination(res)
     x = m.grey_box.inputs['x'].value
     y = m.grey_box.inputs['y'].value
     assert math.isclose(x, -0.4263027509962655)
@@ -141,14 +141,14 @@ def solve_constrained():
 
 
 def solve_constrained_with_hessian():
-    m = pe.ConcreteModel()
-    m.z = pe.Var()
+    m = pyo.ConcreteModel()
+    m.z = pyo.Var()
     m.grey_box = ExternalGreyBoxBlock(external_model=ConstrainedWithHessian())
-    m.c2 = pe.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
+    m.c2 = pyo.Constraint(expr=m.z == m.grey_box.inputs['x'] + 1)
 
-    opt = pe.SolverFactory('cyipopt')
+    opt = pyo.SolverFactory('cyipopt')
     res = opt.solve(m, tee=True)
-    pe.assert_optimal_termination(res)
+    pyo.assert_optimal_termination(res)
     x = m.grey_box.inputs['x'].value
     y = m.grey_box.inputs['y'].value
     assert math.isclose(x, -0.4263027509962655)

--- a/pyomo/contrib/pynumero/examples/tests/test_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_examples.py
@@ -25,9 +25,9 @@ if not AmplInterface.available():
 from pyomo.contrib.pynumero.linalg.mumps_interface import mumps_available
 from pyomo.contrib.pynumero.linalg.scipy_interface import ScipyLU
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
-ipopt_opt = pe.SolverFactory('ipopt')
+ipopt_opt = pyo.SolverFactory('ipopt')
 ipopt_available = ipopt_opt.available(exception_flag=False)
 
 from pyomo.contrib.pynumero.examples import (

--- a/pyomo/contrib/simplification/tests/test_simplification.py
+++ b/pyomo/contrib/simplification/tests/test_simplification.py
@@ -17,7 +17,7 @@ from pyomo.core.expr.compare import assertExpressionsEqual, compare_expressions
 from pyomo.core.expr.calculus.diff_with_pyomo import reverse_sd
 from pyomo.core.expr.sympy_tools import sympy_available
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 
 
 class SimplificationMixin:
@@ -30,9 +30,9 @@ class SimplificationMixin:
         self.assertTrue(success)
 
     def test_simplify(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var(bounds=(0, None))
-        e = x * pe.log(x)
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var(bounds=(0, None))
+        e = x * pyo.log(x)
         der1 = reverse_sd(e)[x]
         der2 = reverse_sd(der1)[x]
         der2_simp = self.simp.simplify(der2)
@@ -40,40 +40,40 @@ class SimplificationMixin:
         assertExpressionsEqual(self, expected, der2_simp)
 
     def test_mul(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
         e = 2 * x
         e2 = self.simp.simplify(e)
         expected = 2.0 * x
         assertExpressionsEqual(self, expected, e2)
 
     def test_sum(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
         e = 2 + x
         e2 = self.simp.simplify(e)
         self.compare_against_possible_results(e2, [2.0 + x, x + 2.0])
 
     def test_neg(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
-        e = -pe.log(x)
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
+        e = -pyo.log(x)
         e2 = self.simp.simplify(e)
         self.compare_against_possible_results(
-            e2, [(-1.0) * pe.log(x), pe.log(x) * (-1.0), -pe.log(x)]
+            e2, [(-1.0) * pyo.log(x), pyo.log(x) * (-1.0), -pyo.log(x)]
         )
 
     def test_pow(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
         e = x**2.0
         e2 = self.simp.simplify(e)
         assertExpressionsEqual(self, e, e2)
 
     def test_div(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
-        y = m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
+        y = m.y = pyo.Var()
         e = x / y + y / x - x / y
         e2 = self.simp.simplify(e)
         self.compare_against_possible_results(
@@ -81,18 +81,18 @@ class SimplificationMixin:
         )
 
     def test_unary(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
-        func_list = [pe.log, pe.sin, pe.cos, pe.tan, pe.asin, pe.acos, pe.atan]
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
+        func_list = [pyo.log, pyo.sin, pyo.cos, pyo.tan, pyo.asin, pyo.acos, pyo.atan]
         for func in func_list:
             e = func(x)
             e2 = self.simp.simplify(e)
             assertExpressionsEqual(self, e, e2)
 
     def test_param(self):
-        m = pe.ConcreteModel()
-        x = m.x = pe.Var()
-        p = m.p = pe.Param(mutable=True)
+        m = pyo.ConcreteModel()
+        x = m.x = pyo.Var()
+        p = m.p = pyo.Param(mutable=True)
         e1 = p * x**2 + p * x + p * x**2
         e2 = self.simp.simplify(e1)
         self.compare_against_possible_results(

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -1226,15 +1226,15 @@ class GurobiPersistent(
             as an MILP using extended cutting planes in callbacks.
 
                 >>> from gurobipy import GRB # doctest:+SKIP
-                >>> import pyomo.environ as pe
+                >>> import pyomo.environ as pyo
                 >>> from pyomo.core.expr.taylor_series import taylor_series_expansion
                 >>> from pyomo.contrib import appsi
                 >>>
-                >>> m = pe.ConcreteModel()
-                >>> m.x = pe.Var(bounds=(0, 4))
-                >>> m.y = pe.Var(within=pe.Integers, bounds=(0, None))
-                >>> m.obj = pe.Objective(expr=2*m.x + m.y)
-                >>> m.cons = pe.ConstraintList()  # for the cutting planes
+                >>> m = pyo.ConcreteModel()
+                >>> m.x = pyo.Var(bounds=(0, 4))
+                >>> m.y = pyo.Var(within=pyo.Integers, bounds=(0, None))
+                >>> m.obj = pyo.Objective(expr=2*m.x + m.y)
+                >>> m.cons = pyo.ConstraintList()  # for the cutting planes
                 >>>
                 >>> def _add_cut(xval):
                 ...     # a function to generate the cut

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_persistent.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_persistent.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.contrib.solver.solvers.gurobi_persistent import GurobiPersistent
 from pyomo.contrib.solver.common.results import SolutionStatus
 from pyomo.core.expr.taylor_series import taylor_series_expansion
@@ -86,17 +86,17 @@ def create_pmedian_model():
         (10, 6): 1.9115931008709737,
     }
 
-    model = pe.ConcreteModel()
-    model.N = pe.Param(initialize=10)
-    model.Locations = pe.RangeSet(1, model.N)
-    model.P = pe.Param(initialize=3)
-    model.M = pe.Param(initialize=6)
-    model.Customers = pe.RangeSet(1, model.M)
-    model.d = pe.Param(
-        model.Locations, model.Customers, initialize=d_dict, within=pe.Reals
+    model = pyo.ConcreteModel()
+    model.N = pyo.Param(initialize=10)
+    model.Locations = pyo.RangeSet(1, model.N)
+    model.P = pyo.Param(initialize=3)
+    model.M = pyo.Param(initialize=6)
+    model.Customers = pyo.RangeSet(1, model.M)
+    model.d = pyo.Param(
+        model.Locations, model.Customers, initialize=d_dict, within=pyo.Reals
     )
-    model.x = pe.Var(model.Locations, model.Customers, bounds=(0.0, 1.0))
-    model.y = pe.Var(model.Locations, within=pe.Binary)
+    model.x = pyo.Var(model.Locations, model.Customers, bounds=(0.0, 1.0))
+    model.y = pyo.Var(model.Locations, within=pyo.Binary)
 
     def rule(model):
         return sum(
@@ -105,39 +105,39 @@ def create_pmedian_model():
             for m in model.Customers
         )
 
-    model.obj = pe.Objective(rule=rule)
+    model.obj = pyo.Objective(rule=rule)
 
     def rule1(model, m):
         return (sum(model.x[n, m] for n in model.Locations), 1.0)
 
-    model.single_x = pe.Constraint(model.Customers, rule=rule1)
+    model.single_x = pyo.Constraint(model.Customers, rule=rule1)
 
     def rule2(model, n, m):
         return (None, model.x[n, m] - model.y[n], 0.0)
 
-    model.bound_y = pe.Constraint(model.Locations, model.Customers, rule=rule2)
+    model.bound_y = pyo.Constraint(model.Locations, model.Customers, rule=rule2)
 
     def rule3(model):
         return (sum(model.y[n] for n in model.Locations) - model.P, 0.0)
 
-    model.num_facilities = pe.Constraint(rule=rule3)
+    model.num_facilities = pyo.Constraint(rule=rule3)
 
     return model
 
 
 class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
     def setUp(self):
-        self.m = pe.ConcreteModel()
+        self.m = pyo.ConcreteModel()
         m = self.m
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.p1 = pe.Param(mutable=True)
-        m.p2 = pe.Param(mutable=True)
-        m.p3 = pe.Param(mutable=True)
-        m.p4 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c1 = pe.Constraint(expr=m.y - m.p1 * m.x >= m.p2)
-        m.c2 = pe.Constraint(expr=m.y - m.p3 * m.x >= m.p4)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.p1 = pyo.Param(mutable=True)
+        m.p2 = pyo.Param(mutable=True)
+        m.p3 = pyo.Param(mutable=True)
+        m.p4 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c1 = pyo.Constraint(expr=m.y - m.p1 * m.x >= m.p2)
+        m.c2 = pyo.Constraint(expr=m.y - m.p3 * m.x >= m.p4)
 
     def get_solution(self):
         try:
@@ -198,12 +198,12 @@ class TestGurobiPersistent(unittest.TestCase):
         #
         # Update: as of Gurobi 11, this test no longer tests the
         # intended behavior (the solver has improved)
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-5, 5))
-        m.y = pe.Var(bounds=(-5, 5))
-        m.obj = pe.Objective(expr=-m.x**2 - m.y)
-        m.c1 = pe.Constraint(expr=m.y <= -2 * m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-5, 5))
+        m.y = pyo.Var(bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pyo.Constraint(expr=m.y <= -2 * m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 2)
         opt = GurobiPersistent()
         opt.config.solver_options['nonconvex'] = 2
         opt.config.solver_options['BestBdStop'] = -8
@@ -226,12 +226,12 @@ class TestGurobiPersistent(unittest.TestCase):
         #
         # Update: as of Gurobi 11, this test no longer tests the
         # intended behavior (the solver has improved)
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-5, 5))
-        m.y = pe.Var(bounds=(-5, 5))
-        m.obj = pe.Objective(expr=-m.x**2 - m.y)
-        m.c1 = pe.Constraint(expr=m.y <= -2 * m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-5, 5))
+        m.y = pyo.Var(bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pyo.Constraint(expr=m.y <= -2 * m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 2)
         opt = GurobiPersistent()
         opt.config.solver_options['nonconvex'] = 2
         opt.config.solver_options['MIPGap'] = 0.5
@@ -243,12 +243,12 @@ class TestGurobiPersistent(unittest.TestCase):
             self.assertAlmostEqual(res.objective_bound, -4)
 
     def test_range_constraints(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.xl = pe.Param(initialize=-1, mutable=True)
-        m.xu = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Constraint(expr=pe.inequality(m.xl, m.x, m.xu))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.xl = pyo.Param(initialize=-1, mutable=True)
+        m.xu = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Constraint(expr=pyo.inequality(m.xl, m.x, m.xu))
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = GurobiPersistent()
         opt.set_instance(m)
@@ -260,7 +260,7 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -3)
 
         del m.obj
-        m.obj = pe.Objective(expr=m.x, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.x, sense=pyo.maximize)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 1)
@@ -270,14 +270,14 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 3)
 
     def test_quadratic_constraint_with_params(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.con = pe.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.con = pyo.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
 
         opt = GurobiPersistent()
         res = opt.solve(m)
@@ -296,12 +296,12 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_quadratic_objective(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.a * m.x**2 + m.b * m.x + m.c)
 
         opt = GurobiPersistent()
         res = opt.solve(m)
@@ -322,9 +322,9 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_var_bounds(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = GurobiPersistent()
         res = opt.solve(m)
@@ -335,7 +335,7 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -3)
 
         del m.obj
-        m.obj = pe.Objective(expr=m.x, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=m.x, sense=pyo.maximize)
 
         opt = GurobiPersistent()
         res = opt.solve(m)
@@ -346,14 +346,14 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 3)
 
     def test_fixed_var(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.con = pe.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.con = pyo.Constraint(expr=m.y >= m.a * m.x**2 + m.b * m.x + m.c)
 
         m.x.fix(1)
         opt = GurobiPersistent()
@@ -374,10 +374,10 @@ class TestGurobiPersistent(unittest.TestCase):
         )
 
     def test_linear_constraint_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c = pyo.Constraint(expr=m.x + m.y == 1)
 
         opt = GurobiPersistent()
         opt.set_instance(m)
@@ -385,19 +385,19 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertEqual(opt.get_linear_constraint_attr(m.c, 'Lazy'), 1)
 
     def test_quadratic_constraint_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c = pe.Constraint(expr=m.y >= m.x**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c = pyo.Constraint(expr=m.y >= m.x**2)
 
         opt = GurobiPersistent()
         opt.set_instance(m)
         self.assertEqual(opt.get_quadratic_constraint_attr(m.c, 'QCRHS'), 0)
 
     def test_var_attr(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.x)
 
         opt = GurobiPersistent()
         opt.set_instance(m)
@@ -405,11 +405,11 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertEqual(opt.get_var_attr(m.x, 'Start'), 1)
 
     def test_callback(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(0, 4))
-        m.y = pe.Var(within=pe.Integers, bounds=(0, None))
-        m.obj = pe.Objective(expr=2 * m.x + m.y)
-        m.cons = pe.ConstraintList()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(0, 4))
+        m.y = pyo.Var(within=pyo.Integers, bounds=(0, None))
+        m.obj = pyo.Objective(expr=2 * m.x + m.y)
+        m.cons = pyo.ConstraintList()
 
         def _add_cut(xval):
             m.x.value = xval
@@ -437,11 +437,11 @@ class TestGurobiPersistent(unittest.TestCase):
     def test_nonconvex(self):
         if gurobipy.GRB.VERSION_MAJOR < 9:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.y == (m.x - 1) ** 2 - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.y == (m.x - 1) ** 2 - 2)
         opt = GurobiPersistent()
         opt.config.solver_options['nonconvex'] = 2
         opt.solve(m)
@@ -451,12 +451,12 @@ class TestGurobiPersistent(unittest.TestCase):
     def test_nonconvex2(self):
         if gurobipy.GRB.VERSION_MAJOR < 9:
             raise unittest.SkipTest
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=0 <= -m.y + (m.x - 1) ** 2 - 2)
-        m.c2 = pe.Constraint(expr=0 >= -m.y + (m.x - 1) ** 2 - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=0 <= -m.y + (m.x - 1) ** 2 - 2)
+        m.c2 = pyo.Constraint(expr=0 >= -m.y + (m.x - 1) ** 2 - 2)
         opt = GurobiPersistent()
         opt.config.solver_options['nonconvex'] = 2
         opt.solve(m)
@@ -472,11 +472,11 @@ class TestGurobiPersistent(unittest.TestCase):
         num_solutions = opt.get_model_attr('SolCount')
         self.assertEqual(num_solutions, 3)
         res.solution_loader.load_vars(solution_number=0)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.431184939357673)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.431184939357673)
         res.solution_loader.load_vars(solution_number=1)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.584793218502477)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.584793218502477)
         res.solution_loader.load_vars(solution_number=2)
-        self.assertAlmostEqual(pe.value(m.obj.expr), 6.592304628123309)
+        self.assertAlmostEqual(pyo.value(m.obj.expr), 6.592304628123309)
 
     def test_zero_time_limit(self):
         m = create_pmedian_model()
@@ -509,11 +509,11 @@ class TestManualModel(unittest.TestCase):
         self.opt = opt
 
     def test_basics(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= 2 * m.x + 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= 2 * m.x + 1)
 
         opt = self.opt
         opt.set_instance(m)
@@ -530,7 +530,7 @@ class TestManualModel(unittest.TestCase):
         duals = res.solution_loader.get_duals()
         self.assertAlmostEqual(duals[m.c1], -0.4)
 
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
         opt.add_constraints([m.c2])
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
         self.assertEqual(opt.get_model_attr('NumConstrs'), 2)
@@ -574,7 +574,7 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_var_attr(m.x, 'LB'), -5)
         self.assertEqual(opt.get_var_attr(m.x, 'UB'), 5)
 
-        m.c2 = pe.Constraint(expr=m.y >= m.x**2)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x**2)
         opt.add_constraints([m.c2])
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
         self.assertEqual(opt.get_model_attr('NumConstrs'), 1)
@@ -586,7 +586,7 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_model_attr('NumConstrs'), 1)
         self.assertEqual(opt.get_model_attr('NumQConstrs'), 0)
 
-        m.z = pe.Var()
+        m.z = pyo.Var()
         opt.add_variables([m.z])
         self.assertEqual(opt.get_model_attr('NumVars'), 3)
         opt.remove_variables([m.z])
@@ -594,12 +594,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
 
     def test_update1(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x**2 + m.y**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x**2 + m.y**2)
 
         opt = self.opt
         opt.set_instance(m)
@@ -615,12 +615,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
     def test_update2(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c2 = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c2 = pyo.Constraint(expr=m.x + m.y == 1)
 
         opt = self.opt
         opt.config.symbolic_solver_labels = True
@@ -637,18 +637,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
     def test_update3(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x**2 + m.y**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x**2 + m.y**2)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
-        m.c2 = pe.Constraint(expr=m.y >= m.x**2)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x**2)
         opt.add_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
         opt.remove_constraints([m.c2])
@@ -656,18 +656,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
     def test_update4(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x + m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x + m.y)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
-        m.c2 = pe.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x)
         opt.add_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
         opt.remove_constraints([m.c2])
@@ -675,12 +675,12 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
     def test_update5(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
         opt = self.opt
         opt.set_instance(m)
@@ -696,18 +696,18 @@ class TestManualModel(unittest.TestCase):
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
     def test_update6(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
         opt = self.opt
         opt.set_instance(m)
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
-        m.c2 = pe.SOSConstraint(var=m.x, sos=2)
+        m.c2 = pyo.SOSConstraint(var=m.x, sos=2)
         opt.add_sos_constraints([m.c2])
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
         opt.remove_sos_constraints([m.c2])

--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -13,7 +13,7 @@ import random
 import math
 from typing import Type
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo import gdp
 from pyomo.common.dependencies import attempt_import
 import pyomo.common.unittest as unittest
@@ -94,17 +94,17 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(2, None))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(2, None))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, 2)
 
         del m.x
         del m.obj
-        m.x = pe.Var(bounds=(2, None))
-        m.obj = pe.Objective(expr=m.x)
+        m.x = pyo.Var(bounds=(2, None))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, 2)
@@ -121,13 +121,13 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x)
         m.x.value = 1
         m.y.value = 1
         m.z.value = 1
@@ -169,16 +169,16 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.x)
-        m.c = pe.Constraint(expr=(-1, m.x, 1))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x)
+        m.c = pyo.Constraint(expr=(-1, m.x, 1))
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, -1)
         duals = res.solution_loader.get_duals()
         self.assertAlmostEqual(duals[m.c], 1)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, 1)
@@ -197,10 +197,10 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.y = pe.Var(bounds=(-2, 2))
-        m.obj = pe.Objective(expr=3 * m.x + 4 * m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.y = pyo.Var(bounds=(-2, 2))
+        m.obj = pyo.Objective(expr=3 * m.x + 4 * m.y)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, -1)
@@ -226,15 +226,15 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, 1))
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, 1))
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, -1)
         rc = res.solution_loader.get_reduced_costs()
         self.assertAlmostEqual(rc[m.x], 1)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, 1)
@@ -253,16 +253,16 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -300,16 +300,16 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(initialize=-1)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(initialize=-1)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
 
         params_to_test = [(1, 2, 1), (1, 2, 1), (1, 3, 1)]
         for a1, b1, b2 in params_to_test:
@@ -343,16 +343,16 @@ class TestSolvers(unittest.TestCase):
                 check_duals = False
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y == m.a1 * m.x + m.b1)
-        m.c2 = pe.Constraint(expr=m.y == m.a2 * m.x + m.b2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y == m.a1 * m.x + m.b1)
+        m.c2 = pyo.Constraint(expr=m.y == m.a2 * m.x + m.b2)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -387,22 +387,22 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
         e = LinearExpression(
             constant=m.b1, linear_coefs=[-1, m.a1], linear_vars=[m.y, m.x]
         )
-        m.c1 = pe.Constraint(expr=e == 0)
+        m.c1 = pyo.Constraint(expr=e == 0)
         e = LinearExpression(
             constant=m.b2, linear_coefs=[-1, m.a2], linear_vars=[m.y, m.x]
         )
-        m.c2 = pe.Constraint(expr=e == 0)
+        m.c2 = pyo.Constraint(expr=e == 0)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -434,15 +434,15 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.c1 = pe.Constraint(expr=m.y == m.a1 * m.x + m.b1)
-        m.c2 = pe.Constraint(expr=m.y == m.a2 * m.x + m.b2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.c1 = pyo.Constraint(expr=m.y == m.a1 * m.x + m.b1)
+        m.c2 = pyo.Constraint(expr=m.y == m.a2 * m.x + m.b2)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -473,18 +473,18 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
         a1 = -1
         a2 = 1
         b1 = 1
         b2 = 2
         a3 = 1
         b3 = 3
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-        m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+        m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
@@ -499,7 +499,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], -(1 + a1 / (a2 - a1)))
         self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
-        m.c3 = pe.Constraint(expr=m.y >= a3 * m.x + b3)
+        m.c3 = pyo.Constraint(expr=m.y >= a3 * m.x + b3)
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, (b3 - b1) / (a1 - a3))
@@ -534,12 +534,12 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y <= m.x - 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y <= m.x - 1)
         with self.assertRaises(Exception):
             res = opt.solve(m)
         opt.config.load_solutions = False
@@ -588,12 +588,12 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y - m.x >= 0)
-        m.c2 = pe.Constraint(expr=m.y + m.x - 2 >= 0)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y - m.x >= 0)
+        m.c2 = pyo.Constraint(expr=m.y + m.x - 2 >= 0)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 1)
@@ -618,13 +618,13 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=-1, mutable=True)
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c = pe.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=-1, mutable=True)
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c = pyo.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.41024548525899274, 4)
@@ -647,15 +647,15 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a = pe.Param(initialize=1, mutable=True)
-        m.b = pe.Param(initialize=-1, mutable=True)
-        m.c = pe.Param(initialize=1, mutable=True)
-        m.d = pe.Param(initialize=1, mutable=True)
-        m.obj = pe.Objective(expr=m.x**2 + m.c * m.y**2 + m.d * m.x)
-        m.ccon = pe.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a = pyo.Param(initialize=1, mutable=True)
+        m.b = pyo.Param(initialize=-1, mutable=True)
+        m.c = pyo.Param(initialize=1, mutable=True)
+        m.d = pyo.Param(initialize=1, mutable=True)
+        m.obj = pyo.Objective(expr=m.x**2 + m.c * m.y**2 + m.d * m.x)
+        m.ccon = pyo.Constraint(expr=m.y >= (m.a * m.x + m.b) ** 2)
 
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.2719178742733325, 4)
@@ -682,17 +682,17 @@ class TestSolvers(unittest.TestCase):
                     opt.config.writer_config.linear_presolve = True
                 else:
                     opt.config.writer_config.linear_presolve = False
-            m = pe.ConcreteModel()
-            m.x = pe.Var()
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var()
             m.x.fix(0)
-            m.y = pe.Var()
+            m.y = pyo.Var()
             a1 = 1
             a2 = -1
             b1 = 1
             b2 = 2
-            m.obj = pe.Objective(expr=m.y)
-            m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-            m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+            m.obj = pyo.Objective(expr=m.y)
+            m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+            m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
             res = opt.solve(m)
             self.assertAlmostEqual(m.x.value, 0)
             self.assertAlmostEqual(m.y.value, 2)
@@ -727,17 +727,17 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         m.x.fix(0)
-        m.y = pe.Var()
+        m.y = pyo.Var()
         a1 = 1
         a2 = -1
         b1 = 1
         b2 = 2
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= a1 * m.x + b1)
-        m.c2 = pe.Constraint(expr=m.y >= a2 * m.x + b2)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= a1 * m.x + b1)
+        m.c2 = pyo.Constraint(expr=m.y >= a2 * m.x + b2)
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 2)
@@ -772,11 +772,11 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x + m.y)
-        m.c1 = pe.Constraint(expr=m.x == 2 / m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c1 = pyo.Constraint(expr=m.x == 2 / m.y)
         m.y.fix(1)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 3)
@@ -796,11 +796,11 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.x == 2 / m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.x == 2 / m.y)
         m.y.fix(1)
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 2)
@@ -821,18 +821,18 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(initialize=0, mutable=True)
-        m.a2 = pe.Param(initialize=0, mutable=True)
-        m.b1 = pe.Param(initialize=0, mutable=True)
-        m.b2 = pe.Param(initialize=0, mutable=True)
-        m.c1 = pe.Param(initialize=0, mutable=True)
-        m.c2 = pe.Param(initialize=0, mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.con1 = pe.Constraint(expr=(m.b1, m.y - m.a1 * m.x, m.c1))
-        m.con2 = pe.Constraint(expr=(m.b2, m.y - m.a2 * m.x, m.c2))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(initialize=0, mutable=True)
+        m.a2 = pyo.Param(initialize=0, mutable=True)
+        m.b1 = pyo.Param(initialize=0, mutable=True)
+        m.b2 = pyo.Param(initialize=0, mutable=True)
+        m.c1 = pyo.Param(initialize=0, mutable=True)
+        m.c2 = pyo.Param(initialize=0, mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.con1 = pyo.Constraint(expr=(m.b1, m.y - m.a1 * m.x, m.c1))
+        m.con2 = pyo.Constraint(expr=(m.b2, m.y - m.a2 * m.x, m.c2))
 
         np.random.seed(0)
         params_to_test = [
@@ -843,7 +843,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.minimize,
+                pyo.minimize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -852,7 +852,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.maximize,
+                pyo.maximize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -861,7 +861,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.minimize,
+                pyo.minimize,
             ),
             (
                 np.random.uniform(0, 10),
@@ -870,7 +870,7 @@ class TestSolvers(unittest.TestCase):
                 np.random.uniform(-5, 2.5),
                 np.random.uniform(2.5, 10),
                 np.random.uniform(2.5, 10),
-                pe.maximize,
+                pyo.maximize,
             ),
         ]
         for a1, a2, b1, b2, c1, c2, sense in params_to_test:
@@ -883,7 +883,7 @@ class TestSolvers(unittest.TestCase):
             m.obj.sense = sense
             res: Results = opt.solve(m)
             self.assertEqual(res.solution_status, SolutionStatus.optimal)
-            if sense is pe.minimize:
+            if sense is pyo.minimize:
                 self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2), 6)
                 self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1, 6)
                 self.assertAlmostEqual(res.incumbent_objective, m.y.value, 6)
@@ -918,9 +918,9 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.y = pe.Var(bounds=(-1, None))
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.y = pyo.Var(bounds=(-1, None))
+        m.obj = pyo.Objective(expr=m.y)
         if opt.is_persistent():
             opt.config.auto_updates.update_parameters = False
             opt.config.auto_updates.update_vars = False
@@ -934,13 +934,13 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         res.solution_loader.load_vars()
         self.assertAlmostEqual(m.y.value, -1)
-        m.x = pe.Var()
+        m.x = pyo.Var()
         a1 = 1
         a2 = -1
         b1 = 2
         b2 = 1
-        m.c1 = pe.Constraint(expr=(0, m.y - a1 * m.x - b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + a2 * m.x + b2, 0))
+        m.c1 = pyo.Constraint(expr=(0, m.y - a1 * m.x - b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + a2 * m.x + b2, 0))
         if opt.is_persistent():
             opt.add_constraints([m.c1, m.c2])
         res = opt.solve(m)
@@ -969,11 +969,11 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= pe.exp(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= pyo.exp(m.x))
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, -0.42630274815985264)
         self.assertAlmostEqual(m.y.value, 0.6529186341994245)
@@ -988,11 +988,11 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(initialize=1)
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y <= pe.log(m.x))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1)
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y <= pyo.log(m.x))
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, 0.6529186341994245)
         self.assertAlmostEqual(m.y.value, -0.42630274815985264)
@@ -1009,18 +1009,18 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
         a1 = 1
         b1 = 3
         a2 = -2
         b2 = 1
-        m.c1 = pe.Constraint(
+        m.c1 = pyo.Constraint(
             expr=(np.float64(0), m.y - np.int64(1) * m.x - np.float32(3), None)
         )
-        m.c2 = pe.Constraint(
+        m.c2 = pyo.Constraint(
             expr=(None, -m.y + np.int32(-2) * m.x + np.float64(1), np.float16(0))
         )
         res = opt.solve(m)
@@ -1040,12 +1040,12 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.y = pe.Var()
-        m.p = pe.Param(mutable=True)
+        m = pyo.ConcreteModel()
+        m.y = pyo.Var()
+        m.p = pyo.Param(mutable=True)
         m.y.setlb(m.p)
         m.p.value = 1
-        m.obj = pe.Objective(expr=m.y)
+        m.obj = pyo.Objective(expr=m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 1)
         m.p.value = -1
@@ -1053,7 +1053,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, -1)
         m.y.setlb(None)
         m.y.setub(m.p)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         m.p.value = 5
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 5)
@@ -1062,7 +1062,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 4)
         m.y.setub(None)
         m.y.setlb(m.p)
-        m.obj.sense = pe.minimize
+        m.obj.sense = pyo.minimize
         m.p.value = 3
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 3)
@@ -1079,12 +1079,12 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(1, None))
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.x, None))
-        m.c2 = pe.Constraint(expr=(0, m.y - m.x + 1, None))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(1, None))
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.x, None))
+        m.c2 = pyo.Constraint(expr=(0, m.y - m.x + 1, None))
         opt.config.load_solutions = False
         res = opt.solve(m)
         self.assertIsNone(m.x.value)
@@ -1142,10 +1142,10 @@ class TestSolvers(unittest.TestCase):
             raise unittest.SkipTest
 
         N = 30
-        m = pe.ConcreteModel()
-        m.jobs = pe.Set(initialize=list(range(N)))
-        m.tasks = pe.Set(initialize=list(range(N)))
-        m.x = pe.Var(m.jobs, m.tasks, bounds=(0, 1))
+        m = pyo.ConcreteModel()
+        m.jobs = pyo.Set(initialize=list(range(N)))
+        m.tasks = pyo.Set(initialize=list(range(N)))
+        m.x = pyo.Var(m.jobs, m.tasks, bounds=(0, 1))
 
         random.seed(0)
         coefs = list()
@@ -1157,10 +1157,10 @@ class TestSolvers(unittest.TestCase):
         obj_expr = LinearExpression(
             linear_coefs=coefs, linear_vars=lin_vars, constant=0
         )
-        m.obj = pe.Objective(expr=obj_expr, sense=pe.maximize)
+        m.obj = pyo.Objective(expr=obj_expr, sense=pyo.maximize)
 
-        m.c1 = pe.Constraint(m.jobs)
-        m.c2 = pe.Constraint(m.tasks)
+        m.c1 = pyo.Constraint(m.jobs)
+        m.c2 = pyo.Constraint(m.tasks)
         for j in m.jobs:
             expr = LinearExpression(
                 linear_coefs=[1] * N,
@@ -1199,22 +1199,22 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.c1 = pe.Constraint(expr=m.y >= m.x + 1)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.c1 = pyo.Constraint(expr=m.y >= m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
+        m.obj = pyo.Objective(expr=m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
         del m.obj
-        m.obj = pe.Objective(expr=2 * m.y)
+        m.obj = pyo.Objective(expr=2 * m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 2)
         m.obj.expr = 3 * m.y
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 3)
-        m.obj.sense = pe.maximize
+        m.obj.sense = pyo.maximize
         opt.config.raise_exception_on_nonoptimal_result = False
         opt.config.load_solutions = False
         res = opt.solve(m)
@@ -1225,10 +1225,10 @@ class TestSolvers(unittest.TestCase):
                 TerminationCondition.infeasibleOrUnbounded,
             },
         )
-        m.obj.sense = pe.minimize
+        m.obj.sense = pyo.minimize
         opt.config.load_solutions = True
         del m.obj
-        m.obj = pe.Objective(expr=m.x * m.y)
+        m.obj = pyo.Objective(expr=m.x * m.y)
         m.x.fix(2)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 6, 6)
@@ -1244,9 +1244,9 @@ class TestSolvers(unittest.TestCase):
         m.y.unfix()
         m.x.setlb(None)
         m.x.setub(None)
-        m.e = pe.Expression(expr=2)
+        m.e = pyo.Expression(expr=2)
         del m.obj
-        m.obj = pe.Objective(expr=m.e * m.y)
+        m.obj = pyo.Objective(expr=m.e * m.y)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 2)
         m.e.expr = 3
@@ -1268,9 +1268,9 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(1, None), domain=pe.NonNegativeReals)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(1, None), domain=pyo.NonNegativeReals)
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
         m.x.setlb(-1)
@@ -1280,10 +1280,10 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
         m.x.setlb(-1)
-        m.x.domain = pe.Reals
+        m.x.domain = pyo.Reals
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, -1)
-        m.x.domain = pe.NonNegativeReals
+        m.x.domain = pyo.NonNegativeReals
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
 
@@ -1299,19 +1299,19 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-1, None), domain=pe.NonNegativeIntegers)
-        m.obj = pe.Objective(expr=m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-1, None), domain=pyo.NonNegativeIntegers)
+        m.obj = pyo.Objective(expr=m.x)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
         m.x.setlb(0.5)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
         m.x.setlb(-5.5)
-        m.x.domain = pe.Integers
+        m.x.domain = pyo.Integers
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, -5)
-        m.x.domain = pe.Binary
+        m.x.domain = pyo.Binary
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
         m.x.setlb(0.5)
@@ -1330,11 +1330,11 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = True
             else:
                 opt.config.writer_config.linear_presolve = False
-        m = pe.ConcreteModel()
-        m.x = pe.Var(domain=pe.Binary)
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c = pe.Constraint(expr=m.y >= m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.Binary)
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c = pyo.Constraint(expr=m.y >= m.x)
         m.x.fix(0)
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
@@ -1364,18 +1364,18 @@ class TestSolvers(unittest.TestCase):
             else:
                 opt.config.writer_config.linear_presolve = False
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var(bounds=(-10, 10))
-        m.obj = pe.Objective(expr=m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var(bounds=(-10, 10))
+        m.obj = pyo.Objective(expr=m.y)
         m.d1 = gdp.Disjunct()
-        m.d1.c1 = pe.Constraint(expr=m.y >= m.x + 2)
-        m.d1.c2 = pe.Constraint(expr=m.y >= -m.x + 2)
+        m.d1.c1 = pyo.Constraint(expr=m.y >= m.x + 2)
+        m.d1.c2 = pyo.Constraint(expr=m.y >= -m.x + 2)
         m.d2 = gdp.Disjunct()
-        m.d2.c1 = pe.Constraint(expr=m.y >= m.x + 1)
-        m.d2.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.d2.c1 = pyo.Constraint(expr=m.y >= m.x + 1)
+        m.d2.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
         m.disjunction = gdp.Disjunction(expr=[m.d2, m.d1])
-        pe.TransformationFactory("gdp.bigm").apply_to(m)
+        pyo.TransformationFactory("gdp.bigm").apply_to(m)
 
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
@@ -1402,13 +1402,13 @@ class TestSolvers(unittest.TestCase):
             else:
                 opt.config.writer_config.linear_presolve = False
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.b = pe.Block()
-        m.b.obj = pe.Objective(expr=m.y)
-        m.b.c1 = pe.Constraint(expr=m.y >= m.x + 2)
-        m.b.c2 = pe.Constraint(expr=m.y >= -m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.b = pyo.Block()
+        m.b.obj = pyo.Objective(expr=m.y)
+        m.b.c1 = pyo.Constraint(expr=m.y >= m.x + 2)
+        m.b.c2 = pyo.Constraint(expr=m.y >= -m.x)
 
         res = opt.solve(m.b)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
@@ -1436,16 +1436,16 @@ class TestSolvers(unittest.TestCase):
             else:
                 opt.config.writer_config.linear_presolve = False
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= m.x)
-        m.c2 = pe.Constraint(expr=m.y >= -m.x)
-        m.c3 = pe.Constraint(expr=m.y >= m.z + 1)
-        m.c4 = pe.Constraint(expr=m.y >= -m.z + 1)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= m.x)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x)
+        m.c3 = pyo.Constraint(expr=m.y >= m.z + 1)
+        m.c4 = pyo.Constraint(expr=m.y >= -m.z + 1)
 
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
@@ -1476,13 +1476,13 @@ class TestSolvers(unittest.TestCase):
             else:
                 opt.config.writer_config.linear_presolve = False
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(3, 7))
-        m.y = pe.Var(bounds=(-10, 10))
-        m.p = pe.Param(mutable=True, initialize=0)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(3, 7))
+        m.y = pyo.Var(bounds=(-10, 10))
+        m.p = pyo.Param(mutable=True, initialize=0)
 
-        m.obj = pe.Objective(expr=m.y)
-        m.c = pe.Constraint(expr=m.y >= m.p * m.x)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c = pyo.Constraint(expr=m.y >= m.p * m.x)
 
         res = opt.solve(m)
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
@@ -1511,11 +1511,11 @@ class TestSolvers(unittest.TestCase):
                 else:
                     opt.config.writer_config.linear_presolve = False
 
-            m = pe.ConcreteModel()
-            m.x = pe.Var(bounds=(-10, 10))
-            m.y = pe.Var()
-            m.obj = pe.Objective(expr=3 * m.y - m.x)
-            m.c = pe.Constraint(expr=m.y >= m.x)
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var(bounds=(-10, 10))
+            m.y = pyo.Var()
+            m.obj = pyo.Objective(expr=3 * m.y - m.x)
+            m.c = pyo.Constraint(expr=m.y >= m.x)
 
             m.x.fix(1)
             res = opt.solve(m)
@@ -1544,13 +1544,13 @@ class TestSolvers(unittest.TestCase):
         x - y + y = 0 which becomes
         x - 0*y == 0 which is the zero we are testing for
         """
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2 + m.z**2)
-        m.c1 = pe.Constraint(expr=m.x == m.y + m.z + 1.5)
-        m.c2 = pe.Constraint(expr=m.z == -m.y)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2 + m.z**2)
+        m.c1 = pyo.Constraint(expr=m.x == m.y + m.z + 1.5)
+        m.c2 = pyo.Constraint(expr=m.z == -m.y)
 
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 2.25)
@@ -1568,15 +1568,15 @@ class TestSolvers(unittest.TestCase):
             exp = TerminationCondition.locallyInfeasible
         self.assertEqual(res.termination_condition, exp)
 
-        m = pe.ConcreteModel()
-        m.w = pe.Var()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2 + m.z**2 + m.w**2)
-        m.c1 = pe.Constraint(expr=m.x + m.w == m.y + m.z)
-        m.c2 = pe.Constraint(expr=m.z == -m.y)
-        m.c3 = pe.Constraint(expr=m.x == -m.w)
+        m = pyo.ConcreteModel()
+        m.w = pyo.Var()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2 + m.z**2 + m.w**2)
+        m.c1 = pyo.Constraint(expr=m.x + m.w == m.y + m.z)
+        m.c2 = pyo.Constraint(expr=m.z == -m.y)
+        m.c3 = pyo.Constraint(expr=m.x == -m.w)
 
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
@@ -1586,7 +1586,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.z.value, 0)
 
         del m.c1
-        m.c1 = pe.Constraint(expr=m.x + m.w == m.y + m.z + 1.5)
+        m.c1 = pyo.Constraint(expr=m.x + m.w == m.y + m.z + 1.5)
         res = opt.solve(
             m, load_solutions=False, raise_exception_on_nonoptimal_result=False
         )
@@ -1605,13 +1605,13 @@ class TestSolvers(unittest.TestCase):
             else:
                 opt.config.writer_config.linear_presolve = False
 
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=m.y >= (m.x - 1) + 1)
-        m.c2 = pe.Constraint(expr=m.y >= -(m.x - 1) + 1)
-        m.scaling_factor = pe.Suffix(direction=pe.Suffix.EXPORT)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=m.y >= (m.x - 1) + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -(m.x - 1) + 1)
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
         m.scaling_factor[m.x] = 0.5
         m.scaling_factor[m.y] = 2
         m.scaling_factor[m.c1] = 0.5
@@ -1653,20 +1653,20 @@ class TestSolvers(unittest.TestCase):
 class TestLegacySolverInterface(unittest.TestCase):
     @parameterized.expand(input=all_solvers)
     def test_param_updates(self, name: str, opt_class: Type[SolverBase]):
-        opt = pe.SolverFactory(name + '_v2')
+        opt = pyo.SolverFactory(name + '_v2')
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest(f'Solver {opt.name} not available.')
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.a1 = pe.Param(mutable=True)
-        m.a2 = pe.Param(mutable=True)
-        m.b1 = pe.Param(mutable=True)
-        m.b2 = pe.Param(mutable=True)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
-        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
-        m.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.a1 = pyo.Param(mutable=True)
+        m.a2 = pyo.Param(mutable=True)
+        m.b1 = pyo.Param(mutable=True)
+        m.b2 = pyo.Param(mutable=True)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.Constraint(expr=(0, m.y - m.a1 * m.x - m.b1, None))
+        m.c2 = pyo.Constraint(expr=(None, -m.y + m.a2 * m.x + m.b2, 0))
+        m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
 
         params_to_test = [(1, -1, 2, 1), (1, -2, 2, 1), (1, -1, 3, 1)]
         for a1, a2, b1, b2 in params_to_test:
@@ -1675,7 +1675,7 @@ class TestLegacySolverInterface(unittest.TestCase):
             m.b1.value = b1
             m.b2.value = b2
             res = opt.solve(m)
-            pe.assert_optimal_termination(res)
+            pyo.assert_optimal_termination(res)
             self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
             self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1)
             self.assertAlmostEqual(m.dual[m.c1], (1 + a1 / (a2 - a1)))
@@ -1683,16 +1683,16 @@ class TestLegacySolverInterface(unittest.TestCase):
 
     @parameterized.expand(input=all_solvers)
     def test_load_solutions(self, name: str, opt_class: Type[SolverBase]):
-        opt = pe.SolverFactory(name + '_v2')
+        opt = pyo.SolverFactory(name + '_v2')
         if not opt.available(exception_flag=False):
             raise unittest.SkipTest(f'Solver {opt.name} not available.')
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.obj = pe.Objective(expr=m.x)
-        m.c = pe.Constraint(expr=(-1, m.x, 1))
-        m.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x)
+        m.c = pyo.Constraint(expr=(-1, m.x, 1))
+        m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
         res = opt.solve(m, load_solutions=False)
-        pe.assert_optimal_termination(res)
+        pyo.assert_optimal_termination(res)
         self.assertIsNone(m.x.value)
         self.assertNotIn(m.c, m.dual)
         m.solutions.load_from(res)

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 from pyomo.common import unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.core.expr.numeric_expr import (
     LinearExpression,
     MonomialTermExpression,
@@ -39,8 +39,8 @@ from pyomo.common.gsl import find_GSL
 
 class TestConvertToPrefixNotation(unittest.TestCase):
     def test_linear_expression(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var([1, 2, 3, 4])
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3, 4])
         e = LinearExpression(
             constant=3, linear_coefs=list(m.x.keys()), linear_vars=list(m.x.values())
         )
@@ -64,9 +64,9 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         self.assertEqual(pn, expected)
 
     def test_multiple(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
 
         e = m.x**2 + m.x * m.y / 3 + 4
         expected = [
@@ -89,9 +89,9 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         self.assertFalse(compare_expressions(e, e3))
 
     def test_unary(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        e = pe.log(m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        e = pyo.log(m.x)
         expected = [(UnaryFunctionExpression, 1, 'log'), m.x]
         pn = convert_expression_to_prefix_notation(e)
         self.assertEqual(expected, pn)
@@ -101,10 +101,10 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         if not DLL:
             self.skipTest('Could not find the amplgsl.dll library')
 
-        m = pe.ConcreteModel()
-        m.hypot = pe.ExternalFunction(library=DLL, function='gsl_hypot')
-        m.x = pe.Var(initialize=0.5)
-        m.y = pe.Var(initialize=1.5)
+        m = pyo.ConcreteModel()
+        m.hypot = pyo.ExternalFunction(library=DLL, function='gsl_hypot')
+        m.x = pyo.Var(initialize=0.5)
+        m.y = pyo.Var(initialize=1.5)
         e = 2 * m.hypot(m.x, m.x * m.y)
         expected = [
             (ProductExpression, 2),
@@ -119,8 +119,8 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         self.assertEqual(expected, pn)
 
     def test_var(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         pn = convert_expression_to_prefix_notation(m.x)
         self.assertEqual(pn, [m.x])
 
@@ -129,34 +129,34 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         self.assertEqual(pn, [4.3])
 
     def test_monomial(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         e = 2 * m.x
         pn = convert_expression_to_prefix_notation(e)
         expected = [(MonomialTermExpression, 2), 2, m.x]
         self.assertEqual(pn, expected)
 
     def test_negation(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         e = -m.x**2
         pn = convert_expression_to_prefix_notation(e)
         expected = [(NegationExpression, 1), (PowExpression, 2), m.x, 2]
         self.assertEqual(pn, expected)
 
     def test_abs(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
         e = abs(m.x)
         pn = convert_expression_to_prefix_notation(e)
         expected = [(AbsExpression, 1, 'abs'), m.x]
         self.assertEqual(pn, expected)
 
     def test_expr_if(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        e = pe.Expr_if(m.x <= 0, m.y + m.x == 0, m.y - m.x == 0)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        e = pyo.Expr_if(m.x <= 0, m.y + m.x == 0, m.y - m.x == 0)
         pn = convert_expression_to_prefix_notation(e)
         expected = [
             (Expr_ifExpression, 3),
@@ -179,20 +179,20 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         self.assertEqual(pn, expected)
 
     def test_ranged_expression(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        e = pe.inequality(-1, m.x, 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        e = pyo.inequality(-1, m.x, 1)
         pn = convert_expression_to_prefix_notation(e)
         expected = [(RangedExpression, 3), -1, m.x, 1]
         self.assertEqual(pn, expected)
 
     def test_assertExpressionsEqual(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.e1 = pe.Expression(expr=m.x**2 + m.x - 1)
-        m.e2 = pe.Expression(expr=m.x**2 + m.x - 1)
-        m.f = pe.Expression(expr=m.x**2 + 2 * m.x - 1)
-        m.g = pe.Expression(expr=m.x**2 + m.x - 2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.e1 = pyo.Expression(expr=m.x**2 + m.x - 1)
+        m.e2 = pyo.Expression(expr=m.x**2 + m.x - 1)
+        m.f = pyo.Expression(expr=m.x**2 + 2 * m.x - 1)
+        m.g = pyo.Expression(expr=m.x**2 + m.x - 2)
 
         assertExpressionsEqual(self, m.e1.expr, m.e2.expr)
         assertExpressionsStructurallyEqual(self, m.e1.expr, m.e2.expr)

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -107,7 +107,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """Update a single variable in the solver's model.
 
         This will update bounds, fix/unfix the variable as needed, and
-        update the variable typyo.
+        update the variable type.
 
         Parameters
         ----------

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -107,7 +107,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """Update a single variable in the solver's model.
 
         This will update bounds, fix/unfix the variable as needed, and
-        update the variable type.
+        update the variable typyo.
 
         Parameters
         ----------
@@ -514,14 +514,14 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
                :skipif: not gurobipy_available
 
                from gurobipy import GRB
-               import pyomo.environ as pe
+               import pyomo.environ as pyo
                from pyomo.core.expr.taylor_series import taylor_series_expansion
 
-               m = pe.ConcreteModel()
-               m.x = pe.Var(bounds=(0, 4))
-               m.y = pe.Var(within=pe.Integers, bounds=(0, None))
-               m.obj = pe.Objective(expr=2*m.x + m.y)
-               m.cons = pe.ConstraintList()  # for the cutting planes
+               m = pyo.ConcreteModel()
+               m.x = pyo.Var(bounds=(0, 4))
+               m.y = pyo.Var(within=pyo.Integers, bounds=(0, None))
+               m.obj = pyo.Objective(expr=2*m.x + m.y)
+               m.cons = pyo.ConstraintList()  # for the cutting planes
 
                def _add_cut(xval):
                    # a function to generate the cut
@@ -531,7 +531,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
                _add_cut(0)  # start with 2 cuts at the bounds of x
                _add_cut(4)  # this is an arbitrary choice
 
-               opt = pe.SolverFactory('gurobi_persistent')
+               opt = pyo.SolverFactory('gurobi_persistent')
                opt.set_instance(m)
                opt.set_gurobi_param('PreCrush', 1)
                opt.set_gurobi_param('LazyConstraints', 1)

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -11,7 +11,7 @@
 import logging
 
 import pyomo.common.unittest as unittest
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import pyomo.solvers.plugins.solvers.xpress_direct as xpd
 
 from pyomo.common.log import LoggingIntercept
@@ -19,19 +19,19 @@ from pyomo.core.expr.taylor_series import taylor_series_expansion
 from pyomo.opt.results.solver import TerminationCondition, SolverStatus
 from pyomo.solvers.plugins.solvers.xpress_persistent import XpressPersistent
 
-xpress_available = pe.SolverFactory('xpress_persistent').available(False)
+xpress_available = pyo.SolverFactory('xpress_persistent').available(False)
 
 
 class TestXpressPersistent(unittest.TestCase):
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_basics(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(bounds=(-10, 10))
-        m.y = pe.Var()
-        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
-        m.c1 = pe.Constraint(expr=m.y >= 2 * m.x + 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(-10, 10))
+        m.y = pyo.Var()
+        m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pyo.Constraint(expr=m.y >= 2 * m.x + 1)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
 
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
@@ -57,7 +57,7 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.slack[m.c1], 0, delta=1e-6)
         del m.slack
 
-        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.c2 = pyo.Constraint(expr=m.y >= -m.x + 1)
         opt.add_constraint(m.c2)
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
         self.assertEqual(opt.get_xpress_attribute('rows'), 2)
@@ -111,7 +111,7 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertEqual(lb[0], -5)
         self.assertEqual(ub[0], 5)
 
-        m.c2 = pe.Constraint(expr=m.y >= m.x**2)
+        m.c2 = pyo.Constraint(expr=m.y >= m.x**2)
         opt.add_constraint(m.c2)
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
         self.assertEqual(opt.get_xpress_attribute('rows'), 2)
@@ -121,7 +121,7 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
-        m.z = pe.Var()
+        m.z = pyo.Var()
         opt.add_var(m.z)
         self.assertEqual(opt.get_xpress_attribute('cols'), 3)
         opt.remove_var(m.z)
@@ -130,14 +130,14 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_qconstraint(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c1 = pe.Constraint(expr=m.z >= m.x**2 + m.y**2)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c1 = pyo.Constraint(expr=m.z >= m.x**2 + m.y**2)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
@@ -149,14 +149,14 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_lconstraint(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
-        m.z = pe.Var()
-        m.obj = pe.Objective(expr=m.z)
-        m.c2 = pe.Constraint(expr=m.x + m.y == 1)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        m.z = pyo.Var()
+        m.obj = pyo.Objective(expr=m.z)
+        m.c2 = pyo.Constraint(expr=m.x + m.y == 1)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
@@ -168,14 +168,14 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_sosconstraint(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         self.assertEqual(opt.get_xpress_attribute('sets'), 1)
 
@@ -187,17 +187,17 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_sosconstraint2(self):
-        m = pe.ConcreteModel()
-        m.a = pe.Set(initialize=[1, 2, 3], ordered=True)
-        m.x = pe.Var(m.a, within=pe.Binary)
-        m.y = pe.Var(within=pe.Binary)
-        m.obj = pe.Objective(expr=m.y)
-        m.c1 = pe.SOSConstraint(var=m.x, sos=1)
+        m = pyo.ConcreteModel()
+        m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
+        m.x = pyo.Var(m.a, within=pyo.Binary)
+        m.y = pyo.Var(within=pyo.Binary)
+        m.obj = pyo.Objective(expr=m.y)
+        m.c1 = pyo.SOSConstraint(var=m.x, sos=1)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         self.assertEqual(opt.get_xpress_attribute('sets'), 1)
-        m.c2 = pe.SOSConstraint(var=m.x, sos=2)
+        m.c2 = pyo.SOSConstraint(var=m.x, sos=2)
         opt.add_sos_constraint(m.c2)
         self.assertEqual(opt.get_xpress_attribute('sets'), 2)
         opt.remove_sos_constraint(m.c2)
@@ -205,11 +205,11 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_var(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.y = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
 
@@ -226,17 +226,17 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_column(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(within=pe.NonNegativeReals)
-        m.c = pe.Constraint(expr=(0, m.x, 1))
-        m.obj = pe.Objective(expr=-m.x)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(within=pyo.NonNegativeReals)
+        m.c = pyo.Constraint(expr=(0, m.x, 1))
+        m.obj = pyo.Objective(expr=-m.x)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
         opt.set_instance(m)
         opt.solve()
         self.assertAlmostEqual(m.x.value, 1)
 
-        m.y = pe.Var(within=pe.NonNegativeReals)
+        m.y = pyo.Var(within=pyo.NonNegativeReals)
 
         opt.add_column(m, m.y, -3, [m.c], [2])
         opt.solve()
@@ -246,35 +246,35 @@ class TestXpressPersistent(unittest.TestCase):
 
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_column_exceptions(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var()
-        m.c = pe.Constraint(expr=(0, m.x, 1))
-        m.ci = pe.Constraint([1, 2], rule=lambda m, i: (0, m.x, i + 1))
-        m.cd = pe.Constraint(expr=(0, -m.x, 1))
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.c = pyo.Constraint(expr=(0, m.x, 1))
+        m.ci = pyo.Constraint([1, 2], rule=lambda m, i: (0, m.x, i + 1))
+        m.cd = pyo.Constraint(expr=(0, -m.x, 1))
         m.cd.deactivate()
-        m.obj = pe.Objective(expr=-m.x)
+        m.obj = pyo.Objective(expr=-m.x)
 
-        opt = pe.SolverFactory('xpress_persistent')
+        opt = pyo.SolverFactory('xpress_persistent')
 
         # set_instance not called
         self.assertRaises(RuntimeError, opt.add_column, m, m.x, 0, [m.c], [1])
 
         opt.set_instance(m)
 
-        m2 = pe.ConcreteModel()
-        m2.y = pe.Var()
-        m2.c = pe.Constraint(expr=(0, m.x, 1))
+        m2 = pyo.ConcreteModel()
+        m2.y = pyo.Var()
+        m2.c = pyo.Constraint(expr=(0, m.x, 1))
 
         # different model than attached to opt
         self.assertRaises(RuntimeError, opt.add_column, m2, m2.y, 0, [], [])
         # pyomo var attached to different model
         self.assertRaises(RuntimeError, opt.add_column, m, m2.y, 0, [], [])
 
-        z = pe.Var()
+        z = pyo.Var()
         # pyomo var floating
         self.assertRaises(RuntimeError, opt.add_column, m, z, -2, [m.c, z], [1])
 
-        m.y = pe.Var()
+        m.y = pyo.Var()
         # len(coefficients) == len(constraints)
         self.assertRaises(RuntimeError, opt.add_column, m, m.y, -2, [m.c], [1, 2])
         self.assertRaises(RuntimeError, opt.add_column, m, m.y, -2, [m.c, z], [1])
@@ -298,17 +298,17 @@ class TestXpressPersistent(unittest.TestCase):
     def test_nonconvexqp_locally_optimal(self):
         """Test non-convex QP for which xpress_direct should find a locally
         optimal solution."""
-        m = pe.ConcreteModel()
-        m.x1 = pe.Var()
-        m.x2 = pe.Var()
-        m.x3 = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x1 = pyo.Var()
+        m.x2 = pyo.Var()
+        m.x3 = pyo.Var()
 
-        m.obj = pe.Objective(rule=lambda m: 2 * m.x1 + m.x2 + m.x3, sense=pe.minimize)
-        m.equ1 = pe.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == 1)
-        m.cone = pe.Constraint(rule=lambda m: m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
-        m.equ2 = pe.Constraint(rule=lambda m: m.x1 >= 0)
+        m.obj = pyo.Objective(rule=lambda m: 2 * m.x1 + m.x2 + m.x3, sense=pyo.minimize)
+        m.equ1 = pyo.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == 1)
+        m.cone = pyo.Constraint(rule=lambda m: m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
+        m.equ2 = pyo.Constraint(rule=lambda m: m.x1 >= 0)
 
-        opt = pe.SolverFactory('xpress_direct')
+        opt = pyo.SolverFactory('xpress_direct')
         opt.options['XSLP_SOLVER'] = 0
         # xpress 9.5.0 now defaults to trying (and failing) to solve this problem
         # using the global solver. This option forces the use of the local solver.
@@ -329,18 +329,18 @@ class TestXpressPersistent(unittest.TestCase):
     @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_nonconvexqp_infeasible(self):
         """Test non-convex QP which xpress_direct should prove infeasible."""
-        m = pe.ConcreteModel()
-        m.x1 = pe.Var()
-        m.x2 = pe.Var()
-        m.x3 = pe.Var()
+        m = pyo.ConcreteModel()
+        m.x1 = pyo.Var()
+        m.x2 = pyo.Var()
+        m.x3 = pyo.Var()
 
-        m.obj = pe.Objective(rule=lambda m: 2 * m.x1 + m.x2 + m.x3, sense=pe.minimize)
-        m.equ1a = pe.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == 1)
-        m.equ1b = pe.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == -1)
-        m.cone = pe.Constraint(rule=lambda m: m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
-        m.equ2 = pe.Constraint(rule=lambda m: m.x1 >= 0)
+        m.obj = pyo.Objective(rule=lambda m: 2 * m.x1 + m.x2 + m.x3, sense=pyo.minimize)
+        m.equ1a = pyo.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == 1)
+        m.equ1b = pyo.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == -1)
+        m.cone = pyo.Constraint(rule=lambda m: m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
+        m.equ2 = pyo.Constraint(rule=lambda m: m.x1 >= 0)
 
-        opt = pe.SolverFactory('xpress_direct')
+        opt = pyo.SolverFactory('xpress_direct')
         opt.options['XSLP_SOLVER'] = 0
 
         results = opt.solve(m)

--- a/pyomo/util/tests/test_report_scaling.py
+++ b/pyomo/util/tests/test_report_scaling.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
+import pyomo.environ as pyo
 from pyomo.util.report_scaling import report_scaling
 import logging
 from pyomo.common import unittest
@@ -20,10 +20,10 @@ import re
 
 class TestReportScaling(unittest.TestCase):
     def test_report_scaling(self):
-        m = pe.ConcreteModel()
-        m.x = pe.Var(list(range(5)))
-        m.c = pe.Constraint(list(range(4)))
-        m.p = pe.Param(initialize=0, mutable=True)
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(list(range(5)))
+        m.c = pyo.Constraint(list(range(4)))
+        m.p = pyo.Param(initialize=0, mutable=True)
 
         m.x[0].setlb(-1)
         m.x[0].setub(1)
@@ -34,8 +34,8 @@ class TestReportScaling(unittest.TestCase):
         m.x[3].setlb(-20)
         m.x[3].setub(20)
 
-        m.obj1 = pe.Objective(expr=1e-8 * m.x[0] + pe.exp(m.x[3]) + m.x[1] * m.x[2])
-        m.obj2 = pe.Objective(expr=m.x[0] * m.x[3] + m.x[1] ** 2)
+        m.obj1 = pyo.Objective(expr=1e-8 * m.x[0] + pyo.exp(m.x[3]) + m.x[1] * m.x[2])
+        m.obj2 = pyo.Objective(expr=m.x[0] * m.x[3] + m.x[1] ** 2)
 
         m.c[0] = m.x[0] + m.x[3] == 0
         m.c[1] = 1 / m.x[1] == 1


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
Inspired by #1026, this standardizes across all documentation and code to use `import pyomo.environ as pyo` rather than `as pe`.

## Changes proposed in this PR:
- Replace `import pyomo.environ as pe` with `import pyomo.environ as pyo`


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
