### PR TITLE
Clean up numeric_expr dispatcher test driver

### DIFF
--- a/pyomo/core/tests/unit/test_numeric_expr_dispatcher.py
+++ b/pyomo/core/tests/unit/test_numeric_expr_dispatcher.py
@@ -201,8 +201,8 @@ class Base(object):
         try:
             for test_num, test in enumerate(tests):
                 ans = None
-                args = test[:-1]
-                result = test[-1]
+                args = [clone_expression(arg) for arg in test[:-1]]
+                result = clone_expression(test[-1])
                 if result is self.SKIP:
                     continue
                 orig_args = list(args)
@@ -212,7 +212,7 @@ class Base(object):
                     classes = [arg.__class__ for arg in args]
                     with LoggingIntercept() as LOG:
                         ans = op(*args)
-                    if not any(arg is self.asbinary for arg in args):
+                    if not any(arg is self.asbinary for arg in test):
                         self.assertEqual(LOG.getvalue(), "")
                     assertExpressionsEqual(self, result, ans)
                     for i, arg in enumerate(args):
@@ -257,8 +257,8 @@ class Base(object):
         try:
             for test_num, test in enumerate(tests):
                 ans = None
-                args = test[:-1]
-                result = test[-1]
+                args = [clone_expression(arg) for arg in test[:-1]]
+                result = clone_expression(test[-1])
                 if result is self.SKIP:
                     continue
                 orig_args = list(args)
@@ -268,7 +268,7 @@ class Base(object):
                     classes = [arg.__class__ for arg in args]
                     with LoggingIntercept() as LOG:
                         ans = op(*args)
-                    if not any(arg is self.asbinary for arg in args):
+                    if not any(arg is self.asbinary for arg in test):
                         self.assertEqual(LOG.getvalue(), "")
                     assertExpressionsEqual(self, result, ans)
                     for i, arg in enumerate(args):

--- a/pyomo/core/tests/unit/test_numeric_expr_dispatcher.py
+++ b/pyomo/core/tests/unit/test_numeric_expr_dispatcher.py
@@ -14,7 +14,6 @@
 import logging
 import math
 import operator
-import sys
 
 import pyomo.common.unittest as unittest
 
@@ -80,7 +79,7 @@ class Base(object):
         #
         # class _EXPR_TYPE(enum.Enum):
         #     MUTABLE = -2
-        #     ASBINARY = -1
+        #     ASNUMERIC = -1
         #     INVALID = 0
         #     NATIVE = 1
         #     NPV = 2
@@ -121,6 +120,10 @@ class Base(object):
         self.mutable_l1 = _MutableLinearExpression([self.mon_npv])
         self.mutable_l2 = _MutableSumExpression([self.mon_npv, self.other])
         self.mutable_l3 = _MutableNPVSumExpression([self.npv])
+        self.l0 = 0
+        self.l1 = self.mon_npv
+        self.l2 = SumExpression([self.mon_npv, self.other])
+        self.l3 = self.npv
 
         # often repeated reference expressions
         self.minus_bin = MonomialTermExpression((-1, self.bin))
@@ -137,7 +140,7 @@ class Base(object):
         self.minus_linear = NegationExpression((self.linear,))
         self.minus_sum = NegationExpression((self.sum,))
         self.minus_other = NegationExpression((self.other,))
-        self.minus_mutable_l2 = NegationExpression((self.mutable_l2,))
+        self.minus_l2 = NegationExpression((self.l2,))
 
         self.TEMPLATE = [
             self.invalid,
@@ -404,11 +407,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.bin, self.mon_npv]),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.bin]),
-            ),
+            (self.asbinary, self.mutable_l2, SumExpression(self.l2.args + [self.bin])),
             (self.asbinary, self.param0, self.bin),
             (self.asbinary, self.param1, LinearExpression([self.bin, 1])),
             # 20:
@@ -440,7 +439,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 0),
             # 16:
             (self.zero, self.mutable_l1, self.mon_npv),
-            (self.zero, self.mutable_l2, self.mutable_l2),
+            (self.zero, self.mutable_l2, self.l2),
             (self.zero, self.param0, 0),
             (self.zero, self.param1, 1),
             # 20:
@@ -471,8 +470,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.one, self.other, SumExpression([1, self.other])),
             (self.one, self.mutable_l0, 1),
             # 16:
-            (self.one, self.mutable_l1, LinearExpression([1] + self.mutable_l1.args)),
-            (self.one, self.mutable_l2, SumExpression(self.mutable_l2.args + [1])),
+            (self.one, self.mutable_l1, LinearExpression([1, self.l1])),
+            (self.one, self.mutable_l2, SumExpression(self.l2.args + [1])),
             (self.one, self.param0, 1),
             (self.one, self.param1, 2),
             # 20:
@@ -503,12 +502,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.native, self.other, SumExpression([5, self.other])),
             (self.native, self.mutable_l0, 5),
             # 16:
-            (
-                self.native,
-                self.mutable_l1,
-                LinearExpression([5] + self.mutable_l1.args),
-            ),
-            (self.native, self.mutable_l2, SumExpression(self.mutable_l2.args + [5])),
+            (self.native, self.mutable_l1, LinearExpression([5, self.l1])),
+            (self.native, self.mutable_l2, SumExpression(self.l2.args + [5])),
             (self.native, self.param0, 5),
             (self.native, self.param1, 6),
             # 20:
@@ -539,16 +534,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.npv, self.other, SumExpression([self.npv, self.other])),
             (self.npv, self.mutable_l0, self.npv),
             # 16:
-            (
-                self.npv,
-                self.mutable_l1,
-                LinearExpression([self.npv] + self.mutable_l1.args),
-            ),
-            (
-                self.npv,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.npv]),
-            ),
+            (self.npv, self.mutable_l1, LinearExpression([self.npv, self.l1])),
+            (self.npv, self.mutable_l2, SumExpression(self.l2.args + [self.npv])),
             (self.npv, self.param0, self.npv),
             (self.npv, self.param1, NPV_SumExpression([self.npv, 1])),
             # 20:
@@ -579,8 +566,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param, self.other, SumExpression([6, self.other])),
             (self.param, self.mutable_l0, 6),
             # 16:
-            (self.param, self.mutable_l1, LinearExpression([6] + self.mutable_l1.args)),
-            (self.param, self.mutable_l2, SumExpression(self.mutable_l2.args + [6])),
+            (self.param, self.mutable_l1, LinearExpression([6, self.l1])),
+            (self.param, self.mutable_l2, SumExpression(self.l2.args + [6])),
             (self.param, self.param0, 6),
             (self.param, self.param1, 7),
             # 20:
@@ -638,12 +625,12 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l1,
-                LinearExpression([self.param_mut] + self.mutable_l1.args),
+                LinearExpression([self.param_mut, self.l1]),
             ),
             (
                 self.param_mut,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.param_mut]),
+                SumExpression(self.l2.args + [self.param_mut]),
             ),
             (self.param_mut, self.param0, self.param_mut),
             (self.param_mut, self.param1, NPV_SumExpression([self.param_mut, 1])),
@@ -679,16 +666,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.var, self.other, SumExpression([self.var, self.other])),
             (self.var, self.mutable_l0, self.var),
             # 16:
-            (
-                self.var,
-                self.mutable_l1,
-                LinearExpression([self.var] + self.mutable_l1.args),
-            ),
-            (
-                self.var,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.var]),
-            ),
+            (self.var, self.mutable_l1, LinearExpression([self.var, self.l1])),
+            (self.var, self.mutable_l2, SumExpression(self.l2.args + [self.var])),
             (self.var, self.param0, self.var),
             (self.var, self.param1, LinearExpression([self.var, 1])),
             # 20:
@@ -750,12 +729,12 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l1,
-                LinearExpression([self.mon_native] + self.mutable_l1.args),
+                LinearExpression([self.mon_native, self.l1]),
             ),
             (
                 self.mon_native,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_native]),
+                SumExpression(self.l2.args + [self.mon_native]),
             ),
             (self.mon_native, self.param0, self.mon_native),
             (self.mon_native, self.param1, LinearExpression([self.mon_native, 1])),
@@ -818,12 +797,12 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l1,
-                LinearExpression([self.mon_param] + self.mutable_l1.args),
+                LinearExpression([self.mon_param, self.l1]),
             ),
             (
                 self.mon_param,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_param]),
+                SumExpression(self.l2.args + [self.mon_param]),
             ),
             (self.mon_param, self.param0, self.mon_param),
             (self.mon_param, self.param1, LinearExpression([self.mon_param, 1])),
@@ -879,15 +858,11 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mon_npv, self.other, SumExpression([self.mon_npv, self.other])),
             (self.mon_npv, self.mutable_l0, self.mon_npv),
             # 16:
-            (
-                self.mon_npv,
-                self.mutable_l1,
-                LinearExpression([self.mon_npv] + self.mutable_l1.args),
-            ),
+            (self.mon_npv, self.mutable_l1, LinearExpression([self.mon_npv, self.l1])),
             (
                 self.mon_npv,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_npv]),
+                SumExpression(self.l2.args + [self.mon_npv]),
             ),
             (self.mon_npv, self.param0, self.mon_npv),
             (self.mon_npv, self.param1, LinearExpression([self.mon_npv, 1])),
@@ -946,13 +921,9 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.linear,
                 self.mutable_l1,
-                LinearExpression(self.linear.args + self.mutable_l1.args),
+                LinearExpression(self.linear.args + [self.l1]),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.linear]),
-            ),
+            (self.linear, self.mutable_l2, SumExpression(self.l2.args + [self.linear])),
             (self.linear, self.param0, self.linear),
             (self.linear, self.param1, LinearExpression(self.linear.args + [1])),
             # 20:
@@ -991,16 +962,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.sum, self.other, SumExpression(self.sum.args + [self.other])),
             (self.sum, self.mutable_l0, self.sum),
             # 16:
-            (
-                self.sum,
-                self.mutable_l1,
-                SumExpression(self.sum.args + self.mutable_l1.args),
-            ),
-            (
-                self.sum,
-                self.mutable_l2,
-                SumExpression(self.sum.args + self.mutable_l2.args),
-            ),
+            (self.sum, self.mutable_l1, SumExpression(self.sum.args + [self.l1])),
+            (self.sum, self.mutable_l2, SumExpression(self.sum.args + self.l2.args)),
             (self.sum, self.param0, self.sum),
             (self.sum, self.param1, SumExpression(self.sum.args + [1])),
             # 20:
@@ -1032,11 +995,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.other, self.mutable_l0, self.other),
             # 16:
             (self.other, self.mutable_l1, SumExpression([self.other, self.mon_npv])),
-            (
-                self.other,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.other]),
-            ),
+            (self.other, self.mutable_l2, SumExpression(self.l2.args + [self.other])),
             (self.other, self.param0, self.other),
             (self.other, self.param1, SumExpression([self.other, 1])),
             # 20:
@@ -1068,7 +1027,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, self.mutable_l0, 0),
             # 16:
             (self.mutable_l0, self.mutable_l1, self.mon_npv),
-            (self.mutable_l0, self.mutable_l2, self.mutable_l2),
+            (self.mutable_l0, self.mutable_l2, self.l2),
             (self.mutable_l0, self.param0, 0),
             (self.mutable_l0, self.param1, 1),
             # 20:
@@ -1081,91 +1040,47 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_add_mutable_l1(self):
         tests = [
             (self.mutable_l1, self.invalid, NotImplemented),
-            (
-                self.mutable_l1,
-                self.asbinary,
-                LinearExpression(self.mutable_l1.args + [self.bin]),
-            ),
+            (self.mutable_l1, self.asbinary, LinearExpression([self.l1, self.bin])),
             (self.mutable_l1, self.zero, self.mon_npv),
-            (self.mutable_l1, self.one, LinearExpression(self.mutable_l1.args + [1])),
+            (self.mutable_l1, self.one, LinearExpression([self.l1, 1])),
             # 4:
-            (
-                self.mutable_l1,
-                self.native,
-                LinearExpression(self.mutable_l1.args + [5]),
-            ),
-            (
-                self.mutable_l1,
-                self.npv,
-                LinearExpression(self.mutable_l1.args + [self.npv]),
-            ),
-            (self.mutable_l1, self.param, LinearExpression(self.mutable_l1.args + [6])),
+            (self.mutable_l1, self.native, LinearExpression([self.l1, 5])),
+            (self.mutable_l1, self.npv, LinearExpression([self.l1, self.npv])),
+            (self.mutable_l1, self.param, LinearExpression([self.l1, 6])),
             (
                 self.mutable_l1,
                 self.param_mut,
-                LinearExpression(self.mutable_l1.args + [self.param_mut]),
+                LinearExpression([self.l1, self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l1,
-                self.var,
-                LinearExpression(self.mutable_l1.args + [self.var]),
-            ),
+            (self.mutable_l1, self.var, LinearExpression([self.l1, self.var])),
             (
                 self.mutable_l1,
                 self.mon_native,
-                LinearExpression(self.mutable_l1.args + [self.mon_native]),
+                LinearExpression([self.l1, self.mon_native]),
             ),
             (
                 self.mutable_l1,
                 self.mon_param,
-                LinearExpression(self.mutable_l1.args + [self.mon_param]),
+                LinearExpression([self.l1, self.mon_param]),
             ),
-            (
-                self.mutable_l1,
-                self.mon_npv,
-                LinearExpression(self.mutable_l1.args + [self.mon_npv]),
-            ),
+            (self.mutable_l1, self.mon_npv, LinearExpression([self.l1, self.mon_npv])),
             # 12:
             (
                 self.mutable_l1,
                 self.linear,
-                LinearExpression(self.linear.args + self.mutable_l1.args),
+                LinearExpression(self.linear.args + [self.l1]),
             ),
-            (
-                self.mutable_l1,
-                self.sum,
-                SumExpression(self.sum.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l1,
-                self.other,
-                SumExpression(self.mutable_l1.args + [self.other]),
-            ),
+            (self.mutable_l1, self.sum, SumExpression(self.sum.args + [self.l1])),
+            (self.mutable_l1, self.other, SumExpression([self.l1, self.other])),
             (self.mutable_l1, self.mutable_l0, self.mon_npv),
             # 16:
-            (
-                self.mutable_l1,
-                self.mutable_l1,
-                LinearExpression(self.mutable_l1.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l1.args),
-            ),
+            (self.mutable_l1, self.mutable_l1, LinearExpression([self.l1, self.l1])),
+            (self.mutable_l1, self.mutable_l2, SumExpression(self.l2.args + [self.l1])),
             (self.mutable_l1, self.param0, self.mon_npv),
-            (
-                self.mutable_l1,
-                self.param1,
-                LinearExpression(self.mutable_l1.args + [1]),
-            ),
+            (self.mutable_l1, self.param1, LinearExpression([self.l1, 1])),
             # 20:
-            (
-                self.mutable_l1,
-                self.mutable_l3,
-                LinearExpression(self.mutable_l1.args + [self.npv]),
-            ),
+            (self.mutable_l1, self.mutable_l3, LinearExpression([self.l1, self.npv])),
         ]
         self._run_cases(tests, operator.add)
         # Mutable iadd handled by separate tests
@@ -1174,82 +1089,54 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_add_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                SumExpression(self.mutable_l2.args + [self.bin]),
-            ),
-            (self.mutable_l2, self.zero, self.mutable_l2),
-            (self.mutable_l2, self.one, SumExpression(self.mutable_l2.args + [1])),
+            (self.mutable_l2, self.asbinary, SumExpression(self.l2.args + [self.bin])),
+            (self.mutable_l2, self.zero, self.l2),
+            (self.mutable_l2, self.one, SumExpression(self.l2.args + [1])),
             # 4:
-            (self.mutable_l2, self.native, SumExpression(self.mutable_l2.args + [5])),
-            (
-                self.mutable_l2,
-                self.npv,
-                SumExpression(self.mutable_l2.args + [self.npv]),
-            ),
-            (self.mutable_l2, self.param, SumExpression(self.mutable_l2.args + [6])),
+            (self.mutable_l2, self.native, SumExpression(self.l2.args + [5])),
+            (self.mutable_l2, self.npv, SumExpression(self.l2.args + [self.npv])),
+            (self.mutable_l2, self.param, SumExpression(self.l2.args + [6])),
             (
                 self.mutable_l2,
                 self.param_mut,
-                SumExpression(self.mutable_l2.args + [self.param_mut]),
+                SumExpression(self.l2.args + [self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                SumExpression(self.mutable_l2.args + [self.var]),
-            ),
+            (self.mutable_l2, self.var, SumExpression(self.l2.args + [self.var])),
             (
                 self.mutable_l2,
                 self.mon_native,
-                SumExpression(self.mutable_l2.args + [self.mon_native]),
+                SumExpression(self.l2.args + [self.mon_native]),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                SumExpression(self.mutable_l2.args + [self.mon_param]),
+                SumExpression(self.l2.args + [self.mon_param]),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                SumExpression(self.mutable_l2.args + [self.mon_npv]),
+                SumExpression(self.l2.args + [self.mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                SumExpression(self.mutable_l2.args + [self.linear]),
-            ),
-            (
-                self.mutable_l2,
-                self.sum,
-                SumExpression(self.mutable_l2.args + self.sum.args),
-            ),
-            (
-                self.mutable_l2,
-                self.other,
-                SumExpression(self.mutable_l2.args + [self.other]),
-            ),
-            (self.mutable_l2, self.mutable_l0, self.mutable_l2),
+            (self.mutable_l2, self.linear, SumExpression(self.l2.args + [self.linear])),
+            (self.mutable_l2, self.sum, SumExpression(self.l2.args + self.sum.args)),
+            (self.mutable_l2, self.other, SumExpression(self.l2.args + [self.other])),
+            (self.mutable_l2, self.mutable_l0, self.l2),
             # 16:
-            (
-                self.mutable_l2,
-                self.mutable_l1,
-                SumExpression(self.mutable_l2.args + self.mutable_l1.args),
-            ),
+            (self.mutable_l2, self.mutable_l1, SumExpression(self.l2.args + [self.l1])),
             (
                 self.mutable_l2,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l2.args),
+                SumExpression(self.l2.args + self.l2.args),
             ),
-            (self.mutable_l2, self.param0, self.mutable_l2),
-            (self.mutable_l2, self.param1, SumExpression(self.mutable_l2.args + [1])),
+            (self.mutable_l2, self.param0, self.l2),
+            (self.mutable_l2, self.param1, SumExpression(self.l2.args + [1])),
             # 20:
             (
                 self.mutable_l2,
                 self.mutable_l3,
-                SumExpression(self.mutable_l2.args + [self.npv]),
+                SumExpression(self.l2.args + [self.npv]),
             ),
         ]
         self._run_cases(tests, operator.add)
@@ -1279,7 +1166,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 0),
             # 16:
             (self.param0, self.mutable_l1, self.mon_npv),
-            (self.param0, self.mutable_l2, self.mutable_l2),
+            (self.param0, self.mutable_l2, self.l2),
             (self.param0, self.param0, 0),
             (self.param0, self.param1, 1),
             # 20:
@@ -1310,12 +1197,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param1, self.other, SumExpression([1, self.other])),
             (self.param1, self.mutable_l0, 1),
             # 16:
-            (
-                self.param1,
-                self.mutable_l1,
-                LinearExpression([1] + self.mutable_l1.args),
-            ),
-            (self.param1, self.mutable_l2, SumExpression(self.mutable_l2.args + [1])),
+            (self.param1, self.mutable_l1, LinearExpression([1, self.l1])),
+            (self.param1, self.mutable_l2, SumExpression(self.l2.args + [1])),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 2),
             # 20:
@@ -1327,95 +1210,47 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_add_mutable_l3(self):
         tests = [
             (self.mutable_l3, self.invalid, NotImplemented),
-            (
-                self.mutable_l3,
-                self.asbinary,
-                LinearExpression(self.mutable_l3.args + [self.bin]),
-            ),
+            (self.mutable_l3, self.asbinary, LinearExpression([self.l3, self.bin])),
             (self.mutable_l3, self.zero, self.npv),
-            (self.mutable_l3, self.one, NPV_SumExpression(self.mutable_l3.args + [1])),
+            (self.mutable_l3, self.one, NPV_SumExpression([self.l3, 1])),
             # 4:
-            (
-                self.mutable_l3,
-                self.native,
-                NPV_SumExpression(self.mutable_l3.args + [5]),
-            ),
-            (
-                self.mutable_l3,
-                self.npv,
-                NPV_SumExpression(self.mutable_l3.args + [self.npv]),
-            ),
-            (
-                self.mutable_l3,
-                self.param,
-                NPV_SumExpression(self.mutable_l3.args + [6]),
-            ),
+            (self.mutable_l3, self.native, NPV_SumExpression([self.l3, 5])),
+            (self.mutable_l3, self.npv, NPV_SumExpression([self.l3, self.npv])),
+            (self.mutable_l3, self.param, NPV_SumExpression([self.l3, 6])),
             (
                 self.mutable_l3,
                 self.param_mut,
-                NPV_SumExpression(self.mutable_l3.args + [self.param_mut]),
+                NPV_SumExpression([self.l3, self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l3,
-                self.var,
-                LinearExpression(self.mutable_l3.args + [self.var]),
-            ),
+            (self.mutable_l3, self.var, LinearExpression([self.l3, self.var])),
             (
                 self.mutable_l3,
                 self.mon_native,
-                LinearExpression(self.mutable_l3.args + [self.mon_native]),
+                LinearExpression([self.l3, self.mon_native]),
             ),
             (
                 self.mutable_l3,
                 self.mon_param,
-                LinearExpression(self.mutable_l3.args + [self.mon_param]),
+                LinearExpression([self.l3, self.mon_param]),
             ),
-            (
-                self.mutable_l3,
-                self.mon_npv,
-                LinearExpression(self.mutable_l3.args + [self.mon_npv]),
-            ),
+            (self.mutable_l3, self.mon_npv, LinearExpression([self.l3, self.mon_npv])),
             # 12:
             (
                 self.mutable_l3,
                 self.linear,
-                LinearExpression(self.linear.args + self.mutable_l3.args),
+                LinearExpression(self.linear.args + [self.l3]),
             ),
-            (
-                self.mutable_l3,
-                self.sum,
-                SumExpression(self.sum.args + self.mutable_l3.args),
-            ),
-            (
-                self.mutable_l3,
-                self.other,
-                SumExpression(self.mutable_l3.args + [self.other]),
-            ),
+            (self.mutable_l3, self.sum, SumExpression(self.sum.args + [self.l3])),
+            (self.mutable_l3, self.other, SumExpression([self.l3, self.other])),
             (self.mutable_l3, self.mutable_l0, self.npv),
             # 16:
-            (
-                self.mutable_l3,
-                self.mutable_l1,
-                LinearExpression(self.mutable_l3.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l3.args),
-            ),
+            (self.mutable_l3, self.mutable_l1, LinearExpression([self.l3, self.l1])),
+            (self.mutable_l3, self.mutable_l2, SumExpression(self.l2.args + [self.l3])),
             (self.mutable_l3, self.param0, self.npv),
-            (
-                self.mutable_l3,
-                self.param1,
-                NPV_SumExpression(self.mutable_l3.args + [1]),
-            ),
+            (self.mutable_l3, self.param1, NPV_SumExpression([self.l3, 1])),
             # 20:
-            (
-                self.mutable_l3,
-                self.mutable_l3,
-                NPV_SumExpression(self.mutable_l3.args + [self.npv]),
-            ),
+            (self.mutable_l3, self.mutable_l3, NPV_SumExpression([self.l3, self.npv])),
         ]
         self._run_cases(tests, operator.add)
         # Mutable iadd handled by separate tests
@@ -1503,11 +1338,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.bin, self.minus_mon_npv]),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                SumExpression([self.bin, self.minus_mutable_l2]),
-            ),
+            (self.asbinary, self.mutable_l2, SumExpression([self.bin, self.minus_l2])),
             (self.asbinary, self.param0, self.bin),
             (self.asbinary, self.param1, LinearExpression([self.bin, -1])),
             # 20:
@@ -1543,7 +1374,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 0),
             # 16:
             (self.zero, self.mutable_l1, self.minus_mon_npv),
-            (self.zero, self.mutable_l2, self.minus_mutable_l2),
+            (self.zero, self.mutable_l2, self.minus_l2),
             (self.zero, self.param0, 0),
             (self.zero, self.param1, -1),
             # 20:
@@ -1575,7 +1406,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 1),
             # 16:
             (self.one, self.mutable_l1, LinearExpression([1, self.minus_mon_npv])),
-            (self.one, self.mutable_l2, SumExpression([1, self.minus_mutable_l2])),
+            (self.one, self.mutable_l2, SumExpression([1, self.minus_l2])),
             (self.one, self.param0, 1),
             (self.one, self.param1, 0),
             # 20:
@@ -1611,7 +1442,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.native, self.mutable_l0, 5),
             # 16:
             (self.native, self.mutable_l1, LinearExpression([5, self.minus_mon_npv])),
-            (self.native, self.mutable_l2, SumExpression([5, self.minus_mutable_l2])),
+            (self.native, self.mutable_l2, SumExpression([5, self.minus_l2])),
             (self.native, self.param0, 5),
             (self.native, self.param1, 4),
             # 20:
@@ -1659,11 +1490,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.npv, self.minus_mon_npv]),
             ),
-            (
-                self.npv,
-                self.mutable_l2,
-                SumExpression([self.npv, self.minus_mutable_l2]),
-            ),
+            (self.npv, self.mutable_l2, SumExpression([self.npv, self.minus_l2])),
             (self.npv, self.param0, self.npv),
             (self.npv, self.param1, NPV_SumExpression([self.npv, -1])),
             # 20:
@@ -1695,7 +1522,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param, self.mutable_l0, 6),
             # 16:
             (self.param, self.mutable_l1, LinearExpression([6, self.minus_mon_npv])),
-            (self.param, self.mutable_l2, SumExpression([6, self.minus_mutable_l2])),
+            (self.param, self.mutable_l2, SumExpression([6, self.minus_l2])),
             (self.param, self.param0, 6),
             (self.param, self.param1, 5),
             # 20:
@@ -1770,7 +1597,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                SumExpression([self.param_mut, self.minus_mutable_l2]),
+                SumExpression([self.param_mut, self.minus_l2]),
             ),
             (self.param_mut, self.param0, self.param_mut),
             (self.param_mut, self.param1, NPV_SumExpression([self.param_mut, -1])),
@@ -1827,11 +1654,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.var, self.minus_mon_npv]),
             ),
-            (
-                self.var,
-                self.mutable_l2,
-                SumExpression([self.var, self.minus_mutable_l2]),
-            ),
+            (self.var, self.mutable_l2, SumExpression([self.var, self.minus_l2])),
             (self.var, self.param0, self.var),
             (self.var, self.param1, LinearExpression([self.var, -1])),
             # 20:
@@ -1910,7 +1733,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                SumExpression([self.mon_native, self.minus_mutable_l2]),
+                SumExpression([self.mon_native, self.minus_l2]),
             ),
             (self.mon_native, self.param0, self.mon_native),
             (self.mon_native, self.param1, LinearExpression([self.mon_native, -1])),
@@ -1990,7 +1813,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                SumExpression([self.mon_param, self.minus_mutable_l2]),
+                SumExpression([self.mon_param, self.minus_l2]),
             ),
             (self.mon_param, self.param0, self.mon_param),
             (self.mon_param, self.param1, LinearExpression([self.mon_param, -1])),
@@ -2058,7 +1881,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_npv,
                 self.mutable_l2,
-                SumExpression([self.mon_npv, self.minus_mutable_l2]),
+                SumExpression([self.mon_npv, self.minus_l2]),
             ),
             (self.mon_npv, self.param0, self.mon_npv),
             (self.mon_npv, self.param1, LinearExpression([self.mon_npv, -1])),
@@ -2127,11 +1950,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression(self.linear.args + [self.minus_mon_npv]),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                SumExpression([self.linear, self.minus_mutable_l2]),
-            ),
+            (self.linear, self.mutable_l2, SumExpression([self.linear, self.minus_l2])),
             (self.linear, self.param0, self.linear),
             (self.linear, self.param1, LinearExpression(self.linear.args + [-1])),
             # 20:
@@ -2187,11 +2006,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 SumExpression(self.sum.args + [self.minus_mon_npv]),
             ),
-            (
-                self.sum,
-                self.mutable_l2,
-                SumExpression(self.sum.args + [self.minus_mutable_l2]),
-            ),
+            (self.sum, self.mutable_l2, SumExpression(self.sum.args + [self.minus_l2])),
             (self.sum, self.param0, self.sum),
             (self.sum, self.param1, SumExpression(self.sum.args + [-1])),
             # 20:
@@ -2243,11 +2058,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 SumExpression([self.other, self.minus_mon_npv]),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                SumExpression([self.other, self.minus_mutable_l2]),
-            ),
+            (self.other, self.mutable_l2, SumExpression([self.other, self.minus_l2])),
             (self.other, self.param0, self.other),
             (self.other, self.param1, SumExpression([self.other, -1])),
             # 20:
@@ -2276,10 +2087,10 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, self.linear, self.minus_linear),
             (self.mutable_l0, self.sum, self.minus_sum),
             (self.mutable_l0, self.other, self.minus_other),
-            (self.mutable_l0, self.mutable_l0, self.mutable_l0),
+            (self.mutable_l0, self.mutable_l0, self.l0),
             # 16:
             (self.mutable_l0, self.mutable_l1, self.minus_mon_npv),
-            (self.mutable_l0, self.mutable_l2, self.minus_mutable_l2),
+            (self.mutable_l0, self.mutable_l2, self.minus_l2),
             (self.mutable_l0, self.param0, 0),
             (self.mutable_l0, self.param1, -1),
             # 20:
@@ -2295,91 +2106,55 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.asbinary,
-                LinearExpression(self.mutable_l1.args + [self.minus_bin]),
+                LinearExpression([self.l1, self.minus_bin]),
             ),
             (self.mutable_l1, self.zero, self.mon_npv),
-            (self.mutable_l1, self.one, LinearExpression(self.mutable_l1.args + [-1])),
+            (self.mutable_l1, self.one, LinearExpression([self.l1, -1])),
             # 4:
-            (
-                self.mutable_l1,
-                self.native,
-                LinearExpression(self.mutable_l1.args + [-5]),
-            ),
-            (
-                self.mutable_l1,
-                self.npv,
-                LinearExpression(self.mutable_l1.args + [self.minus_npv]),
-            ),
-            (
-                self.mutable_l1,
-                self.param,
-                LinearExpression(self.mutable_l1.args + [-6]),
-            ),
+            (self.mutable_l1, self.native, LinearExpression([self.l1, -5])),
+            (self.mutable_l1, self.npv, LinearExpression([self.l1, self.minus_npv])),
+            (self.mutable_l1, self.param, LinearExpression([self.l1, -6])),
             (
                 self.mutable_l1,
                 self.param_mut,
-                LinearExpression(self.mutable_l1.args + [self.minus_param_mut]),
+                LinearExpression([self.l1, self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l1,
-                self.var,
-                LinearExpression(self.mutable_l1.args + [self.minus_var]),
-            ),
+            (self.mutable_l1, self.var, LinearExpression([self.l1, self.minus_var])),
             (
                 self.mutable_l1,
                 self.mon_native,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_native]),
+                LinearExpression([self.l1, self.minus_mon_native]),
             ),
             (
                 self.mutable_l1,
                 self.mon_param,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_param]),
+                LinearExpression([self.l1, self.minus_mon_param]),
             ),
             (
                 self.mutable_l1,
                 self.mon_npv,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_npv]),
+                LinearExpression([self.l1, self.minus_mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l1,
-                self.linear,
-                SumExpression(self.mutable_l1.args + [self.minus_linear]),
-            ),
-            (
-                self.mutable_l1,
-                self.sum,
-                SumExpression(self.mutable_l1.args + [self.minus_sum]),
-            ),
-            (
-                self.mutable_l1,
-                self.other,
-                SumExpression(self.mutable_l1.args + [self.minus_other]),
-            ),
+            (self.mutable_l1, self.linear, SumExpression([self.l1, self.minus_linear])),
+            (self.mutable_l1, self.sum, SumExpression([self.l1, self.minus_sum])),
+            (self.mutable_l1, self.other, SumExpression([self.l1, self.minus_other])),
             (self.mutable_l1, self.mutable_l0, self.mon_npv),
             # 16:
             (
                 self.mutable_l1,
                 self.mutable_l1,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_npv]),
+                LinearExpression([self.l1, self.minus_mon_npv]),
             ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                SumExpression(self.mutable_l1.args + [self.minus_mutable_l2]),
-            ),
+            (self.mutable_l1, self.mutable_l2, SumExpression([self.l1, self.minus_l2])),
             (self.mutable_l1, self.param0, self.mon_npv),
-            (
-                self.mutable_l1,
-                self.param1,
-                LinearExpression(self.mutable_l1.args + [-1]),
-            ),
+            (self.mutable_l1, self.param1, LinearExpression([self.l1, -1])),
             # 20:
             (
                 self.mutable_l1,
                 self.mutable_l3,
-                LinearExpression(self.mutable_l1.args + [self.minus_npv]),
+                LinearExpression([self.l1, self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2392,79 +2167,67 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l2,
                 self.asbinary,
-                SumExpression(self.mutable_l2.args + [self.minus_bin]),
+                SumExpression(self.l2.args + [self.minus_bin]),
             ),
-            (self.mutable_l2, self.zero, self.mutable_l2),
-            (self.mutable_l2, self.one, SumExpression(self.mutable_l2.args + [-1])),
+            (self.mutable_l2, self.zero, self.l2),
+            (self.mutable_l2, self.one, SumExpression(self.l2.args + [-1])),
             # 4:
-            (self.mutable_l2, self.native, SumExpression(self.mutable_l2.args + [-5])),
-            (
-                self.mutable_l2,
-                self.npv,
-                SumExpression(self.mutable_l2.args + [self.minus_npv]),
-            ),
-            (self.mutable_l2, self.param, SumExpression(self.mutable_l2.args + [-6])),
+            (self.mutable_l2, self.native, SumExpression(self.l2.args + [-5])),
+            (self.mutable_l2, self.npv, SumExpression(self.l2.args + [self.minus_npv])),
+            (self.mutable_l2, self.param, SumExpression(self.l2.args + [-6])),
             (
                 self.mutable_l2,
                 self.param_mut,
-                SumExpression(self.mutable_l2.args + [self.minus_param_mut]),
+                SumExpression(self.l2.args + [self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                SumExpression(self.mutable_l2.args + [self.minus_var]),
-            ),
+            (self.mutable_l2, self.var, SumExpression(self.l2.args + [self.minus_var])),
             (
                 self.mutable_l2,
                 self.mon_native,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_native]),
+                SumExpression(self.l2.args + [self.minus_mon_native]),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_param]),
+                SumExpression(self.l2.args + [self.minus_mon_param]),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_npv]),
+                SumExpression(self.l2.args + [self.minus_mon_npv]),
             ),
             # 12:
             (
                 self.mutable_l2,
                 self.linear,
-                SumExpression(self.mutable_l2.args + [self.minus_linear]),
+                SumExpression(self.l2.args + [self.minus_linear]),
             ),
-            (
-                self.mutable_l2,
-                self.sum,
-                SumExpression(self.mutable_l2.args + [self.minus_sum]),
-            ),
+            (self.mutable_l2, self.sum, SumExpression(self.l2.args + [self.minus_sum])),
             (
                 self.mutable_l2,
                 self.other,
-                SumExpression(self.mutable_l2.args + [self.minus_other]),
+                SumExpression(self.l2.args + [self.minus_other]),
             ),
-            (self.mutable_l2, self.mutable_l0, self.mutable_l2),
+            (self.mutable_l2, self.mutable_l0, self.l2),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_npv]),
+                SumExpression(self.l2.args + [self.minus_mon_npv]),
             ),
             (
                 self.mutable_l2,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.minus_mutable_l2]),
+                SumExpression(self.l2.args + [self.minus_l2]),
             ),
-            (self.mutable_l2, self.param0, self.mutable_l2),
-            (self.mutable_l2, self.param1, SumExpression(self.mutable_l2.args + [-1])),
+            (self.mutable_l2, self.param0, self.l2),
+            (self.mutable_l2, self.param1, SumExpression(self.l2.args + [-1])),
             # 20:
             (
                 self.mutable_l2,
                 self.mutable_l3,
-                SumExpression(self.mutable_l2.args + [self.minus_npv]),
+                SumExpression(self.l2.args + [self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2494,7 +2257,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 0),
             # 16:
             (self.param0, self.mutable_l1, self.minus_mon_npv),
-            (self.param0, self.mutable_l2, self.minus_mutable_l2),
+            (self.param0, self.mutable_l2, self.minus_l2),
             (self.param0, self.param0, 0),
             (self.param0, self.param1, -1),
             # 20:
@@ -2530,7 +2293,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 1),
             # 16:
             (self.param1, self.mutable_l1, LinearExpression([1, self.minus_mon_npv])),
-            (self.param1, self.mutable_l2, SumExpression([1, self.minus_mutable_l2])),
+            (self.param1, self.mutable_l2, SumExpression([1, self.minus_l2])),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 0),
             # 20:
@@ -2545,86 +2308,50 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l3,
                 self.asbinary,
-                LinearExpression(self.mutable_l3.args + [self.minus_bin]),
+                LinearExpression([self.l3, self.minus_bin]),
             ),
             (self.mutable_l3, self.zero, self.npv),
-            (self.mutable_l3, self.one, NPV_SumExpression(self.mutable_l3.args + [-1])),
+            (self.mutable_l3, self.one, NPV_SumExpression([self.l3, -1])),
             # 4:
-            (
-                self.mutable_l3,
-                self.native,
-                NPV_SumExpression(self.mutable_l3.args + [-5]),
-            ),
-            (
-                self.mutable_l3,
-                self.npv,
-                NPV_SumExpression(self.mutable_l3.args + [self.minus_npv]),
-            ),
-            (
-                self.mutable_l3,
-                self.param,
-                NPV_SumExpression(self.mutable_l3.args + [-6]),
-            ),
+            (self.mutable_l3, self.native, NPV_SumExpression([self.l3, -5])),
+            (self.mutable_l3, self.npv, NPV_SumExpression([self.l3, self.minus_npv])),
+            (self.mutable_l3, self.param, NPV_SumExpression([self.l3, -6])),
             (
                 self.mutable_l3,
                 self.param_mut,
-                NPV_SumExpression(self.mutable_l3.args + [self.minus_param_mut]),
+                NPV_SumExpression([self.l3, self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l3,
-                self.var,
-                LinearExpression(self.mutable_l3.args + [self.minus_var]),
-            ),
+            (self.mutable_l3, self.var, LinearExpression([self.l3, self.minus_var])),
             (
                 self.mutable_l3,
                 self.mon_native,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_native]),
+                LinearExpression([self.l3, self.minus_mon_native]),
             ),
             (
                 self.mutable_l3,
                 self.mon_param,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_param]),
+                LinearExpression([self.l3, self.minus_mon_param]),
             ),
             (
                 self.mutable_l3,
                 self.mon_npv,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_npv]),
+                LinearExpression([self.l3, self.minus_mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l3,
-                self.linear,
-                SumExpression(self.mutable_l3.args + [self.minus_linear]),
-            ),
-            (
-                self.mutable_l3,
-                self.sum,
-                SumExpression(self.mutable_l3.args + [self.minus_sum]),
-            ),
-            (
-                self.mutable_l3,
-                self.other,
-                SumExpression(self.mutable_l3.args + [self.minus_other]),
-            ),
+            (self.mutable_l3, self.linear, SumExpression([self.l3, self.minus_linear])),
+            (self.mutable_l3, self.sum, SumExpression([self.l3, self.minus_sum])),
+            (self.mutable_l3, self.other, SumExpression([self.l3, self.minus_other])),
             (self.mutable_l3, self.mutable_l0, self.npv),
             # 16:
             (
                 self.mutable_l3,
                 self.mutable_l1,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_npv]),
+                LinearExpression([self.l3, self.minus_mon_npv]),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                SumExpression(self.mutable_l3.args + [self.minus_mutable_l2]),
-            ),
+            (self.mutable_l3, self.mutable_l2, SumExpression([self.l3, self.minus_l2])),
             (self.mutable_l3, self.param0, self.npv),
-            (
-                self.mutable_l3,
-                self.param1,
-                NPV_SumExpression(self.mutable_l3.args + [-1]),
-            ),
+            (self.mutable_l3, self.param1, NPV_SumExpression([self.l3, -1])),
             # 20:
             # Note that because the mutable is resolved to a NPV_Sum in
             # the negation, the 1-term summation for the first arg is
@@ -2632,9 +2359,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l3,
                 self.mutable_l3,
-                NPV_SumExpression(
-                    [NPV_SumExpression(self.mutable_l3.args), self.minus_npv]
-                ),
+                NPV_SumExpression([self.l3, self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2722,11 +2447,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.bin, self.mon_npv)),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                ProductExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, ProductExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, MonomialTermExpression((0, self.bin))),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -2795,7 +2516,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.zero, self.mutable_l2, ProductExpression((0, self.mutable_l2))),
+            (self.zero, self.mutable_l2, ProductExpression((0, self.l2))),
             (self.zero, self.param0, 0),
             (self.zero, self.param1, 0),
             # 20:
@@ -2829,7 +2550,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 0),
             # 16:
             (self.one, self.mutable_l1, self.mon_npv),
-            (self.one, self.mutable_l2, self.mutable_l2),
+            (self.one, self.mutable_l2, self.l2),
             (self.one, self.param0, self.param0),
             (self.one, self.param1, self.param1),
             # 20:
@@ -2894,7 +2615,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.native, self.mutable_l2, ProductExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, ProductExpression((5, self.l2))),
             (self.native, self.param0, 0),
             (self.native, self.param1, 5),
             # 20:
@@ -2966,7 +2687,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.npv, self.mutable_l2, ProductExpression((self.npv, self.mutable_l2))),
+            (self.npv, self.mutable_l2, ProductExpression((self.npv, self.l2))),
             (self.npv, self.param0, NPV_ProductExpression((self.npv, 0))),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -3029,7 +2750,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.param, self.mutable_l2, ProductExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, ProductExpression((6, self.l2))),
             (self.param, self.param0, 0),
             (self.param, self.param1, 6),
             # 20:
@@ -3128,7 +2849,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                ProductExpression((self.param_mut, self.mutable_l2)),
+                ProductExpression((self.param_mut, self.l2)),
             ),
             (self.param_mut, self.param0, NPV_ProductExpression((self.param_mut, 0))),
             (self.param_mut, self.param1, self.param_mut),
@@ -3169,7 +2890,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.var, self.mutable_l0, MonomialTermExpression((0, self.var))),
             # 16:
             (self.var, self.mutable_l1, ProductExpression((self.var, self.mon_npv))),
-            (self.var, self.mutable_l2, ProductExpression((self.var, self.mutable_l2))),
+            (self.var, self.mutable_l2, ProductExpression((self.var, self.l2))),
             (self.var, self.param0, MonomialTermExpression((0, self.var))),
             (self.var, self.param1, self.var),
             # 20:
@@ -3266,7 +2987,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                ProductExpression((self.mon_native, self.mutable_l2)),
+                ProductExpression((self.mon_native, self.l2)),
             ),
             (
                 self.mon_native,
@@ -3397,7 +3118,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                ProductExpression((self.mon_param, self.mutable_l2)),
+                ProductExpression((self.mon_param, self.l2)),
             ),
             (
                 self.mon_param,
@@ -3518,11 +3239,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mon_npv,
-                self.mutable_l2,
-                ProductExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mon_npv, self.mutable_l2, ProductExpression((self.mon_npv, self.l2))),
             (
                 self.mon_npv,
                 self.param0,
@@ -3588,11 +3305,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.linear, self.mon_npv)),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                ProductExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, ProductExpression((self.linear, self.l2))),
             (self.linear, self.param0, ProductExpression((self.linear, 0))),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -3624,7 +3337,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, ProductExpression((self.sum, 0))),
             # 16:
             (self.sum, self.mutable_l1, ProductExpression((self.sum, self.mon_npv))),
-            (self.sum, self.mutable_l2, ProductExpression((self.sum, self.mutable_l2))),
+            (self.sum, self.mutable_l2, ProductExpression((self.sum, self.l2))),
             (self.sum, self.param0, ProductExpression((self.sum, 0))),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -3672,11 +3385,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.other, self.mon_npv)),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                ProductExpression((self.other, self.mutable_l2)),
-            ),
+            (self.other, self.mutable_l2, ProductExpression((self.other, self.l2))),
             (self.other, self.param0, ProductExpression((self.other, 0))),
             (self.other, self.param1, self.other),
             # 20:
@@ -3743,7 +3452,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.mutable_l0, self.mutable_l2, ProductExpression((0, self.mutable_l2))),
+            (self.mutable_l0, self.mutable_l2, ProductExpression((0, self.l2))),
             (self.mutable_l0, self.param0, 0),
             (self.mutable_l0, self.param1, 0),
             # 20:
@@ -3860,7 +3569,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.mutable_l2,
-                ProductExpression((self.mon_npv, self.mutable_l2)),
+                ProductExpression((self.mon_npv, self.l2)),
             ),
             (
                 self.mutable_l1,
@@ -3891,71 +3600,47 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_mul_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                ProductExpression((self.mutable_l2, self.bin)),
-            ),
-            (self.mutable_l2, self.zero, ProductExpression((self.mutable_l2, 0))),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.asbinary, ProductExpression((self.l2, self.bin))),
+            (self.mutable_l2, self.zero, ProductExpression((self.l2, 0))),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, ProductExpression((self.mutable_l2, 5))),
-            (self.mutable_l2, self.npv, ProductExpression((self.mutable_l2, self.npv))),
-            (self.mutable_l2, self.param, ProductExpression((self.mutable_l2, 6))),
+            (self.mutable_l2, self.native, ProductExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, ProductExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, ProductExpression((self.l2, 6))),
             (
                 self.mutable_l2,
                 self.param_mut,
-                ProductExpression((self.mutable_l2, self.param_mut)),
+                ProductExpression((self.l2, self.param_mut)),
             ),
             # 8:
-            (self.mutable_l2, self.var, ProductExpression((self.mutable_l2, self.var))),
+            (self.mutable_l2, self.var, ProductExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                ProductExpression((self.mutable_l2, self.mon_native)),
+                ProductExpression((self.l2, self.mon_native)),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                ProductExpression((self.mutable_l2, self.mon_param)),
+                ProductExpression((self.l2, self.mon_param)),
             ),
-            (
-                self.mutable_l2,
-                self.mon_npv,
-                ProductExpression((self.mutable_l2, self.mon_npv)),
-            ),
+            (self.mutable_l2, self.mon_npv, ProductExpression((self.l2, self.mon_npv))),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                ProductExpression((self.mutable_l2, self.linear)),
-            ),
-            (self.mutable_l2, self.sum, ProductExpression((self.mutable_l2, self.sum))),
-            (
-                self.mutable_l2,
-                self.other,
-                ProductExpression((self.mutable_l2, self.other)),
-            ),
-            (self.mutable_l2, self.mutable_l0, ProductExpression((self.mutable_l2, 0))),
+            (self.mutable_l2, self.linear, ProductExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, ProductExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, ProductExpression((self.l2, self.other))),
+            (self.mutable_l2, self.mutable_l0, ProductExpression((self.l2, 0))),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                ProductExpression((self.mutable_l2, self.mon_npv)),
+                ProductExpression((self.l2, self.mon_npv)),
             ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                ProductExpression((self.mutable_l2, self.mutable_l2)),
-            ),
-            (self.mutable_l2, self.param0, ProductExpression((self.mutable_l2, 0))),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.mutable_l2, ProductExpression((self.l2, self.l2))),
+            (self.mutable_l2, self.param0, ProductExpression((self.l2, 0))),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                ProductExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, ProductExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.mul)
         self._run_cases(tests, operator.imul)
@@ -4016,7 +3701,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.param0, self.mutable_l2, ProductExpression((0, self.mutable_l2))),
+            (self.param0, self.mutable_l2, ProductExpression((0, self.l2))),
             (self.param0, self.param0, 0),
             (self.param0, self.param1, 0),
             # 20:
@@ -4050,7 +3735,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 0),
             # 16:
             (self.param1, self.mutable_l1, self.mon_npv),
-            (self.param1, self.mutable_l2, self.mutable_l2),
+            (self.param1, self.mutable_l2, self.l2),
             (self.param1, self.param0, self.param0),
             (self.param1, self.param1, self.param1),
             # 20:
@@ -4126,11 +3811,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                ProductExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, ProductExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, NPV_ProductExpression((self.npv, 0))),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -4229,11 +3910,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.bin, self.mon_npv)),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                DivisionExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, DivisionExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, ZeroDivisionError),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -4271,7 +3948,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.zero, self.mutable_l1, DivisionExpression((0, self.mon_npv))),
-            (self.zero, self.mutable_l2, DivisionExpression((0, self.mutable_l2))),
+            (self.zero, self.mutable_l2, DivisionExpression((0, self.l2))),
             (self.zero, self.param0, ZeroDivisionError),
             (self.zero, self.param1, 0.0),
             # 20:
@@ -4303,7 +3980,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.one, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.one, self.mutable_l1, DivisionExpression((1, self.mon_npv))),
-            (self.one, self.mutable_l2, DivisionExpression((1, self.mutable_l2))),
+            (self.one, self.mutable_l2, DivisionExpression((1, self.l2))),
             (self.one, self.param0, ZeroDivisionError),
             (self.one, self.param1, 1.0),
             # 20:
@@ -4335,7 +4012,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.native, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.native, self.mutable_l1, DivisionExpression((5, self.mon_npv))),
-            (self.native, self.mutable_l2, DivisionExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, DivisionExpression((5, self.l2))),
             (self.native, self.param0, ZeroDivisionError),
             (self.native, self.param1, 5.0),
             # 20:
@@ -4375,11 +4052,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.npv, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.npv, self.mutable_l1, DivisionExpression((self.npv, self.mon_npv))),
-            (
-                self.npv,
-                self.mutable_l2,
-                DivisionExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.npv, self.mutable_l2, DivisionExpression((self.npv, self.l2))),
             (self.npv, self.param0, ZeroDivisionError),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -4411,7 +4084,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.param, self.mutable_l1, DivisionExpression((6, self.mon_npv))),
-            (self.param, self.mutable_l2, DivisionExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, DivisionExpression((6, self.l2))),
             (self.param, self.param0, ZeroDivisionError),
             (self.param, self.param1, 6.0),
             # 20:
@@ -4482,7 +4155,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                DivisionExpression((self.param_mut, self.mutable_l2)),
+                DivisionExpression((self.param_mut, self.l2)),
             ),
             (self.param_mut, self.param0, ZeroDivisionError),
             (self.param_mut, self.param1, self.param_mut),
@@ -4535,11 +4208,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.var, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.var, self.mutable_l1, DivisionExpression((self.var, self.mon_npv))),
-            (
-                self.var,
-                self.mutable_l2,
-                DivisionExpression((self.var, self.mutable_l2)),
-            ),
+            (self.var, self.mutable_l2, DivisionExpression((self.var, self.l2))),
             (self.var, self.param0, ZeroDivisionError),
             (self.var, self.param1, self.var),
             # 20:
@@ -4644,7 +4313,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                DivisionExpression((self.mon_native, self.mutable_l2)),
+                DivisionExpression((self.mon_native, self.l2)),
             ),
             (self.mon_native, self.param0, ZeroDivisionError),
             (self.mon_native, self.param1, self.mon_native),
@@ -4753,7 +4422,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                DivisionExpression((self.mon_param, self.mutable_l2)),
+                DivisionExpression((self.mon_param, self.l2)),
             ),
             (self.mon_param, self.param0, ZeroDivisionError),
             (self.mon_param, self.param1, self.mon_param),
@@ -4854,7 +4523,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_npv,
                 self.mutable_l2,
-                DivisionExpression((self.mon_npv, self.mutable_l2)),
+                DivisionExpression((self.mon_npv, self.l2)),
             ),
             (self.mon_npv, self.param0, ZeroDivisionError),
             (self.mon_npv, self.param1, self.mon_npv),
@@ -4916,11 +4585,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.linear, self.mon_npv)),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                DivisionExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, DivisionExpression((self.linear, self.l2))),
             (self.linear, self.param0, ZeroDivisionError),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -4956,11 +4621,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.sum, self.mutable_l1, DivisionExpression((self.sum, self.mon_npv))),
-            (
-                self.sum,
-                self.mutable_l2,
-                DivisionExpression((self.sum, self.mutable_l2)),
-            ),
+            (self.sum, self.mutable_l2, DivisionExpression((self.sum, self.l2))),
             (self.sum, self.param0, ZeroDivisionError),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -5008,11 +4669,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.other, self.mon_npv)),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                DivisionExpression((self.other, self.mutable_l2)),
-            ),
+            (self.other, self.mutable_l2, DivisionExpression((self.other, self.l2))),
             (self.other, self.param0, ZeroDivisionError),
             (self.other, self.param1, self.other),
             # 20:
@@ -5052,11 +4709,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.mutable_l0, self.mutable_l1, DivisionExpression((0, self.mon_npv))),
-            (
-                self.mutable_l0,
-                self.mutable_l2,
-                DivisionExpression((0, self.mutable_l2)),
-            ),
+            (self.mutable_l0, self.mutable_l2, DivisionExpression((0, self.l2))),
             (self.mutable_l0, self.param0, ZeroDivisionError),
             (self.mutable_l0, self.param1, 0.0),
             # 20:
@@ -5155,7 +4808,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.mutable_l2,
-                DivisionExpression((self.mon_npv, self.mutable_l2)),
+                DivisionExpression((self.mon_npv, self.l2)),
             ),
             (self.mutable_l1, self.param0, ZeroDivisionError),
             (self.mutable_l1, self.param1, self.mon_npv),
@@ -5177,83 +4830,51 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_div_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                DivisionExpression((self.mutable_l2, self.bin)),
-            ),
+            (self.mutable_l2, self.asbinary, DivisionExpression((self.l2, self.bin))),
             (self.mutable_l2, self.zero, ZeroDivisionError),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, DivisionExpression((self.mutable_l2, 5))),
-            (
-                self.mutable_l2,
-                self.npv,
-                DivisionExpression((self.mutable_l2, self.npv)),
-            ),
-            (self.mutable_l2, self.param, DivisionExpression((self.mutable_l2, 6))),
+            (self.mutable_l2, self.native, DivisionExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, DivisionExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, DivisionExpression((self.l2, 6))),
             (
                 self.mutable_l2,
                 self.param_mut,
-                DivisionExpression((self.mutable_l2, self.param_mut)),
+                DivisionExpression((self.l2, self.param_mut)),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                DivisionExpression((self.mutable_l2, self.var)),
-            ),
+            (self.mutable_l2, self.var, DivisionExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                DivisionExpression((self.mutable_l2, self.mon_native)),
+                DivisionExpression((self.l2, self.mon_native)),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                DivisionExpression((self.mutable_l2, self.mon_param)),
+                DivisionExpression((self.l2, self.mon_param)),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                DivisionExpression((self.mutable_l2, self.mon_npv)),
+                DivisionExpression((self.l2, self.mon_npv)),
             ),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                DivisionExpression((self.mutable_l2, self.linear)),
-            ),
-            (
-                self.mutable_l2,
-                self.sum,
-                DivisionExpression((self.mutable_l2, self.sum)),
-            ),
-            (
-                self.mutable_l2,
-                self.other,
-                DivisionExpression((self.mutable_l2, self.other)),
-            ),
+            (self.mutable_l2, self.linear, DivisionExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, DivisionExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, DivisionExpression((self.l2, self.other))),
             (self.mutable_l2, self.mutable_l0, ZeroDivisionError),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                DivisionExpression((self.mutable_l2, self.mon_npv)),
+                DivisionExpression((self.l2, self.mon_npv)),
             ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                DivisionExpression((self.mutable_l2, self.mutable_l2)),
-            ),
+            (self.mutable_l2, self.mutable_l2, DivisionExpression((self.l2, self.l2))),
             (self.mutable_l2, self.param0, ZeroDivisionError),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                DivisionExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, DivisionExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.truediv)
         self._run_cases(tests, operator.itruediv)
@@ -5281,7 +4902,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.param0, self.mutable_l1, DivisionExpression((0, self.mon_npv))),
-            (self.param0, self.mutable_l2, DivisionExpression((0, self.mutable_l2))),
+            (self.param0, self.mutable_l2, DivisionExpression((0, self.l2))),
             (self.param0, self.param0, ZeroDivisionError),
             (self.param0, self.param1, 0.0),
             # 20:
@@ -5313,7 +4934,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.param1, self.mutable_l1, DivisionExpression((1, self.mon_npv))),
-            (self.param1, self.mutable_l2, DivisionExpression((1, self.mutable_l2))),
+            (self.param1, self.mutable_l2, DivisionExpression((1, self.l2))),
             (self.param1, self.param0, ZeroDivisionError),
             (self.param1, self.param1, 1.0),
             # 20:
@@ -5365,11 +4986,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.npv, self.mon_npv)),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                DivisionExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, DivisionExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, ZeroDivisionError),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -5448,11 +5065,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.asbinary, self.mutable_l0, PowExpression((self.bin, 0))),
             # 16:
             (self.asbinary, self.mutable_l1, PowExpression((self.bin, self.mon_npv))),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                PowExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, PowExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, PowExpression((self.bin, 0))),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -5484,7 +5097,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 1),
             # 16:
             (self.zero, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.zero, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.zero, self.mutable_l2, PowExpression((0, self.l2))),
             (self.zero, self.param0, 1),
             (self.zero, self.param1, 0),
             # 20:
@@ -5516,7 +5129,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 1),
             # 16:
             (self.one, self.mutable_l1, PowExpression((1, self.mon_npv))),
-            (self.one, self.mutable_l2, PowExpression((1, self.mutable_l2))),
+            (self.one, self.mutable_l2, PowExpression((1, self.l2))),
             (self.one, self.param0, 1),
             (self.one, self.param1, 1),
             # 20:
@@ -5548,7 +5161,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.native, self.mutable_l0, 1),
             # 16:
             (self.native, self.mutable_l1, PowExpression((5, self.mon_npv))),
-            (self.native, self.mutable_l2, PowExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, PowExpression((5, self.l2))),
             (self.native, self.param0, 1),
             (self.native, self.param1, 5),
             # 20:
@@ -5580,7 +5193,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.npv, self.mutable_l0, NPV_PowExpression((self.npv, 0))),
             # 16:
             (self.npv, self.mutable_l1, PowExpression((self.npv, self.mon_npv))),
-            (self.npv, self.mutable_l2, PowExpression((self.npv, self.mutable_l2))),
+            (self.npv, self.mutable_l2, PowExpression((self.npv, self.l2))),
             (self.npv, self.param0, NPV_PowExpression((self.npv, 0))),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -5612,7 +5225,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param, self.mutable_l0, 1),
             # 16:
             (self.param, self.mutable_l1, PowExpression((6, self.mon_npv))),
-            (self.param, self.mutable_l2, PowExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, PowExpression((6, self.l2))),
             (self.param, self.param0, 1),
             (self.param, self.param1, 6),
             # 20:
@@ -5664,11 +5277,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.param_mut, self.mon_npv)),
             ),
-            (
-                self.param_mut,
-                self.mutable_l2,
-                PowExpression((self.param_mut, self.mutable_l2)),
-            ),
+            (self.param_mut, self.mutable_l2, PowExpression((self.param_mut, self.l2))),
             (self.param_mut, self.param0, NPV_PowExpression((self.param_mut, 0))),
             (self.param_mut, self.param1, self.param_mut),
             # 20:
@@ -5704,7 +5313,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.var, self.mutable_l0, PowExpression((self.var, 0))),
             # 16:
             (self.var, self.mutable_l1, PowExpression((self.var, self.mon_npv))),
-            (self.var, self.mutable_l2, PowExpression((self.var, self.mutable_l2))),
+            (self.var, self.mutable_l2, PowExpression((self.var, self.l2))),
             (self.var, self.param0, PowExpression((self.var, 0))),
             (self.var, self.param1, self.var),
             # 20:
@@ -5767,7 +5376,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                PowExpression((self.mon_native, self.mutable_l2)),
+                PowExpression((self.mon_native, self.l2)),
             ),
             (self.mon_native, self.param0, PowExpression((self.mon_native, 0))),
             (self.mon_native, self.param1, self.mon_native),
@@ -5824,11 +5433,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_param, self.mon_npv)),
             ),
-            (
-                self.mon_param,
-                self.mutable_l2,
-                PowExpression((self.mon_param, self.mutable_l2)),
-            ),
+            (self.mon_param, self.mutable_l2, PowExpression((self.mon_param, self.l2))),
             (self.mon_param, self.param0, PowExpression((self.mon_param, 0))),
             (self.mon_param, self.param1, self.mon_param),
             # 20:
@@ -5880,11 +5485,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mon_npv,
-                self.mutable_l2,
-                PowExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mon_npv, self.mutable_l2, PowExpression((self.mon_npv, self.l2))),
             (self.mon_npv, self.param0, PowExpression((self.mon_npv, 0))),
             (self.mon_npv, self.param1, self.mon_npv),
             # 20:
@@ -5920,11 +5521,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.linear, self.mutable_l0, PowExpression((self.linear, 0))),
             # 16:
             (self.linear, self.mutable_l1, PowExpression((self.linear, self.mon_npv))),
-            (
-                self.linear,
-                self.mutable_l2,
-                PowExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, PowExpression((self.linear, self.l2))),
             (self.linear, self.param0, PowExpression((self.linear, 0))),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -5956,7 +5553,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, PowExpression((self.sum, 0))),
             # 16:
             (self.sum, self.mutable_l1, PowExpression((self.sum, self.mon_npv))),
-            (self.sum, self.mutable_l2, PowExpression((self.sum, self.mutable_l2))),
+            (self.sum, self.mutable_l2, PowExpression((self.sum, self.l2))),
             (self.sum, self.param0, PowExpression((self.sum, 0))),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -5988,7 +5585,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.other, self.mutable_l0, PowExpression((self.other, 0))),
             # 16:
             (self.other, self.mutable_l1, PowExpression((self.other, self.mon_npv))),
-            (self.other, self.mutable_l2, PowExpression((self.other, self.mutable_l2))),
+            (self.other, self.mutable_l2, PowExpression((self.other, self.l2))),
             (self.other, self.param0, PowExpression((self.other, 0))),
             (self.other, self.param1, self.other),
             # 20:
@@ -6020,7 +5617,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, self.mutable_l0, 1),
             # 16:
             (self.mutable_l0, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.mutable_l0, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.mutable_l0, self.mutable_l2, PowExpression((0, self.l2))),
             (self.mutable_l0, self.param0, 1),
             (self.mutable_l0, self.param1, 0),
             # 20:
@@ -6072,11 +5669,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                PowExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mutable_l1, self.mutable_l2, PowExpression((self.mon_npv, self.l2))),
             (self.mutable_l1, self.param0, PowExpression((self.mon_npv, 0))),
             (self.mutable_l1, self.param1, self.mon_npv),
             # 20:
@@ -6088,67 +5681,35 @@ class TestExpressionGeneration(Base, unittest.TestCase):
     def test_pow_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                PowExpression((self.mutable_l2, self.bin)),
-            ),
-            (self.mutable_l2, self.zero, PowExpression((self.mutable_l2, 0))),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.asbinary, PowExpression((self.l2, self.bin))),
+            (self.mutable_l2, self.zero, PowExpression((self.l2, 0))),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, PowExpression((self.mutable_l2, 5))),
-            (self.mutable_l2, self.npv, PowExpression((self.mutable_l2, self.npv))),
-            (self.mutable_l2, self.param, PowExpression((self.mutable_l2, 6))),
-            (
-                self.mutable_l2,
-                self.param_mut,
-                PowExpression((self.mutable_l2, self.param_mut)),
-            ),
+            (self.mutable_l2, self.native, PowExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, PowExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, PowExpression((self.l2, 6))),
+            (self.mutable_l2, self.param_mut, PowExpression((self.l2, self.param_mut))),
             # 8:
-            (self.mutable_l2, self.var, PowExpression((self.mutable_l2, self.var))),
+            (self.mutable_l2, self.var, PowExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                PowExpression((self.mutable_l2, self.mon_native)),
+                PowExpression((self.l2, self.mon_native)),
             ),
-            (
-                self.mutable_l2,
-                self.mon_param,
-                PowExpression((self.mutable_l2, self.mon_param)),
-            ),
-            (
-                self.mutable_l2,
-                self.mon_npv,
-                PowExpression((self.mutable_l2, self.mon_npv)),
-            ),
+            (self.mutable_l2, self.mon_param, PowExpression((self.l2, self.mon_param))),
+            (self.mutable_l2, self.mon_npv, PowExpression((self.l2, self.mon_npv))),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                PowExpression((self.mutable_l2, self.linear)),
-            ),
-            (self.mutable_l2, self.sum, PowExpression((self.mutable_l2, self.sum))),
-            (self.mutable_l2, self.other, PowExpression((self.mutable_l2, self.other))),
-            (self.mutable_l2, self.mutable_l0, PowExpression((self.mutable_l2, 0))),
+            (self.mutable_l2, self.linear, PowExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, PowExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, PowExpression((self.l2, self.other))),
+            (self.mutable_l2, self.mutable_l0, PowExpression((self.l2, 0))),
             # 16:
-            (
-                self.mutable_l2,
-                self.mutable_l1,
-                PowExpression((self.mutable_l2, self.mon_npv)),
-            ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                PowExpression((self.mutable_l2, self.mutable_l2)),
-            ),
-            (self.mutable_l2, self.param0, PowExpression((self.mutable_l2, 0))),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.mutable_l1, PowExpression((self.l2, self.mon_npv))),
+            (self.mutable_l2, self.mutable_l2, PowExpression((self.l2, self.l2))),
+            (self.mutable_l2, self.param0, PowExpression((self.l2, 0))),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                PowExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, PowExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.pow)
         self._run_cases(tests, operator.ipow)
@@ -6176,7 +5737,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 1),
             # 16:
             (self.param0, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.param0, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.param0, self.mutable_l2, PowExpression((0, self.l2))),
             (self.param0, self.param0, 1),
             (self.param0, self.param1, 0),
             # 20:
@@ -6208,7 +5769,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 1),
             # 16:
             (self.param1, self.mutable_l1, PowExpression((1, self.mon_npv))),
-            (self.param1, self.mutable_l2, PowExpression((1, self.mutable_l2))),
+            (self.param1, self.mutable_l2, PowExpression((1, self.l2))),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 1),
             # 20:
@@ -6252,11 +5813,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l3, self.mutable_l0, NPV_PowExpression((self.npv, 0))),
             # 16:
             (self.mutable_l3, self.mutable_l1, PowExpression((self.npv, self.mon_npv))),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                PowExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, PowExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, NPV_PowExpression((self.npv, 0))),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -6294,7 +5851,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, self.minus_mon_npv),
-            (self.mutable_l2, NegationExpression((self.mutable_l2,))),
+            (self.mutable_l2, NegationExpression((self.l2,))),
             (self.param0, 0),
             (self.param1, -1),
             # 20:
@@ -6328,7 +5885,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, self.mon_npv),
-            (self.mutable_l2, self.mutable_l2),
+            (self.mutable_l2, self.l2),
             (self.param0, 0),
             (self.param1, 1),
             # 20:
@@ -6365,7 +5922,7 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, AbsExpression((self.mon_npv,))),
-            (self.mutable_l2, AbsExpression((self.mutable_l2,))),
+            (self.mutable_l2, AbsExpression((self.l2,))),
             (self.param0, 0),
             (self.param1, 1),
             # 20:
@@ -6431,11 +5988,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
                 (self.other, UnaryFunctionExpression((self.other,), name, fcn)),
                 (self.mutable_l0, ValueError if name in SKIP_0 else fcn(0)),
                 # 16:
-                (self.mutable_l1, UnaryFunctionExpression((self.mon_npv,), name, fcn)),
-                (
-                    self.mutable_l2,
-                    UnaryFunctionExpression((self.mutable_l2,), name, fcn),
-                ),
+                (self.mutable_l1, UnaryFunctionExpression((self.l1,), name, fcn)),
+                (self.mutable_l2, UnaryFunctionExpression((self.l2,), name, fcn)),
                 (self.param0, ValueError if name in SKIP_0 else fcn(0)),
                 (self.param1, ValueError if name in SKIP_1 else fcn(1)),
                 # 20:
@@ -6472,12 +6026,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (mutable_npv, self.other, _MutableSumExpression([self.other])),
             (mutable_npv, self.mutable_l0, _MutableNPVSumExpression([])),
             # 16:
-            (
-                mutable_npv,
-                self.mutable_l1,
-                _MutableLinearExpression(self.mutable_l1.args),
-            ),
-            (mutable_npv, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_npv, self.mutable_l1, _MutableLinearExpression([self.l1])),
+            (mutable_npv, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_npv, self.param0, _MutableNPVSumExpression([])),
             (mutable_npv, self.param1, _MutableNPVSumExpression([1])),
             # 20:
@@ -6523,16 +6073,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (mutable_npv, self.other, _MutableSumExpression([10, self.other])),
             (mutable_npv, self.mutable_l0, _MutableNPVSumExpression([10])),
             # 16:
-            (
-                mutable_npv,
-                self.mutable_l1,
-                _MutableLinearExpression([10] + self.mutable_l1.args),
-            ),
-            (
-                mutable_npv,
-                self.mutable_l2,
-                _MutableSumExpression([10] + self.mutable_l2.args),
-            ),
+            (mutable_npv, self.mutable_l1, _MutableLinearExpression([10, self.l1])),
+            (mutable_npv, self.mutable_l2, _MutableSumExpression([10] + self.l2.args)),
             (mutable_npv, self.param0, _MutableNPVSumExpression([10])),
             (mutable_npv, self.param1, _MutableNPVSumExpression([11])),
             # 20:
@@ -6563,12 +6105,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (mutable_lin, self.other, _MutableSumExpression([self.other])),
             (mutable_lin, self.mutable_l0, _MutableLinearExpression([])),
             # 16:
-            (
-                mutable_lin,
-                self.mutable_l1,
-                _MutableLinearExpression(self.mutable_l1.args),
-            ),
-            (mutable_lin, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_lin, self.mutable_l1, _MutableLinearExpression([self.l1])),
+            (mutable_lin, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_lin, self.param0, _MutableLinearExpression([])),
             (mutable_lin, self.param1, _MutableLinearExpression([1])),
             # 20:
@@ -6625,12 +6163,12 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 mutable_lin,
                 self.mutable_l1,
-                _MutableLinearExpression([self.bin] + self.mutable_l1.args),
+                _MutableLinearExpression([self.bin, self.l1]),
             ),
             (
                 mutable_lin,
                 self.mutable_l2,
-                _MutableSumExpression([self.bin] + self.mutable_l2.args),
+                _MutableSumExpression([self.bin] + self.l2.args),
             ),
             (mutable_lin, self.param0, _MutableLinearExpression([self.bin])),
             (mutable_lin, self.param1, _MutableLinearExpression([self.bin, 1])),
@@ -6666,8 +6204,8 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (mutable_sum, self.other, _MutableSumExpression([self.other])),
             (mutable_sum, self.mutable_l0, _MutableSumExpression([])),
             # 16:
-            (mutable_sum, self.mutable_l1, _MutableSumExpression(self.mutable_l1.args)),
-            (mutable_sum, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_sum, self.mutable_l1, _MutableSumExpression([self.l1])),
+            (mutable_sum, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_sum, self.param0, _MutableSumExpression([])),
             (mutable_sum, self.param1, _MutableSumExpression([1])),
             # 20:
@@ -6724,12 +6262,12 @@ class TestExpressionGeneration(Base, unittest.TestCase):
             (
                 mutable_sum,
                 self.mutable_l1,
-                _MutableSumExpression([self.other] + self.mutable_l1.args),
+                _MutableSumExpression([self.other, self.l1]),
             ),
             (
                 mutable_sum,
                 self.mutable_l2,
-                _MutableSumExpression([self.other] + self.mutable_l2.args),
+                _MutableSumExpression([self.other] + self.l2.args),
             ),
             (mutable_sum, self.param0, _MutableSumExpression([self.other])),
             (mutable_sum, self.param1, _MutableSumExpression([self.other, 1])),

--- a/pyomo/core/tests/unit/test_numeric_expr_zerofilter.py
+++ b/pyomo/core/tests/unit/test_numeric_expr_zerofilter.py
@@ -140,11 +140,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.bin, self.mon_npv]),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.bin]),
-            ),
+            (self.asbinary, self.mutable_l2, SumExpression(self.l2.args + [self.bin])),
             (self.asbinary, self.param0, self.bin),
             (self.asbinary, self.param1, LinearExpression([self.bin, 1])),
             # 20:
@@ -176,7 +172,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 0),
             # 16:
             (self.zero, self.mutable_l1, self.mon_npv),
-            (self.zero, self.mutable_l2, self.mutable_l2),
+            (self.zero, self.mutable_l2, self.l2),
             (self.zero, self.param0, 0),
             (self.zero, self.param1, 1),
             # 20:
@@ -207,8 +203,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.one, self.other, SumExpression([1, self.other])),
             (self.one, self.mutable_l0, 1),
             # 16:
-            (self.one, self.mutable_l1, LinearExpression([1] + self.mutable_l1.args)),
-            (self.one, self.mutable_l2, SumExpression(self.mutable_l2.args + [1])),
+            (self.one, self.mutable_l1, LinearExpression([1, self.l1])),
+            (self.one, self.mutable_l2, SumExpression(self.l2.args + [1])),
             (self.one, self.param0, 1),
             (self.one, self.param1, 2),
             # 20:
@@ -239,12 +235,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.native, self.other, SumExpression([5, self.other])),
             (self.native, self.mutable_l0, 5),
             # 16:
-            (
-                self.native,
-                self.mutable_l1,
-                LinearExpression([5] + self.mutable_l1.args),
-            ),
-            (self.native, self.mutable_l2, SumExpression(self.mutable_l2.args + [5])),
+            (self.native, self.mutable_l1, LinearExpression([5, self.l1])),
+            (self.native, self.mutable_l2, SumExpression(self.l2.args + [5])),
             (self.native, self.param0, 5),
             (self.native, self.param1, 6),
             # 20:
@@ -275,16 +267,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.npv, self.other, SumExpression([self.npv, self.other])),
             (self.npv, self.mutable_l0, self.npv),
             # 16:
-            (
-                self.npv,
-                self.mutable_l1,
-                LinearExpression([self.npv] + self.mutable_l1.args),
-            ),
-            (
-                self.npv,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.npv]),
-            ),
+            (self.npv, self.mutable_l1, LinearExpression([self.npv, self.l1])),
+            (self.npv, self.mutable_l2, SumExpression(self.l2.args + [self.npv])),
             (self.npv, self.param0, self.npv),
             (self.npv, self.param1, NPV_SumExpression([self.npv, 1])),
             # 20:
@@ -315,8 +299,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param, self.other, SumExpression([6, self.other])),
             (self.param, self.mutable_l0, 6),
             # 16:
-            (self.param, self.mutable_l1, LinearExpression([6] + self.mutable_l1.args)),
-            (self.param, self.mutable_l2, SumExpression(self.mutable_l2.args + [6])),
+            (self.param, self.mutable_l1, LinearExpression([6, self.l1])),
+            (self.param, self.mutable_l2, SumExpression(self.l2.args + [6])),
             (self.param, self.param0, 6),
             (self.param, self.param1, 7),
             # 20:
@@ -374,12 +358,12 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l1,
-                LinearExpression([self.param_mut] + self.mutable_l1.args),
+                LinearExpression([self.param_mut, self.l1]),
             ),
             (
                 self.param_mut,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.param_mut]),
+                SumExpression(self.l2.args + [self.param_mut]),
             ),
             (self.param_mut, self.param0, self.param_mut),
             (self.param_mut, self.param1, NPV_SumExpression([self.param_mut, 1])),
@@ -415,16 +399,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.var, self.other, SumExpression([self.var, self.other])),
             (self.var, self.mutable_l0, self.var),
             # 16:
-            (
-                self.var,
-                self.mutable_l1,
-                LinearExpression([self.var] + self.mutable_l1.args),
-            ),
-            (
-                self.var,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.var]),
-            ),
+            (self.var, self.mutable_l1, LinearExpression([self.var, self.l1])),
+            (self.var, self.mutable_l2, SumExpression(self.l2.args + [self.var])),
             (self.var, self.param0, self.var),
             (self.var, self.param1, LinearExpression([self.var, 1])),
             # 20:
@@ -486,12 +462,12 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l1,
-                LinearExpression([self.mon_native] + self.mutable_l1.args),
+                LinearExpression([self.mon_native, self.l1]),
             ),
             (
                 self.mon_native,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_native]),
+                SumExpression(self.l2.args + [self.mon_native]),
             ),
             (self.mon_native, self.param0, self.mon_native),
             (self.mon_native, self.param1, LinearExpression([self.mon_native, 1])),
@@ -554,12 +530,12 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l1,
-                LinearExpression([self.mon_param] + self.mutable_l1.args),
+                LinearExpression([self.mon_param, self.l1]),
             ),
             (
                 self.mon_param,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_param]),
+                SumExpression(self.l2.args + [self.mon_param]),
             ),
             (self.mon_param, self.param0, self.mon_param),
             (self.mon_param, self.param1, LinearExpression([self.mon_param, 1])),
@@ -615,15 +591,11 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mon_npv, self.other, SumExpression([self.mon_npv, self.other])),
             (self.mon_npv, self.mutable_l0, self.mon_npv),
             # 16:
-            (
-                self.mon_npv,
-                self.mutable_l1,
-                LinearExpression([self.mon_npv] + self.mutable_l1.args),
-            ),
+            (self.mon_npv, self.mutable_l1, LinearExpression([self.mon_npv, self.l1])),
             (
                 self.mon_npv,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.mon_npv]),
+                SumExpression(self.l2.args + [self.mon_npv]),
             ),
             (self.mon_npv, self.param0, self.mon_npv),
             (self.mon_npv, self.param1, LinearExpression([self.mon_npv, 1])),
@@ -682,13 +654,9 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.linear,
                 self.mutable_l1,
-                LinearExpression(self.linear.args + self.mutable_l1.args),
+                LinearExpression(self.linear.args + [self.l1]),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.linear]),
-            ),
+            (self.linear, self.mutable_l2, SumExpression(self.l2.args + [self.linear])),
             (self.linear, self.param0, self.linear),
             (self.linear, self.param1, LinearExpression(self.linear.args + [1])),
             # 20:
@@ -727,16 +695,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.sum, self.other, SumExpression(self.sum.args + [self.other])),
             (self.sum, self.mutable_l0, self.sum),
             # 16:
-            (
-                self.sum,
-                self.mutable_l1,
-                SumExpression(self.sum.args + self.mutable_l1.args),
-            ),
-            (
-                self.sum,
-                self.mutable_l2,
-                SumExpression(self.sum.args + self.mutable_l2.args),
-            ),
+            (self.sum, self.mutable_l1, SumExpression(self.sum.args + [self.l1])),
+            (self.sum, self.mutable_l2, SumExpression(self.sum.args + self.l2.args)),
             (self.sum, self.param0, self.sum),
             (self.sum, self.param1, SumExpression(self.sum.args + [1])),
             # 20:
@@ -768,11 +728,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.other, self.mutable_l0, self.other),
             # 16:
             (self.other, self.mutable_l1, SumExpression([self.other, self.mon_npv])),
-            (
-                self.other,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.other]),
-            ),
+            (self.other, self.mutable_l2, SumExpression(self.l2.args + [self.other])),
             (self.other, self.param0, self.other),
             (self.other, self.param1, SumExpression([self.other, 1])),
             # 20:
@@ -804,7 +760,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, self.mutable_l0, 0),
             # 16:
             (self.mutable_l0, self.mutable_l1, self.mon_npv),
-            (self.mutable_l0, self.mutable_l2, self.mutable_l2),
+            (self.mutable_l0, self.mutable_l2, self.l2),
             (self.mutable_l0, self.param0, 0),
             (self.mutable_l0, self.param1, 1),
             # 20:
@@ -817,91 +773,47 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_add_mutable_l1(self):
         tests = [
             (self.mutable_l1, self.invalid, NotImplemented),
-            (
-                self.mutable_l1,
-                self.asbinary,
-                LinearExpression(self.mutable_l1.args + [self.bin]),
-            ),
+            (self.mutable_l1, self.asbinary, LinearExpression([self.l1, self.bin])),
             (self.mutable_l1, self.zero, self.mon_npv),
-            (self.mutable_l1, self.one, LinearExpression(self.mutable_l1.args + [1])),
+            (self.mutable_l1, self.one, LinearExpression([self.l1, 1])),
             # 4:
-            (
-                self.mutable_l1,
-                self.native,
-                LinearExpression(self.mutable_l1.args + [5]),
-            ),
-            (
-                self.mutable_l1,
-                self.npv,
-                LinearExpression(self.mutable_l1.args + [self.npv]),
-            ),
-            (self.mutable_l1, self.param, LinearExpression(self.mutable_l1.args + [6])),
+            (self.mutable_l1, self.native, LinearExpression([self.l1, 5])),
+            (self.mutable_l1, self.npv, LinearExpression([self.l1, self.npv])),
+            (self.mutable_l1, self.param, LinearExpression([self.l1, 6])),
             (
                 self.mutable_l1,
                 self.param_mut,
-                LinearExpression(self.mutable_l1.args + [self.param_mut]),
+                LinearExpression([self.l1, self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l1,
-                self.var,
-                LinearExpression(self.mutable_l1.args + [self.var]),
-            ),
+            (self.mutable_l1, self.var, LinearExpression([self.l1, self.var])),
             (
                 self.mutable_l1,
                 self.mon_native,
-                LinearExpression(self.mutable_l1.args + [self.mon_native]),
+                LinearExpression([self.l1, self.mon_native]),
             ),
             (
                 self.mutable_l1,
                 self.mon_param,
-                LinearExpression(self.mutable_l1.args + [self.mon_param]),
+                LinearExpression([self.l1, self.mon_param]),
             ),
-            (
-                self.mutable_l1,
-                self.mon_npv,
-                LinearExpression(self.mutable_l1.args + [self.mon_npv]),
-            ),
+            (self.mutable_l1, self.mon_npv, LinearExpression([self.l1, self.mon_npv])),
             # 12:
             (
                 self.mutable_l1,
                 self.linear,
-                LinearExpression(self.linear.args + self.mutable_l1.args),
+                LinearExpression(self.linear.args + [self.l1]),
             ),
-            (
-                self.mutable_l1,
-                self.sum,
-                SumExpression(self.sum.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l1,
-                self.other,
-                SumExpression(self.mutable_l1.args + [self.other]),
-            ),
+            (self.mutable_l1, self.sum, SumExpression(self.sum.args + [self.l1])),
+            (self.mutable_l1, self.other, SumExpression([self.l1, self.other])),
             (self.mutable_l1, self.mutable_l0, self.mon_npv),
             # 16:
-            (
-                self.mutable_l1,
-                self.mutable_l1,
-                LinearExpression(self.mutable_l1.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l1.args),
-            ),
+            (self.mutable_l1, self.mutable_l1, LinearExpression([self.l1, self.l1])),
+            (self.mutable_l1, self.mutable_l2, SumExpression(self.l2.args + [self.l1])),
             (self.mutable_l1, self.param0, self.mon_npv),
-            (
-                self.mutable_l1,
-                self.param1,
-                LinearExpression(self.mutable_l1.args + [1]),
-            ),
+            (self.mutable_l1, self.param1, LinearExpression([self.l1, 1])),
             # 20:
-            (
-                self.mutable_l1,
-                self.mutable_l3,
-                LinearExpression(self.mutable_l1.args + [self.npv]),
-            ),
+            (self.mutable_l1, self.mutable_l3, LinearExpression([self.l1, self.npv])),
         ]
         self._run_cases(tests, operator.add)
         # Mutable iadd handled by separate tests
@@ -910,82 +822,54 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_add_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                SumExpression(self.mutable_l2.args + [self.bin]),
-            ),
-            (self.mutable_l2, self.zero, self.mutable_l2),
-            (self.mutable_l2, self.one, SumExpression(self.mutable_l2.args + [1])),
+            (self.mutable_l2, self.asbinary, SumExpression(self.l2.args + [self.bin])),
+            (self.mutable_l2, self.zero, self.l2),
+            (self.mutable_l2, self.one, SumExpression(self.l2.args + [1])),
             # 4:
-            (self.mutable_l2, self.native, SumExpression(self.mutable_l2.args + [5])),
-            (
-                self.mutable_l2,
-                self.npv,
-                SumExpression(self.mutable_l2.args + [self.npv]),
-            ),
-            (self.mutable_l2, self.param, SumExpression(self.mutable_l2.args + [6])),
+            (self.mutable_l2, self.native, SumExpression(self.l2.args + [5])),
+            (self.mutable_l2, self.npv, SumExpression(self.l2.args + [self.npv])),
+            (self.mutable_l2, self.param, SumExpression(self.l2.args + [6])),
             (
                 self.mutable_l2,
                 self.param_mut,
-                SumExpression(self.mutable_l2.args + [self.param_mut]),
+                SumExpression(self.l2.args + [self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                SumExpression(self.mutable_l2.args + [self.var]),
-            ),
+            (self.mutable_l2, self.var, SumExpression(self.l2.args + [self.var])),
             (
                 self.mutable_l2,
                 self.mon_native,
-                SumExpression(self.mutable_l2.args + [self.mon_native]),
+                SumExpression(self.l2.args + [self.mon_native]),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                SumExpression(self.mutable_l2.args + [self.mon_param]),
+                SumExpression(self.l2.args + [self.mon_param]),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                SumExpression(self.mutable_l2.args + [self.mon_npv]),
+                SumExpression(self.l2.args + [self.mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                SumExpression(self.mutable_l2.args + [self.linear]),
-            ),
-            (
-                self.mutable_l2,
-                self.sum,
-                SumExpression(self.mutable_l2.args + self.sum.args),
-            ),
-            (
-                self.mutable_l2,
-                self.other,
-                SumExpression(self.mutable_l2.args + [self.other]),
-            ),
-            (self.mutable_l2, self.mutable_l0, self.mutable_l2),
+            (self.mutable_l2, self.linear, SumExpression(self.l2.args + [self.linear])),
+            (self.mutable_l2, self.sum, SumExpression(self.l2.args + self.sum.args)),
+            (self.mutable_l2, self.other, SumExpression(self.l2.args + [self.other])),
+            (self.mutable_l2, self.mutable_l0, self.l2),
             # 16:
-            (
-                self.mutable_l2,
-                self.mutable_l1,
-                SumExpression(self.mutable_l2.args + self.mutable_l1.args),
-            ),
+            (self.mutable_l2, self.mutable_l1, SumExpression(self.l2.args + [self.l1])),
             (
                 self.mutable_l2,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l2.args),
+                SumExpression(self.l2.args + self.l2.args),
             ),
-            (self.mutable_l2, self.param0, self.mutable_l2),
-            (self.mutable_l2, self.param1, SumExpression(self.mutable_l2.args + [1])),
+            (self.mutable_l2, self.param0, self.l2),
+            (self.mutable_l2, self.param1, SumExpression(self.l2.args + [1])),
             # 20:
             (
                 self.mutable_l2,
                 self.mutable_l3,
-                SumExpression(self.mutable_l2.args + [self.npv]),
+                SumExpression(self.l2.args + [self.npv]),
             ),
         ]
         self._run_cases(tests, operator.add)
@@ -1015,7 +899,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 0),
             # 16:
             (self.param0, self.mutable_l1, self.mon_npv),
-            (self.param0, self.mutable_l2, self.mutable_l2),
+            (self.param0, self.mutable_l2, self.l2),
             (self.param0, self.param0, 0),
             (self.param0, self.param1, 1),
             # 20:
@@ -1046,12 +930,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param1, self.other, SumExpression([1, self.other])),
             (self.param1, self.mutable_l0, 1),
             # 16:
-            (
-                self.param1,
-                self.mutable_l1,
-                LinearExpression([1] + self.mutable_l1.args),
-            ),
-            (self.param1, self.mutable_l2, SumExpression(self.mutable_l2.args + [1])),
+            (self.param1, self.mutable_l1, LinearExpression([1, self.l1])),
+            (self.param1, self.mutable_l2, SumExpression(self.l2.args + [1])),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 2),
             # 20:
@@ -1063,95 +943,47 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_add_mutable_l3(self):
         tests = [
             (self.mutable_l3, self.invalid, NotImplemented),
-            (
-                self.mutable_l3,
-                self.asbinary,
-                LinearExpression(self.mutable_l3.args + [self.bin]),
-            ),
+            (self.mutable_l3, self.asbinary, LinearExpression([self.l3, self.bin])),
             (self.mutable_l3, self.zero, self.npv),
-            (self.mutable_l3, self.one, NPV_SumExpression(self.mutable_l3.args + [1])),
+            (self.mutable_l3, self.one, NPV_SumExpression([self.l3, 1])),
             # 4:
-            (
-                self.mutable_l3,
-                self.native,
-                NPV_SumExpression(self.mutable_l3.args + [5]),
-            ),
-            (
-                self.mutable_l3,
-                self.npv,
-                NPV_SumExpression(self.mutable_l3.args + [self.npv]),
-            ),
-            (
-                self.mutable_l3,
-                self.param,
-                NPV_SumExpression(self.mutable_l3.args + [6]),
-            ),
+            (self.mutable_l3, self.native, NPV_SumExpression([self.l3, 5])),
+            (self.mutable_l3, self.npv, NPV_SumExpression([self.l3, self.npv])),
+            (self.mutable_l3, self.param, NPV_SumExpression([self.l3, 6])),
             (
                 self.mutable_l3,
                 self.param_mut,
-                NPV_SumExpression(self.mutable_l3.args + [self.param_mut]),
+                NPV_SumExpression([self.l3, self.param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l3,
-                self.var,
-                LinearExpression(self.mutable_l3.args + [self.var]),
-            ),
+            (self.mutable_l3, self.var, LinearExpression([self.l3, self.var])),
             (
                 self.mutable_l3,
                 self.mon_native,
-                LinearExpression(self.mutable_l3.args + [self.mon_native]),
+                LinearExpression([self.l3, self.mon_native]),
             ),
             (
                 self.mutable_l3,
                 self.mon_param,
-                LinearExpression(self.mutable_l3.args + [self.mon_param]),
+                LinearExpression([self.l3, self.mon_param]),
             ),
-            (
-                self.mutable_l3,
-                self.mon_npv,
-                LinearExpression(self.mutable_l3.args + [self.mon_npv]),
-            ),
+            (self.mutable_l3, self.mon_npv, LinearExpression([self.l3, self.mon_npv])),
             # 12:
             (
                 self.mutable_l3,
                 self.linear,
-                LinearExpression(self.linear.args + self.mutable_l3.args),
+                LinearExpression(self.linear.args + [self.l3]),
             ),
-            (
-                self.mutable_l3,
-                self.sum,
-                SumExpression(self.sum.args + self.mutable_l3.args),
-            ),
-            (
-                self.mutable_l3,
-                self.other,
-                SumExpression(self.mutable_l3.args + [self.other]),
-            ),
+            (self.mutable_l3, self.sum, SumExpression(self.sum.args + [self.l3])),
+            (self.mutable_l3, self.other, SumExpression([self.l3, self.other])),
             (self.mutable_l3, self.mutable_l0, self.npv),
             # 16:
-            (
-                self.mutable_l3,
-                self.mutable_l1,
-                LinearExpression(self.mutable_l3.args + self.mutable_l1.args),
-            ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                SumExpression(self.mutable_l2.args + self.mutable_l3.args),
-            ),
+            (self.mutable_l3, self.mutable_l1, LinearExpression([self.l3, self.l1])),
+            (self.mutable_l3, self.mutable_l2, SumExpression(self.l2.args + [self.l3])),
             (self.mutable_l3, self.param0, self.npv),
-            (
-                self.mutable_l3,
-                self.param1,
-                NPV_SumExpression(self.mutable_l3.args + [1]),
-            ),
+            (self.mutable_l3, self.param1, NPV_SumExpression([self.l3, 1])),
             # 20:
-            (
-                self.mutable_l3,
-                self.mutable_l3,
-                NPV_SumExpression(self.mutable_l3.args + [self.npv]),
-            ),
+            (self.mutable_l3, self.mutable_l3, NPV_SumExpression([self.l3, self.npv])),
         ]
         self._run_cases(tests, operator.add)
         # Mutable iadd handled by separate tests
@@ -1239,11 +1071,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.bin, self.minus_mon_npv]),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                SumExpression([self.bin, self.minus_mutable_l2]),
-            ),
+            (self.asbinary, self.mutable_l2, SumExpression([self.bin, self.minus_l2])),
             (self.asbinary, self.param0, self.bin),
             (self.asbinary, self.param1, LinearExpression([self.bin, -1])),
             # 20:
@@ -1279,7 +1107,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 0),
             # 16:
             (self.zero, self.mutable_l1, self.minus_mon_npv),
-            (self.zero, self.mutable_l2, self.minus_mutable_l2),
+            (self.zero, self.mutable_l2, self.minus_l2),
             (self.zero, self.param0, 0),
             (self.zero, self.param1, -1),
             # 20:
@@ -1311,7 +1139,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 1),
             # 16:
             (self.one, self.mutable_l1, LinearExpression([1, self.minus_mon_npv])),
-            (self.one, self.mutable_l2, SumExpression([1, self.minus_mutable_l2])),
+            (self.one, self.mutable_l2, SumExpression([1, self.minus_l2])),
             (self.one, self.param0, 1),
             (self.one, self.param1, 0),
             # 20:
@@ -1347,7 +1175,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.native, self.mutable_l0, 5),
             # 16:
             (self.native, self.mutable_l1, LinearExpression([5, self.minus_mon_npv])),
-            (self.native, self.mutable_l2, SumExpression([5, self.minus_mutable_l2])),
+            (self.native, self.mutable_l2, SumExpression([5, self.minus_l2])),
             (self.native, self.param0, 5),
             (self.native, self.param1, 4),
             # 20:
@@ -1395,11 +1223,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.npv, self.minus_mon_npv]),
             ),
-            (
-                self.npv,
-                self.mutable_l2,
-                SumExpression([self.npv, self.minus_mutable_l2]),
-            ),
+            (self.npv, self.mutable_l2, SumExpression([self.npv, self.minus_l2])),
             (self.npv, self.param0, self.npv),
             (self.npv, self.param1, NPV_SumExpression([self.npv, -1])),
             # 20:
@@ -1431,7 +1255,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param, self.mutable_l0, 6),
             # 16:
             (self.param, self.mutable_l1, LinearExpression([6, self.minus_mon_npv])),
-            (self.param, self.mutable_l2, SumExpression([6, self.minus_mutable_l2])),
+            (self.param, self.mutable_l2, SumExpression([6, self.minus_l2])),
             (self.param, self.param0, 6),
             (self.param, self.param1, 5),
             # 20:
@@ -1506,7 +1330,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                SumExpression([self.param_mut, self.minus_mutable_l2]),
+                SumExpression([self.param_mut, self.minus_l2]),
             ),
             (self.param_mut, self.param0, self.param_mut),
             (self.param_mut, self.param1, NPV_SumExpression([self.param_mut, -1])),
@@ -1563,11 +1387,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression([self.var, self.minus_mon_npv]),
             ),
-            (
-                self.var,
-                self.mutable_l2,
-                SumExpression([self.var, self.minus_mutable_l2]),
-            ),
+            (self.var, self.mutable_l2, SumExpression([self.var, self.minus_l2])),
             (self.var, self.param0, self.var),
             (self.var, self.param1, LinearExpression([self.var, -1])),
             # 20:
@@ -1646,7 +1466,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                SumExpression([self.mon_native, self.minus_mutable_l2]),
+                SumExpression([self.mon_native, self.minus_l2]),
             ),
             (self.mon_native, self.param0, self.mon_native),
             (self.mon_native, self.param1, LinearExpression([self.mon_native, -1])),
@@ -1726,7 +1546,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                SumExpression([self.mon_param, self.minus_mutable_l2]),
+                SumExpression([self.mon_param, self.minus_l2]),
             ),
             (self.mon_param, self.param0, self.mon_param),
             (self.mon_param, self.param1, LinearExpression([self.mon_param, -1])),
@@ -1794,7 +1614,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_npv,
                 self.mutable_l2,
-                SumExpression([self.mon_npv, self.minus_mutable_l2]),
+                SumExpression([self.mon_npv, self.minus_l2]),
             ),
             (self.mon_npv, self.param0, self.mon_npv),
             (self.mon_npv, self.param1, LinearExpression([self.mon_npv, -1])),
@@ -1863,11 +1683,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 LinearExpression(self.linear.args + [self.minus_mon_npv]),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                SumExpression([self.linear, self.minus_mutable_l2]),
-            ),
+            (self.linear, self.mutable_l2, SumExpression([self.linear, self.minus_l2])),
             (self.linear, self.param0, self.linear),
             (self.linear, self.param1, LinearExpression(self.linear.args + [-1])),
             # 20:
@@ -1923,11 +1739,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 SumExpression(self.sum.args + [self.minus_mon_npv]),
             ),
-            (
-                self.sum,
-                self.mutable_l2,
-                SumExpression(self.sum.args + [self.minus_mutable_l2]),
-            ),
+            (self.sum, self.mutable_l2, SumExpression(self.sum.args + [self.minus_l2])),
             (self.sum, self.param0, self.sum),
             (self.sum, self.param1, SumExpression(self.sum.args + [-1])),
             # 20:
@@ -1979,11 +1791,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 SumExpression([self.other, self.minus_mon_npv]),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                SumExpression([self.other, self.minus_mutable_l2]),
-            ),
+            (self.other, self.mutable_l2, SumExpression([self.other, self.minus_l2])),
             (self.other, self.param0, self.other),
             (self.other, self.param1, SumExpression([self.other, -1])),
             # 20:
@@ -2012,10 +1820,10 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, self.linear, self.minus_linear),
             (self.mutable_l0, self.sum, self.minus_sum),
             (self.mutable_l0, self.other, self.minus_other),
-            (self.mutable_l0, self.mutable_l0, self.mutable_l0),
+            (self.mutable_l0, self.mutable_l0, self.l0),
             # 16:
             (self.mutable_l0, self.mutable_l1, self.minus_mon_npv),
-            (self.mutable_l0, self.mutable_l2, self.minus_mutable_l2),
+            (self.mutable_l0, self.mutable_l2, self.minus_l2),
             (self.mutable_l0, self.param0, 0),
             (self.mutable_l0, self.param1, -1),
             # 20:
@@ -2031,91 +1839,55 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.asbinary,
-                LinearExpression(self.mutable_l1.args + [self.minus_bin]),
+                LinearExpression([self.l1, self.minus_bin]),
             ),
             (self.mutable_l1, self.zero, self.mon_npv),
-            (self.mutable_l1, self.one, LinearExpression(self.mutable_l1.args + [-1])),
+            (self.mutable_l1, self.one, LinearExpression([self.l1, -1])),
             # 4:
-            (
-                self.mutable_l1,
-                self.native,
-                LinearExpression(self.mutable_l1.args + [-5]),
-            ),
-            (
-                self.mutable_l1,
-                self.npv,
-                LinearExpression(self.mutable_l1.args + [self.minus_npv]),
-            ),
-            (
-                self.mutable_l1,
-                self.param,
-                LinearExpression(self.mutable_l1.args + [-6]),
-            ),
+            (self.mutable_l1, self.native, LinearExpression([self.l1, -5])),
+            (self.mutable_l1, self.npv, LinearExpression([self.l1, self.minus_npv])),
+            (self.mutable_l1, self.param, LinearExpression([self.l1, -6])),
             (
                 self.mutable_l1,
                 self.param_mut,
-                LinearExpression(self.mutable_l1.args + [self.minus_param_mut]),
+                LinearExpression([self.l1, self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l1,
-                self.var,
-                LinearExpression(self.mutable_l1.args + [self.minus_var]),
-            ),
+            (self.mutable_l1, self.var, LinearExpression([self.l1, self.minus_var])),
             (
                 self.mutable_l1,
                 self.mon_native,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_native]),
+                LinearExpression([self.l1, self.minus_mon_native]),
             ),
             (
                 self.mutable_l1,
                 self.mon_param,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_param]),
+                LinearExpression([self.l1, self.minus_mon_param]),
             ),
             (
                 self.mutable_l1,
                 self.mon_npv,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_npv]),
+                LinearExpression([self.l1, self.minus_mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l1,
-                self.linear,
-                SumExpression(self.mutable_l1.args + [self.minus_linear]),
-            ),
-            (
-                self.mutable_l1,
-                self.sum,
-                SumExpression(self.mutable_l1.args + [self.minus_sum]),
-            ),
-            (
-                self.mutable_l1,
-                self.other,
-                SumExpression(self.mutable_l1.args + [self.minus_other]),
-            ),
+            (self.mutable_l1, self.linear, SumExpression([self.l1, self.minus_linear])),
+            (self.mutable_l1, self.sum, SumExpression([self.l1, self.minus_sum])),
+            (self.mutable_l1, self.other, SumExpression([self.l1, self.minus_other])),
             (self.mutable_l1, self.mutable_l0, self.mon_npv),
             # 16:
             (
                 self.mutable_l1,
                 self.mutable_l1,
-                LinearExpression(self.mutable_l1.args + [self.minus_mon_npv]),
+                LinearExpression([self.l1, self.minus_mon_npv]),
             ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                SumExpression(self.mutable_l1.args + [self.minus_mutable_l2]),
-            ),
+            (self.mutable_l1, self.mutable_l2, SumExpression([self.l1, self.minus_l2])),
             (self.mutable_l1, self.param0, self.mon_npv),
-            (
-                self.mutable_l1,
-                self.param1,
-                LinearExpression(self.mutable_l1.args + [-1]),
-            ),
+            (self.mutable_l1, self.param1, LinearExpression([self.l1, -1])),
             # 20:
             (
                 self.mutable_l1,
                 self.mutable_l3,
-                LinearExpression(self.mutable_l1.args + [self.minus_npv]),
+                LinearExpression([self.l1, self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2128,79 +1900,67 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l2,
                 self.asbinary,
-                SumExpression(self.mutable_l2.args + [self.minus_bin]),
+                SumExpression(self.l2.args + [self.minus_bin]),
             ),
-            (self.mutable_l2, self.zero, self.mutable_l2),
-            (self.mutable_l2, self.one, SumExpression(self.mutable_l2.args + [-1])),
+            (self.mutable_l2, self.zero, self.l2),
+            (self.mutable_l2, self.one, SumExpression(self.l2.args + [-1])),
             # 4:
-            (self.mutable_l2, self.native, SumExpression(self.mutable_l2.args + [-5])),
-            (
-                self.mutable_l2,
-                self.npv,
-                SumExpression(self.mutable_l2.args + [self.minus_npv]),
-            ),
-            (self.mutable_l2, self.param, SumExpression(self.mutable_l2.args + [-6])),
+            (self.mutable_l2, self.native, SumExpression(self.l2.args + [-5])),
+            (self.mutable_l2, self.npv, SumExpression(self.l2.args + [self.minus_npv])),
+            (self.mutable_l2, self.param, SumExpression(self.l2.args + [-6])),
             (
                 self.mutable_l2,
                 self.param_mut,
-                SumExpression(self.mutable_l2.args + [self.minus_param_mut]),
+                SumExpression(self.l2.args + [self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                SumExpression(self.mutable_l2.args + [self.minus_var]),
-            ),
+            (self.mutable_l2, self.var, SumExpression(self.l2.args + [self.minus_var])),
             (
                 self.mutable_l2,
                 self.mon_native,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_native]),
+                SumExpression(self.l2.args + [self.minus_mon_native]),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_param]),
+                SumExpression(self.l2.args + [self.minus_mon_param]),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_npv]),
+                SumExpression(self.l2.args + [self.minus_mon_npv]),
             ),
             # 12:
             (
                 self.mutable_l2,
                 self.linear,
-                SumExpression(self.mutable_l2.args + [self.minus_linear]),
+                SumExpression(self.l2.args + [self.minus_linear]),
             ),
-            (
-                self.mutable_l2,
-                self.sum,
-                SumExpression(self.mutable_l2.args + [self.minus_sum]),
-            ),
+            (self.mutable_l2, self.sum, SumExpression(self.l2.args + [self.minus_sum])),
             (
                 self.mutable_l2,
                 self.other,
-                SumExpression(self.mutable_l2.args + [self.minus_other]),
+                SumExpression(self.l2.args + [self.minus_other]),
             ),
-            (self.mutable_l2, self.mutable_l0, self.mutable_l2),
+            (self.mutable_l2, self.mutable_l0, self.l2),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                SumExpression(self.mutable_l2.args + [self.minus_mon_npv]),
+                SumExpression(self.l2.args + [self.minus_mon_npv]),
             ),
             (
                 self.mutable_l2,
                 self.mutable_l2,
-                SumExpression(self.mutable_l2.args + [self.minus_mutable_l2]),
+                SumExpression(self.l2.args + [self.minus_l2]),
             ),
-            (self.mutable_l2, self.param0, self.mutable_l2),
-            (self.mutable_l2, self.param1, SumExpression(self.mutable_l2.args + [-1])),
+            (self.mutable_l2, self.param0, self.l2),
+            (self.mutable_l2, self.param1, SumExpression(self.l2.args + [-1])),
             # 20:
             (
                 self.mutable_l2,
                 self.mutable_l3,
-                SumExpression(self.mutable_l2.args + [self.minus_npv]),
+                SumExpression(self.l2.args + [self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2230,7 +1990,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 0),
             # 16:
             (self.param0, self.mutable_l1, self.minus_mon_npv),
-            (self.param0, self.mutable_l2, self.minus_mutable_l2),
+            (self.param0, self.mutable_l2, self.minus_l2),
             (self.param0, self.param0, 0),
             (self.param0, self.param1, -1),
             # 20:
@@ -2266,7 +2026,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 1),
             # 16:
             (self.param1, self.mutable_l1, LinearExpression([1, self.minus_mon_npv])),
-            (self.param1, self.mutable_l2, SumExpression([1, self.minus_mutable_l2])),
+            (self.param1, self.mutable_l2, SumExpression([1, self.minus_l2])),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 0),
             # 20:
@@ -2281,86 +2041,50 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l3,
                 self.asbinary,
-                LinearExpression(self.mutable_l3.args + [self.minus_bin]),
+                LinearExpression([self.l3, self.minus_bin]),
             ),
             (self.mutable_l3, self.zero, self.npv),
-            (self.mutable_l3, self.one, NPV_SumExpression(self.mutable_l3.args + [-1])),
+            (self.mutable_l3, self.one, NPV_SumExpression([self.l3, -1])),
             # 4:
-            (
-                self.mutable_l3,
-                self.native,
-                NPV_SumExpression(self.mutable_l3.args + [-5]),
-            ),
-            (
-                self.mutable_l3,
-                self.npv,
-                NPV_SumExpression(self.mutable_l3.args + [self.minus_npv]),
-            ),
-            (
-                self.mutable_l3,
-                self.param,
-                NPV_SumExpression(self.mutable_l3.args + [-6]),
-            ),
+            (self.mutable_l3, self.native, NPV_SumExpression([self.l3, -5])),
+            (self.mutable_l3, self.npv, NPV_SumExpression([self.l3, self.minus_npv])),
+            (self.mutable_l3, self.param, NPV_SumExpression([self.l3, -6])),
             (
                 self.mutable_l3,
                 self.param_mut,
-                NPV_SumExpression(self.mutable_l3.args + [self.minus_param_mut]),
+                NPV_SumExpression([self.l3, self.minus_param_mut]),
             ),
             # 8:
-            (
-                self.mutable_l3,
-                self.var,
-                LinearExpression(self.mutable_l3.args + [self.minus_var]),
-            ),
+            (self.mutable_l3, self.var, LinearExpression([self.l3, self.minus_var])),
             (
                 self.mutable_l3,
                 self.mon_native,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_native]),
+                LinearExpression([self.l3, self.minus_mon_native]),
             ),
             (
                 self.mutable_l3,
                 self.mon_param,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_param]),
+                LinearExpression([self.l3, self.minus_mon_param]),
             ),
             (
                 self.mutable_l3,
                 self.mon_npv,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_npv]),
+                LinearExpression([self.l3, self.minus_mon_npv]),
             ),
             # 12:
-            (
-                self.mutable_l3,
-                self.linear,
-                SumExpression(self.mutable_l3.args + [self.minus_linear]),
-            ),
-            (
-                self.mutable_l3,
-                self.sum,
-                SumExpression(self.mutable_l3.args + [self.minus_sum]),
-            ),
-            (
-                self.mutable_l3,
-                self.other,
-                SumExpression(self.mutable_l3.args + [self.minus_other]),
-            ),
+            (self.mutable_l3, self.linear, SumExpression([self.l3, self.minus_linear])),
+            (self.mutable_l3, self.sum, SumExpression([self.l3, self.minus_sum])),
+            (self.mutable_l3, self.other, SumExpression([self.l3, self.minus_other])),
             (self.mutable_l3, self.mutable_l0, self.npv),
             # 16:
             (
                 self.mutable_l3,
                 self.mutable_l1,
-                LinearExpression(self.mutable_l3.args + [self.minus_mon_npv]),
+                LinearExpression([self.l3, self.minus_mon_npv]),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                SumExpression(self.mutable_l3.args + [self.minus_mutable_l2]),
-            ),
+            (self.mutable_l3, self.mutable_l2, SumExpression([self.l3, self.minus_l2])),
             (self.mutable_l3, self.param0, self.npv),
-            (
-                self.mutable_l3,
-                self.param1,
-                NPV_SumExpression(self.mutable_l3.args + [-1]),
-            ),
+            (self.mutable_l3, self.param1, NPV_SumExpression([self.l3, -1])),
             # 20:
             # Note that because the mutable is resolved to a NPV_Sum in
             # the negation, the 1-term summation for the first arg is
@@ -2368,9 +2092,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l3,
                 self.mutable_l3,
-                NPV_SumExpression(
-                    [NPV_SumExpression(self.mutable_l3.args), self.minus_npv]
-                ),
+                NPV_SumExpression([self.l3, self.minus_npv]),
             ),
         ]
         self._run_cases(tests, operator.sub)
@@ -2458,11 +2180,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.bin, self.mon_npv)),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                ProductExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, ProductExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, 0),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -2534,7 +2252,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 0),
             # 16:
             (self.one, self.mutable_l1, self.mon_npv),
-            (self.one, self.mutable_l2, self.mutable_l2),
+            (self.one, self.mutable_l2, self.l2),
             (self.one, self.param0, self.param0),
             (self.one, self.param1, self.param1),
             # 20:
@@ -2599,7 +2317,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.native, self.mutable_l2, ProductExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, ProductExpression((5, self.l2))),
             (self.native, self.param0, 0),
             (self.native, self.param1, 5),
             # 20:
@@ -2671,7 +2389,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.npv, self.mutable_l2, ProductExpression((self.npv, self.mutable_l2))),
+            (self.npv, self.mutable_l2, ProductExpression((self.npv, self.l2))),
             (self.npv, self.param0, 0),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -2734,7 +2452,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (self.param, self.mutable_l2, ProductExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, ProductExpression((6, self.l2))),
             (self.param, self.param0, 0),
             (self.param, self.param1, 6),
             # 20:
@@ -2829,7 +2547,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                ProductExpression((self.param_mut, self.mutable_l2)),
+                ProductExpression((self.param_mut, self.l2)),
             ),
             (self.param_mut, self.param0, 0),
             (self.param_mut, self.param1, self.param_mut),
@@ -2870,7 +2588,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.var, self.mutable_l0, 0),
             # 16:
             (self.var, self.mutable_l1, ProductExpression((self.var, self.mon_npv))),
-            (self.var, self.mutable_l2, ProductExpression((self.var, self.mutable_l2))),
+            (self.var, self.mutable_l2, ProductExpression((self.var, self.l2))),
             (self.var, self.param0, 0),
             (self.var, self.param1, self.var),
             # 20:
@@ -2959,7 +2677,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                ProductExpression((self.mon_native, self.mutable_l2)),
+                ProductExpression((self.mon_native, self.l2)),
             ),
             (self.mon_native, self.param0, 0),
             (self.mon_native, self.param1, self.mon_native),
@@ -3068,7 +2786,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                ProductExpression((self.mon_param, self.mutable_l2)),
+                ProductExpression((self.mon_param, self.l2)),
             ),
             (self.mon_param, self.param0, 0),
             (self.mon_param, self.param1, self.mon_param),
@@ -3162,11 +2880,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mon_npv,
-                self.mutable_l2,
-                ProductExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mon_npv, self.mutable_l2, ProductExpression((self.mon_npv, self.l2))),
             (self.mon_npv, self.param0, 0),
             (self.mon_npv, self.param1, self.mon_npv),
             # 20:
@@ -3223,11 +2937,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.linear, self.mon_npv)),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                ProductExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, ProductExpression((self.linear, self.l2))),
             (self.linear, self.param0, 0),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -3259,7 +2969,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, 0),
             # 16:
             (self.sum, self.mutable_l1, ProductExpression((self.sum, self.mon_npv))),
-            (self.sum, self.mutable_l2, ProductExpression((self.sum, self.mutable_l2))),
+            (self.sum, self.mutable_l2, ProductExpression((self.sum, self.l2))),
             (self.sum, self.param0, 0),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -3307,11 +3017,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 ProductExpression((self.other, self.mon_npv)),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                ProductExpression((self.other, self.mutable_l2)),
-            ),
+            (self.other, self.mutable_l2, ProductExpression((self.other, self.l2))),
             (self.other, self.param0, 0),
             (self.other, self.param1, self.other),
             # 20:
@@ -3442,7 +3148,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.mutable_l2,
-                ProductExpression((self.mon_npv, self.mutable_l2)),
+                ProductExpression((self.mon_npv, self.l2)),
             ),
             (self.mutable_l1, self.param0, 0),
             (self.mutable_l1, self.param1, self.mon_npv),
@@ -3464,71 +3170,47 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_mul_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                ProductExpression((self.mutable_l2, self.bin)),
-            ),
+            (self.mutable_l2, self.asbinary, ProductExpression((self.l2, self.bin))),
             (self.mutable_l2, self.zero, 0),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, ProductExpression((self.mutable_l2, 5))),
-            (self.mutable_l2, self.npv, ProductExpression((self.mutable_l2, self.npv))),
-            (self.mutable_l2, self.param, ProductExpression((self.mutable_l2, 6))),
+            (self.mutable_l2, self.native, ProductExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, ProductExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, ProductExpression((self.l2, 6))),
             (
                 self.mutable_l2,
                 self.param_mut,
-                ProductExpression((self.mutable_l2, self.param_mut)),
+                ProductExpression((self.l2, self.param_mut)),
             ),
             # 8:
-            (self.mutable_l2, self.var, ProductExpression((self.mutable_l2, self.var))),
+            (self.mutable_l2, self.var, ProductExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                ProductExpression((self.mutable_l2, self.mon_native)),
+                ProductExpression((self.l2, self.mon_native)),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                ProductExpression((self.mutable_l2, self.mon_param)),
+                ProductExpression((self.l2, self.mon_param)),
             ),
-            (
-                self.mutable_l2,
-                self.mon_npv,
-                ProductExpression((self.mutable_l2, self.mon_npv)),
-            ),
+            (self.mutable_l2, self.mon_npv, ProductExpression((self.l2, self.mon_npv))),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                ProductExpression((self.mutable_l2, self.linear)),
-            ),
-            (self.mutable_l2, self.sum, ProductExpression((self.mutable_l2, self.sum))),
-            (
-                self.mutable_l2,
-                self.other,
-                ProductExpression((self.mutable_l2, self.other)),
-            ),
+            (self.mutable_l2, self.linear, ProductExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, ProductExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, ProductExpression((self.l2, self.other))),
             (self.mutable_l2, self.mutable_l0, 0),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                ProductExpression((self.mutable_l2, self.mon_npv)),
+                ProductExpression((self.l2, self.mon_npv)),
             ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                ProductExpression((self.mutable_l2, self.mutable_l2)),
-            ),
+            (self.mutable_l2, self.mutable_l2, ProductExpression((self.l2, self.l2))),
             (self.mutable_l2, self.param0, 0),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                ProductExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, ProductExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.mul)
         self._run_cases(tests, operator.imul)
@@ -3592,7 +3274,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 0),
             # 16:
             (self.param1, self.mutable_l1, self.mon_npv),
-            (self.param1, self.mutable_l2, self.mutable_l2),
+            (self.param1, self.mutable_l2, self.l2),
             (self.param1, self.param0, self.param0),
             (self.param1, self.param1, self.param1),
             # 20:
@@ -3668,11 +3350,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                     )
                 ),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                ProductExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, ProductExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, 0),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -3771,11 +3449,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.bin, self.mon_npv)),
             ),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                DivisionExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, DivisionExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, ZeroDivisionError),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -3845,7 +3519,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.one, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.one, self.mutable_l1, DivisionExpression((1, self.mon_npv))),
-            (self.one, self.mutable_l2, DivisionExpression((1, self.mutable_l2))),
+            (self.one, self.mutable_l2, DivisionExpression((1, self.l2))),
             (self.one, self.param0, ZeroDivisionError),
             (self.one, self.param1, 1.0),
             # 20:
@@ -3877,7 +3551,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.native, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.native, self.mutable_l1, DivisionExpression((5, self.mon_npv))),
-            (self.native, self.mutable_l2, DivisionExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, DivisionExpression((5, self.l2))),
             (self.native, self.param0, ZeroDivisionError),
             (self.native, self.param1, 5.0),
             # 20:
@@ -3917,11 +3591,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.npv, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.npv, self.mutable_l1, DivisionExpression((self.npv, self.mon_npv))),
-            (
-                self.npv,
-                self.mutable_l2,
-                DivisionExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.npv, self.mutable_l2, DivisionExpression((self.npv, self.l2))),
             (self.npv, self.param0, ZeroDivisionError),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -3953,7 +3623,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.param, self.mutable_l1, DivisionExpression((6, self.mon_npv))),
-            (self.param, self.mutable_l2, DivisionExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, DivisionExpression((6, self.l2))),
             (self.param, self.param0, ZeroDivisionError),
             (self.param, self.param1, 6.0),
             # 20:
@@ -4024,7 +3694,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.param_mut,
                 self.mutable_l2,
-                DivisionExpression((self.param_mut, self.mutable_l2)),
+                DivisionExpression((self.param_mut, self.l2)),
             ),
             (self.param_mut, self.param0, ZeroDivisionError),
             (self.param_mut, self.param1, self.param_mut),
@@ -4077,11 +3747,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.var, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.var, self.mutable_l1, DivisionExpression((self.var, self.mon_npv))),
-            (
-                self.var,
-                self.mutable_l2,
-                DivisionExpression((self.var, self.mutable_l2)),
-            ),
+            (self.var, self.mutable_l2, DivisionExpression((self.var, self.l2))),
             (self.var, self.param0, ZeroDivisionError),
             (self.var, self.param1, self.var),
             # 20:
@@ -4186,7 +3852,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                DivisionExpression((self.mon_native, self.mutable_l2)),
+                DivisionExpression((self.mon_native, self.l2)),
             ),
             (self.mon_native, self.param0, ZeroDivisionError),
             (self.mon_native, self.param1, self.mon_native),
@@ -4295,7 +3961,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_param,
                 self.mutable_l2,
-                DivisionExpression((self.mon_param, self.mutable_l2)),
+                DivisionExpression((self.mon_param, self.l2)),
             ),
             (self.mon_param, self.param0, ZeroDivisionError),
             (self.mon_param, self.param1, self.mon_param),
@@ -4396,7 +4062,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_npv,
                 self.mutable_l2,
-                DivisionExpression((self.mon_npv, self.mutable_l2)),
+                DivisionExpression((self.mon_npv, self.l2)),
             ),
             (self.mon_npv, self.param0, ZeroDivisionError),
             (self.mon_npv, self.param1, self.mon_npv),
@@ -4458,11 +4124,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.linear, self.mon_npv)),
             ),
-            (
-                self.linear,
-                self.mutable_l2,
-                DivisionExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, DivisionExpression((self.linear, self.l2))),
             (self.linear, self.param0, ZeroDivisionError),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -4498,11 +4160,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.sum, self.mutable_l1, DivisionExpression((self.sum, self.mon_npv))),
-            (
-                self.sum,
-                self.mutable_l2,
-                DivisionExpression((self.sum, self.mutable_l2)),
-            ),
+            (self.sum, self.mutable_l2, DivisionExpression((self.sum, self.l2))),
             (self.sum, self.param0, ZeroDivisionError),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -4550,11 +4208,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.other, self.mon_npv)),
             ),
-            (
-                self.other,
-                self.mutable_l2,
-                DivisionExpression((self.other, self.mutable_l2)),
-            ),
+            (self.other, self.mutable_l2, DivisionExpression((self.other, self.l2))),
             (self.other, self.param0, ZeroDivisionError),
             (self.other, self.param1, self.other),
             # 20:
@@ -4685,7 +4339,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mutable_l1,
                 self.mutable_l2,
-                DivisionExpression((self.mon_npv, self.mutable_l2)),
+                DivisionExpression((self.mon_npv, self.l2)),
             ),
             (self.mutable_l1, self.param0, ZeroDivisionError),
             (self.mutable_l1, self.param1, self.mon_npv),
@@ -4707,83 +4361,51 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_div_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                DivisionExpression((self.mutable_l2, self.bin)),
-            ),
+            (self.mutable_l2, self.asbinary, DivisionExpression((self.l2, self.bin))),
             (self.mutable_l2, self.zero, ZeroDivisionError),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, DivisionExpression((self.mutable_l2, 5))),
-            (
-                self.mutable_l2,
-                self.npv,
-                DivisionExpression((self.mutable_l2, self.npv)),
-            ),
-            (self.mutable_l2, self.param, DivisionExpression((self.mutable_l2, 6))),
+            (self.mutable_l2, self.native, DivisionExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, DivisionExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, DivisionExpression((self.l2, 6))),
             (
                 self.mutable_l2,
                 self.param_mut,
-                DivisionExpression((self.mutable_l2, self.param_mut)),
+                DivisionExpression((self.l2, self.param_mut)),
             ),
             # 8:
-            (
-                self.mutable_l2,
-                self.var,
-                DivisionExpression((self.mutable_l2, self.var)),
-            ),
+            (self.mutable_l2, self.var, DivisionExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                DivisionExpression((self.mutable_l2, self.mon_native)),
+                DivisionExpression((self.l2, self.mon_native)),
             ),
             (
                 self.mutable_l2,
                 self.mon_param,
-                DivisionExpression((self.mutable_l2, self.mon_param)),
+                DivisionExpression((self.l2, self.mon_param)),
             ),
             (
                 self.mutable_l2,
                 self.mon_npv,
-                DivisionExpression((self.mutable_l2, self.mon_npv)),
+                DivisionExpression((self.l2, self.mon_npv)),
             ),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                DivisionExpression((self.mutable_l2, self.linear)),
-            ),
-            (
-                self.mutable_l2,
-                self.sum,
-                DivisionExpression((self.mutable_l2, self.sum)),
-            ),
-            (
-                self.mutable_l2,
-                self.other,
-                DivisionExpression((self.mutable_l2, self.other)),
-            ),
+            (self.mutable_l2, self.linear, DivisionExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, DivisionExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, DivisionExpression((self.l2, self.other))),
             (self.mutable_l2, self.mutable_l0, ZeroDivisionError),
             # 16:
             (
                 self.mutable_l2,
                 self.mutable_l1,
-                DivisionExpression((self.mutable_l2, self.mon_npv)),
+                DivisionExpression((self.l2, self.mon_npv)),
             ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                DivisionExpression((self.mutable_l2, self.mutable_l2)),
-            ),
+            (self.mutable_l2, self.mutable_l2, DivisionExpression((self.l2, self.l2))),
             (self.mutable_l2, self.param0, ZeroDivisionError),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                DivisionExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, DivisionExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.truediv)
         self._run_cases(tests, operator.itruediv)
@@ -4843,7 +4465,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, ZeroDivisionError),
             # 16:
             (self.param1, self.mutable_l1, DivisionExpression((1, self.mon_npv))),
-            (self.param1, self.mutable_l2, DivisionExpression((1, self.mutable_l2))),
+            (self.param1, self.mutable_l2, DivisionExpression((1, self.l2))),
             (self.param1, self.param0, ZeroDivisionError),
             (self.param1, self.param1, 1.0),
             # 20:
@@ -4895,11 +4517,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 DivisionExpression((self.npv, self.mon_npv)),
             ),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                DivisionExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, DivisionExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, ZeroDivisionError),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -4978,11 +4596,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.asbinary, self.mutable_l0, 1),
             # 16:
             (self.asbinary, self.mutable_l1, PowExpression((self.bin, self.mon_npv))),
-            (
-                self.asbinary,
-                self.mutable_l2,
-                PowExpression((self.bin, self.mutable_l2)),
-            ),
+            (self.asbinary, self.mutable_l2, PowExpression((self.bin, self.l2))),
             (self.asbinary, self.param0, 1),
             (self.asbinary, self.param1, self.bin),
             # 20:
@@ -5014,7 +4628,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.zero, self.mutable_l0, 1),
             # 16:
             (self.zero, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.zero, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.zero, self.mutable_l2, PowExpression((0, self.l2))),
             (self.zero, self.param0, 1),
             (self.zero, self.param1, 0),
             # 20:
@@ -5046,7 +4660,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.one, self.mutable_l0, 1),
             # 16:
             (self.one, self.mutable_l1, PowExpression((1, self.mon_npv))),
-            (self.one, self.mutable_l2, PowExpression((1, self.mutable_l2))),
+            (self.one, self.mutable_l2, PowExpression((1, self.l2))),
             (self.one, self.param0, 1),
             (self.one, self.param1, 1),
             # 20:
@@ -5078,7 +4692,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.native, self.mutable_l0, 1),
             # 16:
             (self.native, self.mutable_l1, PowExpression((5, self.mon_npv))),
-            (self.native, self.mutable_l2, PowExpression((5, self.mutable_l2))),
+            (self.native, self.mutable_l2, PowExpression((5, self.l2))),
             (self.native, self.param0, 1),
             (self.native, self.param1, 5),
             # 20:
@@ -5110,7 +4724,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.npv, self.mutable_l0, 1),
             # 16:
             (self.npv, self.mutable_l1, PowExpression((self.npv, self.mon_npv))),
-            (self.npv, self.mutable_l2, PowExpression((self.npv, self.mutable_l2))),
+            (self.npv, self.mutable_l2, PowExpression((self.npv, self.l2))),
             (self.npv, self.param0, 1),
             (self.npv, self.param1, self.npv),
             # 20:
@@ -5142,7 +4756,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param, self.mutable_l0, 1),
             # 16:
             (self.param, self.mutable_l1, PowExpression((6, self.mon_npv))),
-            (self.param, self.mutable_l2, PowExpression((6, self.mutable_l2))),
+            (self.param, self.mutable_l2, PowExpression((6, self.l2))),
             (self.param, self.param0, 1),
             (self.param, self.param1, 6),
             # 20:
@@ -5194,11 +4808,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.param_mut, self.mon_npv)),
             ),
-            (
-                self.param_mut,
-                self.mutable_l2,
-                PowExpression((self.param_mut, self.mutable_l2)),
-            ),
+            (self.param_mut, self.mutable_l2, PowExpression((self.param_mut, self.l2))),
             (self.param_mut, self.param0, 1),
             (self.param_mut, self.param1, self.param_mut),
             # 20:
@@ -5234,7 +4844,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.var, self.mutable_l0, 1),
             # 16:
             (self.var, self.mutable_l1, PowExpression((self.var, self.mon_npv))),
-            (self.var, self.mutable_l2, PowExpression((self.var, self.mutable_l2))),
+            (self.var, self.mutable_l2, PowExpression((self.var, self.l2))),
             (self.var, self.param0, 1),
             (self.var, self.param1, self.var),
             # 20:
@@ -5297,7 +4907,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 self.mon_native,
                 self.mutable_l2,
-                PowExpression((self.mon_native, self.mutable_l2)),
+                PowExpression((self.mon_native, self.l2)),
             ),
             (self.mon_native, self.param0, 1),
             (self.mon_native, self.param1, self.mon_native),
@@ -5354,11 +4964,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_param, self.mon_npv)),
             ),
-            (
-                self.mon_param,
-                self.mutable_l2,
-                PowExpression((self.mon_param, self.mutable_l2)),
-            ),
+            (self.mon_param, self.mutable_l2, PowExpression((self.mon_param, self.l2))),
             (self.mon_param, self.param0, 1),
             (self.mon_param, self.param1, self.mon_param),
             # 20:
@@ -5410,11 +5016,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mon_npv,
-                self.mutable_l2,
-                PowExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mon_npv, self.mutable_l2, PowExpression((self.mon_npv, self.l2))),
             (self.mon_npv, self.param0, 1),
             (self.mon_npv, self.param1, self.mon_npv),
             # 20:
@@ -5450,11 +5052,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.linear, self.mutable_l0, 1),
             # 16:
             (self.linear, self.mutable_l1, PowExpression((self.linear, self.mon_npv))),
-            (
-                self.linear,
-                self.mutable_l2,
-                PowExpression((self.linear, self.mutable_l2)),
-            ),
+            (self.linear, self.mutable_l2, PowExpression((self.linear, self.l2))),
             (self.linear, self.param0, 1),
             (self.linear, self.param1, self.linear),
             # 20:
@@ -5486,7 +5084,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.sum, self.mutable_l0, 1),
             # 16:
             (self.sum, self.mutable_l1, PowExpression((self.sum, self.mon_npv))),
-            (self.sum, self.mutable_l2, PowExpression((self.sum, self.mutable_l2))),
+            (self.sum, self.mutable_l2, PowExpression((self.sum, self.l2))),
             (self.sum, self.param0, 1),
             (self.sum, self.param1, self.sum),
             # 20:
@@ -5518,7 +5116,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.other, self.mutable_l0, 1),
             # 16:
             (self.other, self.mutable_l1, PowExpression((self.other, self.mon_npv))),
-            (self.other, self.mutable_l2, PowExpression((self.other, self.mutable_l2))),
+            (self.other, self.mutable_l2, PowExpression((self.other, self.l2))),
             (self.other, self.param0, 1),
             (self.other, self.param1, self.other),
             # 20:
@@ -5550,7 +5148,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, self.mutable_l0, 1),
             # 16:
             (self.mutable_l0, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.mutable_l0, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.mutable_l0, self.mutable_l2, PowExpression((0, self.l2))),
             (self.mutable_l0, self.param0, 1),
             (self.mutable_l0, self.param1, 0),
             # 20:
@@ -5602,11 +5200,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 PowExpression((self.mon_npv, self.mon_npv)),
             ),
-            (
-                self.mutable_l1,
-                self.mutable_l2,
-                PowExpression((self.mon_npv, self.mutable_l2)),
-            ),
+            (self.mutable_l1, self.mutable_l2, PowExpression((self.mon_npv, self.l2))),
             (self.mutable_l1, self.param0, 1),
             (self.mutable_l1, self.param1, self.mon_npv),
             # 20:
@@ -5618,67 +5212,35 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
     def test_pow_mutable_l2(self):
         tests = [
             (self.mutable_l2, self.invalid, NotImplemented),
-            (
-                self.mutable_l2,
-                self.asbinary,
-                PowExpression((self.mutable_l2, self.bin)),
-            ),
+            (self.mutable_l2, self.asbinary, PowExpression((self.l2, self.bin))),
             (self.mutable_l2, self.zero, 1),
-            (self.mutable_l2, self.one, self.mutable_l2),
+            (self.mutable_l2, self.one, self.l2),
             # 4:
-            (self.mutable_l2, self.native, PowExpression((self.mutable_l2, 5))),
-            (self.mutable_l2, self.npv, PowExpression((self.mutable_l2, self.npv))),
-            (self.mutable_l2, self.param, PowExpression((self.mutable_l2, 6))),
-            (
-                self.mutable_l2,
-                self.param_mut,
-                PowExpression((self.mutable_l2, self.param_mut)),
-            ),
+            (self.mutable_l2, self.native, PowExpression((self.l2, 5))),
+            (self.mutable_l2, self.npv, PowExpression((self.l2, self.npv))),
+            (self.mutable_l2, self.param, PowExpression((self.l2, 6))),
+            (self.mutable_l2, self.param_mut, PowExpression((self.l2, self.param_mut))),
             # 8:
-            (self.mutable_l2, self.var, PowExpression((self.mutable_l2, self.var))),
+            (self.mutable_l2, self.var, PowExpression((self.l2, self.var))),
             (
                 self.mutable_l2,
                 self.mon_native,
-                PowExpression((self.mutable_l2, self.mon_native)),
+                PowExpression((self.l2, self.mon_native)),
             ),
-            (
-                self.mutable_l2,
-                self.mon_param,
-                PowExpression((self.mutable_l2, self.mon_param)),
-            ),
-            (
-                self.mutable_l2,
-                self.mon_npv,
-                PowExpression((self.mutable_l2, self.mon_npv)),
-            ),
+            (self.mutable_l2, self.mon_param, PowExpression((self.l2, self.mon_param))),
+            (self.mutable_l2, self.mon_npv, PowExpression((self.l2, self.mon_npv))),
             # 12:
-            (
-                self.mutable_l2,
-                self.linear,
-                PowExpression((self.mutable_l2, self.linear)),
-            ),
-            (self.mutable_l2, self.sum, PowExpression((self.mutable_l2, self.sum))),
-            (self.mutable_l2, self.other, PowExpression((self.mutable_l2, self.other))),
+            (self.mutable_l2, self.linear, PowExpression((self.l2, self.linear))),
+            (self.mutable_l2, self.sum, PowExpression((self.l2, self.sum))),
+            (self.mutable_l2, self.other, PowExpression((self.l2, self.other))),
             (self.mutable_l2, self.mutable_l0, 1),
             # 16:
-            (
-                self.mutable_l2,
-                self.mutable_l1,
-                PowExpression((self.mutable_l2, self.mon_npv)),
-            ),
-            (
-                self.mutable_l2,
-                self.mutable_l2,
-                PowExpression((self.mutable_l2, self.mutable_l2)),
-            ),
+            (self.mutable_l2, self.mutable_l1, PowExpression((self.l2, self.mon_npv))),
+            (self.mutable_l2, self.mutable_l2, PowExpression((self.l2, self.l2))),
             (self.mutable_l2, self.param0, 1),
-            (self.mutable_l2, self.param1, self.mutable_l2),
+            (self.mutable_l2, self.param1, self.l2),
             # 20:
-            (
-                self.mutable_l2,
-                self.mutable_l3,
-                PowExpression((self.mutable_l2, self.npv)),
-            ),
+            (self.mutable_l2, self.mutable_l3, PowExpression((self.l2, self.npv))),
         ]
         self._run_cases(tests, operator.pow)
         self._run_cases(tests, operator.ipow)
@@ -5706,7 +5268,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param0, self.mutable_l0, 1),
             # 16:
             (self.param0, self.mutable_l1, PowExpression((0, self.mon_npv))),
-            (self.param0, self.mutable_l2, PowExpression((0, self.mutable_l2))),
+            (self.param0, self.mutable_l2, PowExpression((0, self.l2))),
             (self.param0, self.param0, 1),
             (self.param0, self.param1, 0),
             # 20:
@@ -5738,7 +5300,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.param1, self.mutable_l0, 1),
             # 16:
             (self.param1, self.mutable_l1, PowExpression((1, self.mon_npv))),
-            (self.param1, self.mutable_l2, PowExpression((1, self.mutable_l2))),
+            (self.param1, self.mutable_l2, PowExpression((1, self.l2))),
             (self.param1, self.param0, 1),
             (self.param1, self.param1, 1),
             # 20:
@@ -5782,11 +5344,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l3, self.mutable_l0, 1),
             # 16:
             (self.mutable_l3, self.mutable_l1, PowExpression((self.npv, self.mon_npv))),
-            (
-                self.mutable_l3,
-                self.mutable_l2,
-                PowExpression((self.npv, self.mutable_l2)),
-            ),
+            (self.mutable_l3, self.mutable_l2, PowExpression((self.npv, self.l2))),
             (self.mutable_l3, self.param0, 1),
             (self.mutable_l3, self.param1, self.npv),
             # 20:
@@ -5824,7 +5382,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, self.minus_mon_npv),
-            (self.mutable_l2, NegationExpression((self.mutable_l2,))),
+            (self.mutable_l2, NegationExpression((self.l2,))),
             (self.param0, 0),
             (self.param1, -1),
             # 20:
@@ -5858,7 +5416,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, self.mon_npv),
-            (self.mutable_l2, self.mutable_l2),
+            (self.mutable_l2, self.l2),
             (self.param0, 0),
             (self.param1, 1),
             # 20:
@@ -5895,7 +5453,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (self.mutable_l0, 0),
             # 16:
             (self.mutable_l1, AbsExpression((self.mon_npv,))),
-            (self.mutable_l2, AbsExpression((self.mutable_l2,))),
+            (self.mutable_l2, AbsExpression((self.l2,))),
             (self.param0, 0),
             (self.param1, 1),
             # 20:
@@ -5962,10 +5520,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 (self.mutable_l0, ValueError if name in SKIP_0 else fcn(0)),
                 # 16:
                 (self.mutable_l1, UnaryFunctionExpression((self.mon_npv,), name, fcn)),
-                (
-                    self.mutable_l2,
-                    UnaryFunctionExpression((self.mutable_l2,), name, fcn),
-                ),
+                (self.mutable_l2, UnaryFunctionExpression((self.l2,), name, fcn)),
                 (self.param0, ValueError if name in SKIP_0 else fcn(0)),
                 (self.param1, ValueError if name in SKIP_1 else fcn(1)),
                 # 20:
@@ -6007,7 +5562,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 _MutableLinearExpression(self.mutable_l1.args),
             ),
-            (mutable_npv, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_npv, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_npv, self.param0, _MutableNPVSumExpression([])),
             (mutable_npv, self.param1, _MutableNPVSumExpression([1])),
             # 20:
@@ -6053,16 +5608,8 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (mutable_npv, self.other, _MutableSumExpression([10, self.other])),
             (mutable_npv, self.mutable_l0, _MutableNPVSumExpression([10])),
             # 16:
-            (
-                mutable_npv,
-                self.mutable_l1,
-                _MutableLinearExpression([10] + self.mutable_l1.args),
-            ),
-            (
-                mutable_npv,
-                self.mutable_l2,
-                _MutableSumExpression([10] + self.mutable_l2.args),
-            ),
+            (mutable_npv, self.mutable_l1, _MutableLinearExpression([10, self.l1])),
+            (mutable_npv, self.mutable_l2, _MutableSumExpression([10] + self.l2.args)),
             (mutable_npv, self.param0, _MutableNPVSumExpression([10])),
             (mutable_npv, self.param1, _MutableNPVSumExpression([11])),
             # 20:
@@ -6098,7 +5645,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
                 self.mutable_l1,
                 _MutableLinearExpression(self.mutable_l1.args),
             ),
-            (mutable_lin, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_lin, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_lin, self.param0, _MutableLinearExpression([])),
             (mutable_lin, self.param1, _MutableLinearExpression([1])),
             # 20:
@@ -6155,12 +5702,12 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 mutable_lin,
                 self.mutable_l1,
-                _MutableLinearExpression([self.bin] + self.mutable_l1.args),
+                _MutableLinearExpression([self.bin, self.l1]),
             ),
             (
                 mutable_lin,
                 self.mutable_l2,
-                _MutableSumExpression([self.bin] + self.mutable_l2.args),
+                _MutableSumExpression([self.bin] + self.l2.args),
             ),
             (mutable_lin, self.param0, _MutableLinearExpression([self.bin])),
             (mutable_lin, self.param1, _MutableLinearExpression([self.bin, 1])),
@@ -6197,7 +5744,7 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (mutable_sum, self.mutable_l0, _MutableSumExpression([])),
             # 16:
             (mutable_sum, self.mutable_l1, _MutableSumExpression(self.mutable_l1.args)),
-            (mutable_sum, self.mutable_l2, _MutableSumExpression(self.mutable_l2.args)),
+            (mutable_sum, self.mutable_l2, _MutableSumExpression(self.l2.args)),
             (mutable_sum, self.param0, _MutableSumExpression([])),
             (mutable_sum, self.param1, _MutableSumExpression([1])),
             # 20:
@@ -6254,12 +5801,12 @@ class TestExpressionGeneration_ZeroFilter(Base, unittest.TestCase):
             (
                 mutable_sum,
                 self.mutable_l1,
-                _MutableSumExpression([self.other] + self.mutable_l1.args),
+                _MutableSumExpression([self.other, self.l1]),
             ),
             (
                 mutable_sum,
                 self.mutable_l2,
-                _MutableSumExpression([self.other] + self.mutable_l2.args),
+                _MutableSumExpression([self.other] + self.l2.args),
             ),
             (mutable_sum, self.param0, _MutableSumExpression([self.other])),
             (mutable_sum, self.param1, _MutableSumExpression([self.other, 1])),


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This is a NFC PR that resolves a bug in the test driver for testing the numeric_expr dispatchers where one test could bleed into the next (specifically, when testing a mutable sum as the first argument, the conversion of that argument to immutable would bleed into the remaining tests in that test group).  Fixing this (lines 207 and 263) led to 170 test failures because the baselines were referring to the mutable expressions.  Updating the baselines to NOT refer tot he original mutable expressions resulted in identifying 4 tests whose baselines were "materially wrong" (i.e., the test was testing the wrong thing):
```
pyomo/core/tests/unit/test_numeric_expr_dispatcher.py::TestExpressionGeneration::test_sub_mutable_l0
pyomo/core/tests/unit/test_numeric_expr_dispatcher.py::TestExpressionGeneration::test_sub_mutable_l3
pyomo/core/tests/unit/test_numeric_expr_zerofilter.py::TestExpressionGeneration_ZeroFilter::test_sub_mutable_l0
pyomo/core/tests/unit/test_numeric_expr_zerofilter.py::TestExpressionGeneration_ZeroFilter::test_sub_mutable_l3
```

Note that this is only affecting test code: the expression system was - and continues to be - doing the right thing.

## Changes proposed in this PR:
- Correct expression dispatcher test driver to not allow tests to bleed into each otehr

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
