### PR TITLE
Removing octeract from list of NEOS solvers

### DIFF
--- a/pyomo/neos/__init__.py
+++ b/pyomo/neos/__init__.py
@@ -32,7 +32,7 @@ doc = {
     'minos': 'NLP solver',
     'minto': 'MILP solver',
     'mosek': 'Interior point NLP solver',
-    'octeract': 'Deterministic global MINLP solver',
+    # 'octeract': 'Deterministic global MINLP solver',
     'ooqp': 'Convex QP solver',
     'path': 'Nonlinear MCP solver',
     'raposa': 'A Global Solver for Polynomial Programming Problems',

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -164,9 +164,10 @@ class RunAllNEOSSolvers(object):
     # (and testing) until we have time to resolve #3321
     # [20 Sep 24]: and appears to have been removed from NEOS
     # [24 Apr 25]: it appears to be there but causes timeouts
-    def test_octeract(self):
-        pass
-        # self._run('octeract')
+    # [29 Apr 25]: JK, it has been removed again
+    # def test_octeract(self):
+    #     pass
+    #     self._run('octeract')
 
     def test_ooqp(self):
         if self.sense == pyo.maximize:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:
Looks like Octeract was removed from NEOS again so removing it from our list of available NEOS solvers.

## Changes proposed in this PR:
- Remove octeract from list of available and tested NEOS solvers

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
