### PR TITLE
Relax test tolerances due to changes in Xpress 45.1.1

### DIFF
--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -66,8 +66,8 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -0.4, delta=1e-6)
         self.assertAlmostEqual(m.y.value, 0.2, delta=1e-6)
         opt.load_vars()
-        self.assertAlmostEqual(m.x.value, 0, delta=1e-6)
-        self.assertAlmostEqual(m.y.value, 1, delta=2e-6)
+        self.assertAlmostEqual(m.x.value, 0, delta=2.5e-6)
+        self.assertAlmostEqual(m.y.value, 1, delta=2.5e-6)
 
         opt.remove_constraint(m.c2)
         m.del_component(m.c2)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
A new release of Xpress is giving slightly different answers.  This PR relaxes a solver test to get things passing.

@djunglas: FYSA, I don't think this is an issue, but it is indicative of a change in Xpress' behavior.

## Changes proposed in this PR:
- Relax solution tolerance from 1e-6 to 2.5e-6 (test is returning `m.x == -2.422768352860257e-06`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
