### PR TITLE
Address two intermittent test failures when capturing output

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -120,9 +120,11 @@ class redirect_fd(object):
 
     def __enter__(self):
         if self.std:
+            # We used to flush original_file here.  We have removed that
+            # because the std* streams are flushed by capture_output.
+            # Flushing again here caused intermittent errors due to
+            # clodes file handles on OSX
             self.original_file = getattr(sys, self.std)
-            # important: flush the current file buffer when redirecting
-            self.original_file.flush()
         # Duplicate the original standard file descriptor(file
         # descriptor 1 or 2) to a different file descriptor number
         self.original_fd = os.dup(self.fd)

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -123,7 +123,7 @@ class redirect_fd(object):
             # We used to flush original_file here.  We have removed that
             # because the std* streams are flushed by capture_output.
             # Flushing again here caused intermittent errors due to
-            # clodes file handles on OSX
+            # closed file handles on OSX
             self.original_file = getattr(sys, self.std)
         # Duplicate the original standard file descriptor(file
         # descriptor 1 or 2) to a different file descriptor number

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -591,7 +591,16 @@ class TestCapture(unittest.TestCase):
             gc.collect()
             time.sleep(((4 - remaining_attempts) / 4.0) ** 2)
             remaining_attempts -= 1
-        self.assertEqual(len(stack), 0)
+        try:
+            self.assertEqual(len(stack), 0)
+        except:
+            # We still want to unwind the context managers if the test fails:
+            while stack:
+                try:
+                    stack.pop().__exit__(None, None, None)
+                except:
+                    pass
+            raise
 
     def test_deadlock(self):
         class MockStream(object):

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -589,6 +589,7 @@ class TestCapture(unittest.TestCase):
         remaining_attempts = 4
         while len(stack) and remaining_attempts:
             gc.collect()
+            time.sleep(((4 - remaining_attempts) / 4.0) ** 2)
             remaining_attempts -= 1
         self.assertEqual(len(stack), 0)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This PR attempts to resolve two intermittent test failures:
- On OSX (usually Python 3.10), we occasionally get a solver test failing with "I/O operation on a closed file".  This PR removes the `flush()` that can trigger this error.  The streams that were being flushed are already being flushed just before reaching this code (rendering this call redundant).
- On PyPy, we see a test failure caused by what looks like an incomplete GC run.  This adds short delays between calls to the GC to hopefully resolve the problem.

## Changes proposed in this PR:
- See above

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
