### PR TITLE
Manually install setuptools on conda GHA jobs

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -337,6 +337,9 @@ jobs:
         conda list --show-channel-urls
         which python
         python --version
+        # As of May 2025, python 3.13/conda doesn't default have setuptools
+        # Manually install to bypass this issue
+        conda install setuptools
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -337,7 +337,7 @@ jobs:
         conda list --show-channel-urls
         which python
         python --version
-        # As of May 2025, python 3.13/conda doesn't default have setuptools
+        # As of May 2025, python 3.13/conda doesn't have setuptools by default
         # Manually install to bypass this issue
         conda install setuptools
         # Note: some pypi packages are not available through conda

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -389,7 +389,7 @@ jobs:
         conda list --show-channel-urls
         which python
         python --version
-        # As of May 2025, python 3.13/conda doesn't default have setuptools
+        # As of May 2025, python 3.13/conda doesn't have setuptools by default
         # Manually install to bypass this issue
         conda install setuptools
         # Note: some pypi packages are not available through conda

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -389,6 +389,9 @@ jobs:
         conda list --show-channel-urls
         which python
         python --version
+        # As of May 2025, python 3.13/conda doesn't default have setuptools
+        # Manually install to bypass this issue
+        conda install setuptools
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:
For some reason, `setuptools` is no longer available in the base conda environment for Python 3.13 (causing an early failure). This adds manual installation to all conda jobs because why not.

## Changes proposed in this PR:
- Add `conda install setuptools` before all other conda installations

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
