### PR TITLE
Support passing LoggerAdapter objects to LogStream

### DIFF
--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -415,6 +415,8 @@ class LogStream(io.TextIOBase):
         """
         found = 0
         logger = self._logger
+        while isinstance(logger, logging.LoggerAdapter):
+            logger = logger.logger
         while logger:
             for handler in logger.handlers:
                 found += 1

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -550,6 +550,18 @@ class TestLogStream(unittest.TestCase):
             # Exiting the context manager flushes the LogStream
             self.assertEqual(OUT.getvalue(), "INFO: line 1\nINFO: line 2\n")
 
+    def test_loggerAdapter(self):
+        class Adapter(logging.LoggerAdapter):
+            def process(self, msg, kwargs):
+                return '[%s] %s' % (self.extra['foo'], msg), kwargs
+
+        adapter = Adapter(logging.getLogger('pyomo'), {"foo": 42})
+        ls = LogStream(logging.INFO, adapter)
+        LI = LoggingIntercept(level=logging.INFO, formatter=pyomo_formatter)
+        with LI as OUT:
+            ls.write("hello, world\n")
+            self.assertEqual(OUT.getvalue(), "INFO: [42] hello, world\n")
+
 
 class TestPreformatted(unittest.TestCase):
     def test_preformatted_api(self):

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -89,7 +89,7 @@ class Solution(MapContainer):
         #
         # the following is specialized logic for handling variable and
         # constraint maps - which are dictionaries of dictionaries, with
-        # at a minimum an "id" element per sub-directionary.
+        # at a minimum an "id" element per sub-dictionary.
         #
         first = True
         for key in self._order:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
@michaelbynum noted that `capture_output` was not compatible with `LogStreams` that pointed to `logging.LoggerAdapter` objects (this was generating exceptions in IDAES).  This resolves that limitation.

## Changes proposed in this PR:
- `LogStream.redirect_streams()`: resolve `LoggerAdapter` objects to their underlying `Logger` before looking for handlers.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
