### PR TITLE
Update ASL CMake builders

### DIFF
--- a/pyomo/contrib/ampl_function_demo/src/CMakeLists.txt
+++ b/pyomo/contrib/ampl_function_demo/src/CMakeLists.txt
@@ -9,8 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0)
-# CMake 3.0 needed by AMPL/asl build
+cmake_minimum_required(VERSION 3.0...3.5)
+# This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( ampl_function_demo )
 

--- a/pyomo/contrib/ampl_function_demo/src/CMakeLists.txt
+++ b/pyomo/contrib/ampl_function_demo/src/CMakeLists.txt
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0...3.5)
+cmake_minimum_required(VERSION 3.0...3.31)
 # This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( ampl_function_demo )

--- a/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
+++ b/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0...3.5)
+cmake_minimum_required(VERSION 3.0...3.31)
 # CMake 3.0 added GIT_SUBMODULES to ExternalProject_ADD, and without it
 # the Ampl/MP checkout fails because one of the submodules (gecode) is a
 # private repository.

--- a/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
+++ b/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
@@ -9,8 +9,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0)
-# Minimum version inherited from AMPL/asl
+cmake_minimum_required(VERSION 3.0...3.5)
+# CMake 3.0 added GIT_SUBMODULES to ExternalProject_ADD, and without it
+# the Ampl/MP checkout fails because one of the submodules (gecode) is a
+# private repository.
+#
+# CMake will complain/fail if we don't explicitly acknowledge 3.5
+# compatibility.  AMPL/asl has moved their min version to 3.5.
 
 include(ExternalProject)
 

--- a/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
+++ b/pyomo/contrib/ampl_function_demo/src/FindASL.cmake
@@ -20,9 +20,10 @@ cmake_minimum_required(VERSION 3.0...3.5)
 include(ExternalProject)
 
 # Dependencies that we manage / can install
-SET(AMPLASL_TAG "9fb7cb8e4f68ed1c3bc066d191e63698b7d7d1d2" CACHE STRING
+SET(AMPLASL_TAG "ae937db9bd1169ec2c4cb8d75196f67cdcb8041b" CACHE STRING
   "AMPL/asl git tag/branch to checkout and build")
-# 9fb7cb8e4f68ed1c3bc066d191e63698b7d7d1d2 corresponds to ASLdate = 20211109
+# 9fb7cb8e4f68ed1c3bc066d191e63698b7d7d1d2: ASLdate=20211109
+# ae937db9bd1169ec2c4cb8d75196f67cdcb8041b: v1.0.1  ASLdate = 20241202/20241122
 OPTION(BUILD_AMPLASL
   "Download and build AMPL/asl ${AMPLASL_TAG} from GitHub" OFF)
 

--- a/pyomo/contrib/cspline_external/src/CMakeLists.txt
+++ b/pyomo/contrib/cspline_external/src/CMakeLists.txt
@@ -9,8 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0)
-# CMake 3.0 needed by AMPL/asl build
+cmake_minimum_required(VERSION 3.0...3.5)
+# This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( cspline_external )
 

--- a/pyomo/contrib/cspline_external/src/CMakeLists.txt
+++ b/pyomo/contrib/cspline_external/src/CMakeLists.txt
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0...3.5)
+cmake_minimum_required(VERSION 3.0...3.31)
 # This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( cspline_external )

--- a/pyomo/contrib/pynumero/src/CMakeLists.txt
+++ b/pyomo/contrib/pynumero/src/CMakeLists.txt
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-cmake_minimum_required(VERSION 3.0...3.5)
+cmake_minimum_required(VERSION 3.0...3.31)
 # This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( pynumero )

--- a/pyomo/contrib/pynumero/src/CMakeLists.txt
+++ b/pyomo/contrib/pynumero/src/CMakeLists.txt
@@ -1,7 +1,16 @@
-cmake_minimum_required(VERSION 3.0)
-# CMake 3.0 added GIT_SUBMODULES to ExternalProject_ADD, and without it
-# the Ampl/MP checkout fails because one of the submodules (gecode) is a
-# private repository.
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2025
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+cmake_minimum_required(VERSION 3.0...3.5)
+# This was developed against CMake 3.0, and appears to comply with 3.5
 
 PROJECT( pynumero )
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
CMake will now error if the project minimum version is <3.5.  This PR bumps the declared minimum versions to suppress that error.  It also takes the opportunity to bump the version of the ASL we check out to the `v1.0.1` release.

## Changes proposed in this PR:
- Bump CMake minimum version from `3.0` to `3.0...3.31` to suppress CMake error
- Bump the ASL hash to check out to match the `v1.0.1` release
- Fix a file with a missing copyright statement

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
