### PR TITLE
Add `moved_module` deprecation for `contrib.solver` modules

### DIFF
--- a/pyomo/contrib/solver/__init__.py
+++ b/pyomo/contrib/solver/__init__.py
@@ -8,3 +8,33 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+
+from pyomo.common.deprecation import moved_module
+
+for _module in ('base', 'config', 'factory', 'results', 'util', 'persistent'):
+    moved_module(
+        f'pyomo.contrib.solver.{_module}',
+        f'pyomo.contrib.solver.common.{_module}',
+        version='6.9.2.dev0',
+    )
+
+moved_module(
+    'pyomo.contrib.solver.solution',
+    'pyomo.contrib.solver.common.solution_loader',
+    version='6.9.2.dev0',
+)
+
+for _module in ('ipopt', 'gurobi_direct', 'sol_reader'):
+    moved_module(
+        f'pyomo.contrib.solver.{_module}',
+        f'pyomo.contrib.solver.solvers.{_module}',
+        version='6.9.2.dev0',
+    )
+
+moved_module(
+    'pyomo.contrib.solver.gurobi',
+    'pyomo.contrib.solver.solvers.gurobi_persistent',
+    version='6.9.2.dev0',
+)
+
+del _module, moved_module


### PR DESCRIPTION

## Fixes NA

## Summary/Motivation:
We reorganized the `pyomo.contrib.solver` directory for better clarity and broken import paths. This introduces deprecation / `moved_module` warnings for folks.

## Changes proposed in this PR:
- `moved_module` for relevant files in `pyomo.contrib.solver`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
