### PR TITLE
Suppress warmstart message from Xpress

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -239,6 +239,10 @@ class XpressDirect(DirectSolver):
         # version of xpress is supported (and stored as a class attribute)
         del self._version
 
+        # xpress will apply the warmstart itself instead of
+        # DirectOrPersistentSolver._presolve
+        self._apply_warmstart = False
+
     def available(self, exception_flag=True):
         """True if the solver is available."""
 
@@ -260,6 +264,13 @@ class XpressDirect(DirectSolver):
             return False
         finally:
             xpress.free()
+
+    def _presolve(self, *args, **kwds):
+        # we'll apply the warmstart in _solve_model so the
+        # message "User solution (_) stored" is wrote to the
+        # correct place, i.e., the console or the log or both
+        self._apply_warmstart = kwds.pop("warmstart", False)
+        return super(XpressDirect, self)._presolve(*args, **kwds)
 
     def _apply_solver(self):
         StaleFlagManager.mark_all_as_stale()
@@ -623,6 +634,9 @@ class XpressDirect(DirectSolver):
         return have_soln
 
     def _solve_model(self):
+        if self._apply_warmstart:
+            self._warm_start()
+
         xprob = self._solver_model
 
         is_mip = (xprob.attributes.mipents > 0) or (xprob.attributes.sets > 0)

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -270,7 +270,7 @@ class XpressDirect(DirectSolver):
         # message "User solution (_) stored" is wrote to the
         # correct place, i.e., the console or the log or both
         self._apply_warmstart = kwds.pop("warmstart", False)
-        return super(XpressDirect, self)._presolve(*args, **kwds)
+        return super()._presolve(*args, **kwds)
 
     def _apply_solver(self):
         StaleFlagManager.mark_all_as_stale()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # N/A

## Summary/Motivation:
On `main`, when using `warmstart = True` with Xpress, you will always see the below message printed to the screen:
```
User solution (_) stored.
```
which is emitted by the `addmipsol` method of `xpress.problem`. This can be troublesome because (1) the message is printed to the screen unconditionally and (2) does not end up in a specified `logfile`.

## Changes proposed in this PR:
- Delay calling `XpressDirect._warm_start` until the model is about to be solved, when the `logfile` and / or `tee` attributes have been properly configured.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
