### PR TITLE
Support multi-column DataFrames in Initializer

### DIFF
--- a/pyomo/core/base/initializer.py
+++ b/pyomo/core/base/initializer.py
@@ -12,6 +12,7 @@
 import collections
 import functools
 import inspect
+import itertools
 
 from collections.abc import Sequence
 from collections.abc import Mapping
@@ -315,18 +316,19 @@ class DataFrameInitializer(InitializerBase):
         elif len(dataframe.columns) == 1:
             self._column = dataframe.columns[0]
         else:
-            raise ValueError(
-                "Cannot construct DataFrameInitializer for DataFrame with "
-                "multiple columns without also specifying the data column"
-            )
+            self._column = None
 
     def __call__(self, parent, idx):
+        if self._column is None:
+            return self._df.at[idx]
         return self._df.at[idx, self._column]
 
     def contains_indices(self):
         return True
 
     def indices(self):
+        if self._column is None:
+            return itertools.product(self._df.index, self._df)
         return self._df.index
 
 

--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -688,10 +688,26 @@ class Test_Initializer(unittest.TestCase):
 
         d = {'col1': [1, 2, 4], 'col2': [10, 20, 40]}
         df = pd.DataFrame(data=d)
-        with self.assertRaisesRegex(
-            ValueError, 'DataFrameInitializer for DataFrame with multiple columns'
-        ):
-            a = Initializer(df)
+        a = Initializer(df)
+        self.assertIs(type(a), DataFrameInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertTrue(a.contains_indices())
+        self.assertEqual(
+            list(a.indices()),
+            [
+                (0, 'col1'),
+                (0, 'col2'),
+                (1, 'col1'),
+                (1, 'col2'),
+                (2, 'col1'),
+                (2, 'col2'),
+            ],
+        )
+        self.assertEqual(a(None, (0, 'col1')), 1)
+        self.assertEqual(a(None, (1, 'col2')), 20)
+        self.assertEqual(a(None, (2, 'col2')), 40)
+
         a = DataFrameInitializer(df, 'col2')
         self.assertIs(type(a), DataFrameInitializer)
         self.assertFalse(a.constant())


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This relaxes the requirements in the `DataFrameInitializer` to accept multi-column DataFrame objects.  This allows DataFrames to be used directly to initialize 2-dimensional objects where the second dimension are the column labels.

For example, the following will work:
```python
from pyomo.environ import *
import pandas as pd

df = pd.read_csv('data.csv')

m = ConcreteModel()
m.R = Set(initialize=df.index)
m.C = Set(initialize=list(df))
m.data = Param(m.R, m.C, initialize=df)
```

## Changes proposed in this PR:
- Relax restriction on multi-column DataFrames (and add tests)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
