### PR TITLE
Add IDAES Solvers to Mac; Update to Ubuntu 22.04

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -490,10 +490,6 @@ jobs:
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
-            if test "${{matrix.TARGET}}" == osx; then
-                echo "IDAES Ipopt not available on OSX"
-                exit 0
-            fi
             URL=https://github.com/IDAES/idaes-ext
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
@@ -501,7 +497,11 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2004-x86_64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                    > $IPOPT_TAR
+            elif test "${{matrix.TARGET}}" == osx; then
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -498,19 +498,22 @@ jobs:
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    > $IPOPT_TAR
+                    -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    > $IPOPT_TAR
+                    -o $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                    -o $IPOPT_TAR
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-lib-windows-x86_64.tar.gz \
+                    -o $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        tar -xzi < $IPOPT_TAR
+        tar -xzf $IPOPT_TAR
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -484,6 +484,7 @@ jobs:
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
+        echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         NEW_PYOMO_PATH="$IPOPT_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p $IPOPT_DIR
@@ -506,14 +507,15 @@ jobs:
             else
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    -o $IPOPT_TAR
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-lib-windows-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        tar -xzf $IPOPT_TAR
+        if test "${{matrix.TARGET}}" == win; then
+            tar -xzi < $IPOPT_TAR
+        else
+            tar -xzf $IPOPT_TAR
+        fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -542,10 +542,6 @@ jobs:
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
-            if test "${{matrix.TARGET}}" == osx; then
-                echo "IDAES Ipopt not available on OSX"
-                exit 0
-            fi
             URL=https://github.com/IDAES/idaes-ext
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
@@ -553,7 +549,11 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2004-x86_64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                    > $IPOPT_TAR
+            elif test "${{matrix.TARGET}}" == osx; then
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -536,6 +536,7 @@ jobs:
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
+        echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         NEW_PYOMO_PATH="$IPOPT_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p $IPOPT_DIR
@@ -558,14 +559,15 @@ jobs:
             else
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    -o $IPOPT_TAR
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-lib-windows-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        tar -xzf $IPOPT_TAR
+        if test "${{matrix.TARGET}}" == win; then
+            tar -xzi < $IPOPT_TAR
+        else
+            tar -xzf $IPOPT_TAR
+        fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -550,19 +550,22 @@ jobs:
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    > $IPOPT_TAR
+                    -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    > $IPOPT_TAR
+                    -o $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                    -o $IPOPT_TAR
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-lib-windows-x86_64.tar.gz \
+                    -o $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        tar -xzi < $IPOPT_TAR
+        tar -xzf $IPOPT_TAR
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR


### PR DESCRIPTION

## Fixes NA

## Summary/Motivation:
We did not used to download the IDAES-ext solvers/libs for OSX because they were unavailable and/or built without HSL. I am fairly certain that is not true anymore, so this adds those solvers into our jobs.

**NOTE**: When I ran this on my branch, it passes for osx/3.12, and the coverage goes up by ~8%.

## Changes proposed in this PR:
- Add IDAES-ext solvers to OSX on GHA
- Update Linux to ubuntu-2204 (we were on 2004)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
