### PR TITLE
Fix bug in `XpressPersistent.update_var`

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_persistent.py
+++ b/pyomo/solvers/plugins/solvers/xpress_persistent.py
@@ -110,8 +110,8 @@ class XpressPersistent(PersistentSolver, XpressDirect):
         qctype = self._xpress_chgcoltype_from_var(var)
         lb, ub = self._xpress_lb_ub_from_var(var)
 
-        self._solver_model.chgbounds([xpress_var, xpress_var], ['L', 'U'], [lb, ub])
         self._solver_model.chgcoltype([xpress_var], [qctype])
+        self._solver_model.chgbounds([xpress_var, xpress_var], ['L', 'U'], [lb, ub])
 
     def _add_column(self, var, obj_coef, constraints, coefficients):
         """Add a column to the solver's model


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3565

## Summary/Motivation:
`XpressPersistent.update_var` was not behaving as I expected (see #3565)

## Changes proposed in this PR:
- Add test demonstrating #3565 
- Switch the order of operations in `XpressPersistent.update_var` to change the variable type first, and then change the bounds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
