### PR TITLE
Update tabluate_table to include option to not sort rows

### DIFF
--- a/pyomo/common/formatting.py
+++ b/pyomo/common/formatting.py
@@ -102,7 +102,7 @@ tostr.handlers = {
 }
 
 
-def tabular_writer(ostream, prefix, data, header, row_generator):
+def tabular_writer(ostream, prefix, data, header, row_generator, sort_rows=True):
     """Output data in tabular form
 
     Parameters
@@ -121,7 +121,8 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
         returns either a tuple defining the entries for a single row, or
         a generator that returns a sequence of table rows to be output
         for the specified `key`
-
+    sort_rows: bool
+        sets if rows should be sorted using robust_sort, default (True)
     """
 
     prefix = tostr(prefix)
@@ -186,6 +187,8 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
 
     if any(' ' in r[-1] for x in _rows.values() if x is not None for r in x):
         _width[-1] = '%s'
+    if sort_rows:
+        _rows=sort_rows(_rows)
     for _key in sorted_robust(_rows):
         _rowSet = _rows[_key]
         if not _rowSet:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
tabular_writer forces sorting on the user provided Rows even when user might not desire such sorting to occur, this adds an option to disable sorting
## Summary/Motivation:
I want to be in control of my table order. 

## Changes proposed in this PR:
- adds option to disable sorting of rows. 
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
