### PR TITLE
Improve TeeStream robustness

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -455,8 +455,9 @@ class _StreamHandle(object):
         # Close both the file and the underlying file descriptor.  Note
         # that this may get called more than once.
         if self.write_file is not None:
-            self.write_file.flush()
-            self.write_file.close()
+            if not self.write_file.closed:
+                self.write_file.flush()
+                self.write_file.close()
             self.write_file = None
 
         if self.write_pipe is not None:

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -374,7 +374,8 @@ class capture_output(object):
                         stream = self._enter_context(
                             os.fdopen(
                                 self._enter_context(
-                                    _fd_closer(os.dup(fd_redirect[fd].original_fd))
+                                    _fd_closer(os.dup(fd_redirect[fd].original_fd)),
+                                    prior_to=self.tee,
                                 ),
                                 mode="w",
                                 closefd=False,

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -635,7 +635,10 @@ class TeeStream(object):
             if _poll_timeout <= _poll < 2 * _poll_timeout:
                 if in_exception:
                     # We are already processing an exception: no reason
-                    # to trigger another, nor to deadlock for an extended time
+                    # to trigger another, nor to deadlock for an
+                    # extended time.  Silently clean everything up
+                    # (because emitting logger messages could trigger
+                    # yet another exception and mask the true cause).
                     break
                 logger.warning(
                     "Significant delay observed waiting to join reader "

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -277,9 +277,11 @@ class capture_output(object):
         FAIL = []
         while self.context_stack:
             try:
-                self.context_stack.pop().__exit__(et, ev, tb)
+                cm = self.context_stack.pop()
+                cm.__exit__(et, ev, tb)
             except:
-                FAIL.append(str(sys.exc_info()[1]))
+                _stack = self.context_stack
+                FAIL.append(f"{sys.exc_info()[1]} ({len(_stack)+1}: {cm}@{id(cm):x})")
         return FAIL
 
     def __enter__(self):

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -89,6 +89,7 @@ class _fd_closer(object):
     the file descriptors that we open using this context manager.
 
     """
+
     def __init__(self, fd):
         self.fd = fd
 

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -366,10 +366,16 @@ class capture_output(object):
     def __exit__(self, et, ev, tb):
         # Check that we were nested correctly
         FAIL = []
-        if self.tee.STDOUT is not sys.stdout:
-            FAIL.append('Captured output does not match sys.stdout.')
-        if self.tee.STDERR is not sys.stderr:
-            FAIL.append('Captured output does not match sys.stderr.')
+        if self.tee._stdout is not None and self.tee.STDOUT is not sys.stdout:
+            FAIL.append(
+                'Captured output (%s) does not match sys.stdout (%s).'
+                % (self.tee._stdout, sys.stdout)
+            )
+        if self.tee._stderr is not None and self.tee.STDERR is not sys.stderr:
+            FAIL.append(
+                'Captured output (%s) does not match sys.stderr (%s).'
+                % (self.tee._stdout, sys.stdout)
+            )
         # Exit all context managers.  This includes
         #  - Restore any file descriptors we commandeered
         #  - Close / join the TeeStream

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -572,6 +572,7 @@ class TeeStream(object):
         self._handles = []
         self._active_handles = []
         self._threads = []
+        self._enter_count = 0
 
     @property
     def STDOUT(self):
@@ -659,9 +660,13 @@ class TeeStream(object):
             raise RuntimeError("TeeStream: deadlock observed joining reader threads")
 
     def __enter__(self):
+        self._enter_count += 1
         return self
 
     def __exit__(self, et, ev, tb):
+        if not self._enter_count:
+            raise RuntimeError("TeeStream: exiting a context that was not entered")
+        self._enter_count -= 1
         self.close(et is not None)
 
     def __del__(self):

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -534,11 +534,12 @@ class TestCapture(unittest.TestCase):
             b = tee.capture_output(OUT2)
             b.setup()
             with self.assertRaisesRegex(
-                RuntimeError, 'Captured output does not match sys.stdout'
+                RuntimeError, 'Captured output .* does not match sys.stdout'
             ):
                 a.reset()
-            b.tee = None
         finally:
+            # Clear b so that it doesn't call __exit__ and corrupt stdout/stderr
+            b.tee = None
             os.dup2(old_fd[0], 1)
             os.dup2(old_fd[1], 2)
             sys.stdout, sys.stderr = old

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -278,6 +278,12 @@ class TestTeeStream(unittest.TestCase):
             r"\nThe following was left in the output buffer:\n    'i\\n'\n$",
         )
 
+    def test_context_mismatch(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "TeeStream: exiting a context that was not entered"
+        ):
+            with tee.TeeStream() as t:
+                t.__exit__(None, None, None)
 
 class TestCapture(unittest.TestCase):
     def setUp(self):

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -298,6 +298,7 @@ class TestTeeStream(unittest.TestCase):
                 os.close(t.STDOUT.fileno())
         self.assertEqual(LOG.getvalue(), "")
 
+
 class TestCapture(unittest.TestCase):
     def setUp(self):
         self.streams = sys.stdout, sys.stderr

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -285,6 +285,19 @@ class TestTeeStream(unittest.TestCase):
             with tee.TeeStream() as t:
                 t.__exit__(None, None, None)
 
+    def test_handle_prematurely_closed(self):
+        # Close the TextIO object
+        with LoggingIntercept() as LOG:
+            with tee.TeeStream() as t:
+                t.STDOUT.close()
+        self.assertEqual(LOG.getvalue(), "")
+
+        # Close the underlying file descriptor
+        with LoggingIntercept() as LOG:
+            with tee.TeeStream() as t:
+                os.close(t.STDOUT.fileno())
+        self.assertEqual(LOG.getvalue(), "")
+
 class TestCapture(unittest.TestCase):
     def setUp(self):
         self.streams = sys.stdout, sys.stderr

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -618,7 +618,6 @@ class TestCapture(unittest.TestCase):
         _save = tee._poll_timeout, tee._poll_timeout_deadlock
         tee._poll_timeout = tee._poll_interval * 2**5  # 0.0032
         tee._poll_timeout_deadlock = tee._poll_interval * 2**7  # 0.0128
-
         try:
             with LoggingIntercept() as LOG, self.assertRaisesRegex(
                 RuntimeError, 'deadlock'
@@ -631,6 +630,20 @@ class TestCapture(unittest.TestCase):
                 'TeeStream: deadlock observed joining reader threads\n',
                 LOG.getvalue(),
             )
+        finally:
+            tee._poll_timeout, tee._poll_timeout_deadlock = _save
+
+        _save = tee._poll_timeout, tee._poll_timeout_deadlock
+        tee._poll_timeout = tee._poll_interval * 2**5  # 0.0032
+        tee._poll_timeout_deadlock = tee._poll_interval * 2**7  # 0.0128
+        try:
+            with LoggingIntercept() as LOG, self.assertRaisesRegex(
+                ValueError, 'testing'
+            ):
+                with tee.TeeStream(MockStream()) as t:
+                    t.STDERR.write('*')
+                    raise ValueError('testing')
+            self.assertEqual("", LOG.getvalue())
         finally:
             tee._poll_timeout, tee._poll_timeout_deadlock = _save
 

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -523,19 +523,19 @@ class TestCapture(unittest.TestCase):
         sys.stderr = os.fdopen(os.dup(2), closefd=True)
         with sys.stdout, sys.stderr:
             with T:
-                self.assertEqual(len(T.context_stack), 7)
+                self.assertEqual(len(T.context_stack), 8)
         # out & err point to fd 1 and 2
         sys.stdout = os.fdopen(1, closefd=False)
         sys.stderr = os.fdopen(2, closefd=False)
         with sys.stdout, sys.stderr:
             with T:
-                self.assertEqual(len(T.context_stack), 5)
+                self.assertEqual(len(T.context_stack), 6)
         # out & err have no fileno
         sys.stdout = StringIO()
         sys.stderr = StringIO()
         with sys.stdout, sys.stderr:
             with T:
-                self.assertEqual(len(T.context_stack), 5)
+                self.assertEqual(len(T.context_stack), 6)
 
     def test_capture_output_stack_error(self):
         OUT1 = StringIO()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3587 .

## Summary/Motivation:
Recent testing and issues (e.g., #3587) have highlighted some ongoing fragility in the `TeeStream` / `capture_output` machinery.  This PR addresses some of those errors, in particular:
- resolve the intermittent `RuntimeError: Captured output does not match sys.stdout.` exception.
- resolve a file descriptor leak on Windows (see #3587)

## Changes proposed in this PR:
- explicitly close all file descriptors we open (work around Python bug with `os.fdopen`?)
- avoid exceptions when TeeStream is closed multiple times
- improve test coverage

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
