### PR TITLE
BlockVector: improve numpy2 compatability (`__getitem__(())` is identity)

### DIFF
--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -1526,6 +1526,9 @@ class BlockVector(BaseBlockVector, np.ndarray):
         return True
 
     def __getitem__(self, item):
+        # numpy: __getitem__[()] is identity
+        if item.__class__ is tuple and not item:
+            return self
         if not self._has_equal_structure(item):
             raise ValueError(
                 'BlockVector.__getitem__ only accepts slices in the form of BlockVectors of the same structure'


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves a problem with the implementation of PyNumero's `BlockVector`: numpy has the convention that `__getitem__(tuple())` will return the original array.  This adds support for that convention in BlockVector so that NumPy2 implementations of operators like `isclose` will not fail.

## Changes proposed in this PR:
- Adopt NumPy convention that passing an empty tuple to `__getitem__` will return the original array.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
