### PR TITLE
FBBT: resolve bug registering native type handlers

### DIFF
--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -1105,7 +1105,9 @@ def _before_external_function(visitor, child):
 def _register_new_before_child_handler(visitor, child):
     handlers = _before_child_handlers
     child_type = child.__class__
-    if child.is_variable_type():
+    if child_type in native_types:
+        handlers[child_type] = _before_constant
+    elif child.is_variable_type():
         handlers[child_type] = _before_var
     elif not child.is_potentially_variable():
         handlers[child_type] = _before_NPV


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
As part of #3558 we hit a bug where NumPy types were not getting correctly registered with the FBBT before child dispatcher.  This resolves the error and adds a test covering it.

## Changes proposed in this PR:
- Support automatic registration of native types for the FBBT before child dispatcher

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
