### PR TITLE
May Constraint.Feasible/Infeasible to concrete constraints

### DIFF
--- a/pyomo/contrib/cp/transform/logical_to_disjunctive_walker.py
+++ b/pyomo/contrib/cp/transform/logical_to_disjunctive_walker.py
@@ -29,6 +29,10 @@ from pyomo.core.base.var import ScalarVar, VarData
 from pyomo.gdp.disjunct import AutoLinkedBooleanVar, Disjunct, Disjunction
 
 
+def _dispatch_boolean_const(visitor, node):
+    return False, 1 if node.value else 0
+
+
 def _dispatch_boolean_var(visitor, node):
     if node not in visitor.boolean_to_binary_map:
         binary = node.get_associated_binary()
@@ -197,6 +201,7 @@ _operator_dispatcher[EXPR.AtLeastExpression] = _dispatch_atleast
 _operator_dispatcher[EXPR.AtMostExpression] = _dispatch_atmost
 
 _before_child_dispatcher = {}
+_before_child_dispatcher[EXPR.BooleanConstant] = _dispatch_boolean_const
 _before_child_dispatcher[BV.ScalarBooleanVar] = _dispatch_boolean_var
 _before_child_dispatcher[BV.BooleanVarData] = _dispatch_boolean_var
 _before_child_dispatcher[AutoLinkedBooleanVar] = _dispatch_boolean_var

--- a/pyomo/contrib/cp/transform/logical_to_disjunctive_walker.py
+++ b/pyomo/contrib/cp/transform/logical_to_disjunctive_walker.py
@@ -269,5 +269,9 @@ class LogicalToDisjunctiveVisitor(StreamBasedExpressionVisitor):
         # This LogicalExpression must evaluate to True (but note that we cannot
         # fix this variable to 1 since this logical expression could be living
         # on a Disjunct and later need to be relaxed.)
-        self.constraints.add(result >= 1)
+        expr = result >= 1
+        if expr.__class__ is bool:
+            self.constraints.add(Constraint.Feasible if expr else Constraint.Infeasible)
+        else:
+            self.constraints.add(expr)
         return result

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -380,7 +380,7 @@ class ConstraintData(ActiveComponentData):
 
     def set_value(self, expr):
         """Set the expression on this constraint."""
-        # Clear any previously-cached normalized constraint
+        # Clear any previous constraint
         self._expr = None
         if expr.__class__ in _known_relational_expression_types:
             if getattr(expr, 'strict', False) in _strict_relational_exprs:
@@ -406,7 +406,7 @@ class ConstraintData(ActiveComponentData):
                     "Constraint expressions expressed as tuples must "
                     "contain native numeric types or Pyomo NumericValue "
                     "objects. Tuple %s contained invalid type, %s"
-                    % (self.name, expr, arg.__class__.__name__)
+                    % (self.name, expr, type(arg).__name__)
                 )
             if len(expr) == 2:
                 #
@@ -639,11 +639,11 @@ class Constraint(ActiveIndexedComponent):
 
     def __new__(cls, *args, **kwds):
         if cls != Constraint:
-            return super(Constraint, cls).__new__(cls)
+            return super().__new__(cls)
         if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
-            return super(Constraint, cls).__new__(AbstractScalarConstraint)
+            return super().__new__(AbstractScalarConstraint)
         else:
-            return super(Constraint, cls).__new__(IndexedConstraint)
+            return super().__new__(IndexedConstraint)
 
     @overload
     def __init__(self, *indexes, expr=None, rule=None, name=None, doc=None): ...
@@ -900,7 +900,7 @@ class ScalarConstraint(ConstraintData, Constraint):
         """Set the expression on this constraint."""
         if not self._data:
             self._data[None] = self
-        return super(ScalarConstraint, self).set_value(expr)
+        return super().set_value(expr)
 
     #
     # Leaving this method for backward compatibility reasons.
@@ -980,7 +980,7 @@ class ConstraintList(IndexedConstraint):
         _rule = kwargs.pop('rule', None)
         self._starting_index = kwargs.pop('starting_index', 1)
 
-        super(ConstraintList, self).__init__(Set(dimen=1), **kwargs)
+        super().__init__(Set(dimen=1), **kwargs)
 
         self.rule = Initializer(
             _rule, treat_sequences_as_mappings=False, allow_generators=True

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -484,7 +484,7 @@ class ConstraintData(ActiveComponentData):
             "relational expression. Examples:"
             "\n   sum(model.costs) == model.income"
             "\n   (0, model.price[item], 50)"
-            % (self.name, type(arg).__name__, str(expr))
+            % (self.name, type(expr).__name__, str(expr))
         )
         raise ValueError(msg)
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -448,9 +448,16 @@ class ConstraintData(ActiveComponentData):
                 del self.parent_component()[self.index()]
                 return
             elif expr is Constraint.Infeasible:
+                # Note that an inequality is sufficient to induce
+                # infeasibility and is simpler to relax (in the Big-M
+                # sense) than an equality.
                 self._expr = InequalityExpression((1, 0), False)
                 return
             elif expr is Constraint.Feasible:
+                # Note that we do not want to provide a trivial equality
+                # constraint as that can confuse solvers like Ipopt into
+                # believing that the model has fewer degrees of freedom
+                # than it actually has.
                 self._expr = InequalityExpression((0, 0), False)
                 return
             else:

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -62,7 +62,7 @@ TEMPLATIZE_CONSTRAINTS = False
 
 _inf = float('inf')
 _nonfinite_values = {_inf, -_inf}
-_known_relational_expressions = {
+_known_relational_expression_types = {
     EqualityExpression,
     InequalityExpression,
     RangedExpression,
@@ -382,7 +382,7 @@ class ConstraintData(ActiveComponentData):
         """Set the expression on this constraint."""
         # Clear any previously-cached normalized constraint
         self._expr = None
-        if expr.__class__ in _known_relational_expressions:
+        if expr.__class__ in _known_relational_expression_types:
             if getattr(expr, 'strict', False) in _strict_relational_exprs:
                 raise ValueError(
                     "Constraint '%s' encountered a strict "

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -441,16 +441,15 @@ class ConstraintData(ActiveComponentData):
         # Ignore an 'empty' constraint
         #
         elif expr.__class__ is type:
-            del self.parent_component()[self.index()]
             if expr is Constraint.Skip:
+                del self.parent_component()[self.index()]
                 return
             elif expr is Constraint.Infeasible:
-                # TODO: create a trivial infeasible constraint.  This
-                # could be useful in the case of GDP where certain
-                # disjuncts are trivially infeasible, but we would still
-                # like to express the disjunction.
-                # del self.parent_component()[self.index()]
-                raise ValueError("Constraint '%s' is always infeasible" % (self.name,))
+                self._expr = InequalityExpression((1, 0), False)
+                return
+            elif expr is Constraint.Feasible:
+                self._expr = InequalityExpression((0, 0), False)
+                return
             else:
                 raise ValueError(
                     "Constraint '%s' does not have a proper "
@@ -620,7 +619,9 @@ class Constraint(ActiveIndexedComponent):
     class Infeasible(object):
         pass
 
-    Feasible = ActiveIndexedComponent.Skip
+    class Feasible(object):
+        pass
+
     NoConstraint = ActiveIndexedComponent.Skip
     Violated = Infeasible
     Satisfied = Feasible

--- a/pyomo/core/plugins/transform/logical_to_linear.py
+++ b/pyomo/core/plugins/transform/logical_to_linear.py
@@ -263,12 +263,14 @@ def _cnf_to_linear_constraint_list(cnf_expr, indicator_var=None, binary_varlist=
     # Screen for constants
     if type(cnf_expr) in native_types or cnf_expr.is_constant():
         if value(cnf_expr) is True:
+            # Trivially feasible: no constraints
             return []
         else:
-            raise ValueError(
-                "Cannot build linear constraint for logical expression with "
-                "constant value False: %s" % cnf_expr
-            )
+            # Trivially infeasible: we will return an infeasible
+            # constant expression, because is we are nested within
+            # something like a Disjunct, the model may still be feasible
+            # (only this disjunct is not feasible).
+            return [InequalityExpression((1, 0), False)]
     if cnf_expr.is_expression_type():
         return CnfToLinearVisitor(indicator_var, binary_varlist).walk_expression(
             cnf_expr

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -1375,26 +1375,43 @@ class Test2DArrayCon(unittest.TestCase):
 class MiscConTests(unittest.TestCase):
     def test_infeasible(self):
         m = ConcreteModel()
-        with self.assertRaisesRegex(ValueError, "Constraint 'c' is always infeasible"):
-            m.c = Constraint(expr=Constraint.Infeasible)
-        self.assertEqual(m.c._data, {})
-
-        with self.assertRaisesRegex(ValueError, "Constraint 'c' is always infeasible"):
-            m.c = Constraint.Infeasible
-        self.assertEqual(m.c._data, {})
-        self.assertIsNone(m.c.expr)
+        m.c = Constraint(expr=Constraint.Infeasible)
+        self.assertIn(None, m.c._data)
+        self.assertEqual(m.c.lb, None)
+        self.assertEqual(m.c.body, 1)
+        self.assertEqual(m.c.ub, 0)
 
         m.c = (0, 1, 2)
         self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, 0)
+        self.assertEqual(m.c.body, 1)
         self.assertEqual(m.c.ub, 2)
 
-        with self.assertRaisesRegex(ValueError, "Constraint 'c' is always infeasible"):
-            m.c = Constraint.Infeasible
-        self.assertEqual(m.c._data, {})
-        self.assertIsNone(m.c.expr)
+        m.c = Constraint.Infeasible
+        self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, None)
-        self.assertEqual(m.c.ub, None)
+        self.assertEqual(m.c.body, 1)
+        self.assertEqual(m.c.ub, 0)
+
+    def test_feasible(self):
+        m = ConcreteModel()
+        m.c = Constraint(expr=Constraint.Feasible)
+        self.assertIn(None, m.c._data)
+        self.assertEqual(m.c.lb, None)
+        self.assertEqual(m.c.body, 0)
+        self.assertEqual(m.c.ub, 0)
+
+        m.c = (0, 1, 2)
+        self.assertIn(None, m.c._data)
+        self.assertEqual(m.c.lb, 0)
+        self.assertEqual(m.c.body, 1)
+        self.assertEqual(m.c.ub, 2)
+
+        m.c = Constraint.Feasible
+        self.assertIn(None, m.c._data)
+        self.assertEqual(m.c.lb, None)
+        self.assertEqual(m.c.body, 0)
+        self.assertEqual(m.c.ub, 0)
 
     def test_slack_methods(self):
         model = ConcreteModel()

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -27,8 +27,10 @@ from pyomo.core import (
     ModelComponentFactory,
     Binary,
     Block,
+    Constraint,
     ConstraintList,
     Any,
+    LogicalConstraint,
     LogicalConstraintList,
     BooleanValue,
     ScalarBooleanVar,
@@ -575,19 +577,30 @@ class DisjunctionData(ActiveComponentData):
             # The user was lazy and gave us a single constraint
             # expression or an iterable of expressions
             expressions = []
-            for _tmpe in e_iter:
+            propositions = []
+            for _tmp_e in e_iter:
                 try:
-                    if _tmpe.is_expression_type():
-                        expressions.append(_tmpe)
+                    if _tmp_e.is_expression_type(ExpressionType.RELATIONAL):
+                        expressions.append(_tmp_e)
+                        continue
+                    if _tmp_e.is_expression_type(ExpressionType.LOGICAL):
+                        propositions.append(_tmp_e)
                         continue
                 except AttributeError:
                     pass
+                if _tmp_e in (Constraint.Feasible, Constraint.Infeasible):
+                    expressions.append(_tmp_e)
+                    continue
+                if _tmp_e in (LogicalConstraint.Feasible, LogicalConstraint.Infeasible):
+                    propositions.append(_tmp_e)
+                    continue
                 msg = " in '%s'" % (type(e).__name__,) if e_iter is e else ""
                 raise ValueError(
-                    "Unexpected term for Disjunction '%s'.\n"
-                    "    Expected a Disjunct object, relational expression, "
-                    "or iterable of\n    relational expressions but got '%s'%s"
-                    % (self.name, type(_tmpe).__name__, msg)
+                    "Unexpected term for Disjunction '%s'.\n    "
+                    "Expected a Disjunct object, relational or logical "
+                    "expression, or\n    iterable of relational/logical "
+                    "expressions but got '%s'%s"
+                    % (self.name, type(_tmp_e).__name__, msg)
                 )
 
             comp = self.parent_component()
@@ -603,19 +616,8 @@ class DisjunctionData(ActiveComponentData):
                 # happen automatically.
                 comp._autodisjuncts.construct()
             disjunct = comp._autodisjuncts[len(comp._autodisjuncts)]
-            disjunct.constraint = c = ConstraintList()
-            disjunct.propositions = p = LogicalConstraintList()
-            for e in expressions:
-                if e.is_expression_type(ExpressionType.RELATIONAL):
-                    c.add(e)
-                elif e.is_expression_type(ExpressionType.LOGICAL):
-                    p.add(e)
-                else:
-                    raise RuntimeError(
-                        "Unsupported expression type on Disjunct "
-                        f"{disjunct.name}: expected either relational or "
-                        f"logical expression, found {e.__class__.__name__}"
-                    )
+            disjunct.constraint = ConstraintList(rule=expressions)
+            disjunct.propositions = LogicalConstraintList(rule=propositions)
             self.disjuncts.append(disjunct)
 
 

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -40,6 +40,7 @@ import random
 import pyomo.opt
 
 linear_solvers = pyomo.opt.check_available_solvers('glpk', 'cbc', 'gurobi', 'cplex')
+nonlinear_solvers = pyomo.opt.check_available_solvers('ipopt')
 
 # utility functions
 
@@ -1852,6 +1853,31 @@ def check_untransformed_network_raises_GDPError(self, transformation, **kwargs):
         m,
         **kwargs
     )
+
+
+def check_trivial_constraints(self, solver, transformation, **kwds):
+    m = models.makeTrivialGDP()
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, **kwds)
+    results = SolverFactory(solver).solve(m)
+    self.assertEqual(results.solver.termination_condition, TerminationCondition.optimal)
+    self.assertTrue(m.numeric.disjuncts[0].indicator_var.value)
+    self.assertFalse(m.numeric.disjuncts[1].indicator_var.value)
+    self.assertTrue(m.logical.disjuncts[0].indicator_var.value)
+    self.assertFalse(m.logical.disjuncts[1].indicator_var.value)
+
+    m.numeric.disjuncts[0].indicator_var.fix(False)
+    results = SolverFactory(solver).solve(m)
+    self.assertEqual(
+        results.solver.termination_condition, TerminationCondition.infeasible
+    )
+    m.numeric.disjuncts[0].indicator_var.unfix()
+
+    m.logical.disjuncts[0].indicator_var.fix(False)
+    results = SolverFactory(solver).solve(m)
+    self.assertEqual(
+        results.solver.termination_condition, TerminationCondition.infeasible
+    )
+    m.logical.disjuncts[0].indicator_var.unfix()
 
 
 def check_network_disjuncts(self, minimize, transformation, **kwds):

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -862,6 +862,16 @@ def makeAnyIndexedDisjunctionOfDisjunctDatas():
     return m
 
 
+def makeTrivialGDP():
+    m = ConcreteModel()
+
+    m.numeric = Disjunction(expr=[Constraint.Feasible, Constraint.Infeasible])
+    m.logical = Disjunction(
+        expr=[LogicalConstraint.Feasible, LogicalConstraint.Infeasible]
+    )
+    return m
+
+
 def makeNetworkDisjunction(minimize=True):
     """creates a GDP model with pyomo.network components"""
     m = ConcreteModel()

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -2697,6 +2697,18 @@ class EstimatingMwithFixedVars(unittest.TestCase):
         ct.check_linear_coef(self, repn, promise.d.indicator_var, 7)
 
 
+class TrivialDisjuncts(unittest.TestCase):
+    @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
+    def test_trivial_disjuncts_linear(self):
+        ct.check_trivial_constraints(self, ct.linear_solvers[0], transformation='bigm')
+
+    @unittest.skipIf(not ct.nonlinear_solvers, "No linear solver available")
+    def test_trivial_disjuncts_nonlinear(self):
+        ct.check_trivial_constraints(
+            self, ct.nonlinear_solvers[0], transformation='bigm'
+        )
+
+
 class NetworkDisjuncts(unittest.TestCase, CommonTests):
     @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
     def test_solution_maximize(self):

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -114,22 +114,25 @@ class TestDisjunction(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError,
             "Unexpected term for Disjunction 'dd'.\n    "
-            "Expected a Disjunct object, relational expression, or iterable of\n"
-            "    relational expressions but got 'IndexedDisjunct'",
+            "Expected a Disjunct object, relational or logical "
+            "expression, or\n    iterable of relational/logical "
+            "expressions but got 'IndexedDisjunct'",
         ):
             m.dd = Disjunction(expr=[m.d])
         with self.assertRaisesRegex(
             ValueError,
             "Unexpected term for Disjunction 'ee'.\n    "
-            "Expected a Disjunct object, relational expression, or iterable of\n"
-            "    relational expressions but got 'str' in 'list'",
+            "Expected a Disjunct object, relational or logical "
+            "expression, or\n    iterable of relational/logical "
+            "expressions but got 'str' in 'list'",
         ):
             m.ee = Disjunction(expr=[['a']])
         with self.assertRaisesRegex(
             ValueError,
             "Unexpected term for Disjunction 'ff'.\n    "
-            "Expected a Disjunct object, relational expression, or iterable of\n"
-            "    relational expressions but got 'str'",
+            "Expected a Disjunct object, relational or logical "
+            "expression, or\n    iterable of relational/logical "
+            "expressions but got 'str'",
         ):
             m.ff = Disjunction(expr=['a'])
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #2918 .

## Summary/Motivation:
We have historically mapped `Constraint.Feasible` to `Constraint.Skip` and had `Constraint.Infeasible` immediately raise a `ValueError`.  This causes some undesirable behavior:
- You cannot "evaluate" a `Constraint` that was set by `Constraint.Feasible` because the `ConstraintData` was not created (see [this question](https://stackoverflow.com/questions/79535717/constraint-feasible-does-not-return-callable-constraints) on SO)
- You cannot (easily) have a trivially infeasible constraint anywhere in the model, even if the infeasible constraint would not cause the model to be infeasible (because it was on a disjunct; see #2918)

This updates `Constraint` and `LogicalConstraint` to map `Constraint.Feasible` to a trivial inequality, and `Constraint.Infeasible` to a trivial infeasible Inequality.

## Changes proposed in this PR:
- Map `Constraint.Feasible` and `Constraint.Infeasible` to actual trivial constraints
- Rework part of Constraint to remove a repeated exception
- Port LogicalConstraint to the new structure (initillizers, disable_method, Abstract classes, simplified method overrides) from Constraint
- Update `logical_to_linear` and `logical_to_disjunctive` to support constant expressions
- Update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
