### PR TITLE
Resolve intermittent `capture_output` deadlock 

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -24,6 +24,7 @@ import sys
 import threading
 import time
 
+from pyomo.common.errors import DeveloperError
 from pyomo.common.log import LoggingIntercept, LogStream
 
 _poll_interval = 0.0001

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -244,8 +244,6 @@ class capture_output(object):
     startup_shutdown = threading.Lock()
 
     def __init__(self, output=None, capture_fd=False):
-        if output is None:
-            output = io.StringIO()
         self.output = output
         self.old = None
         self.tee = None
@@ -360,6 +358,8 @@ class capture_output(object):
 
             if isinstance(self.output, str):
                 self.output_stream = self._enter_context(open(self.output, 'w'))
+            elif self.output is None:
+                self.output_stream = io.StringIO()
             else:
                 self.output_stream = self.output
             if isinstance(self.output, TeeStream):

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -754,7 +754,8 @@ class TeeStream(object):
         if not self._enter_count:
             raise RuntimeError("TeeStream: exiting a context that was not entered")
         self._enter_count -= 1
-        self.close(et is not None)
+        if not self._enter_count:
+            self.close(et is not None)
 
     def __del__(self):
         # Implement __del__ to guarantee that file descriptors are closed

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -319,10 +319,13 @@ class capture_output(object):
         self.old = (sys.stdout, sys.stderr)
         old_fd = []
         for stream in self.old:
-            stream.flush()
             try:
-                old_fd.append(stream.fileno())
-            except (AttributeError, OSError):
+                stream.flush()
+                try:
+                    old_fd.append(stream.fileno())
+                except (AttributeError, OSError):
+                    old_fd.append(None)
+            except (ValueError, OSError):
                 old_fd.append(None)
         try:
             # We have an issue where we are (very aggressively)

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -336,6 +336,17 @@ class TestCapture(unittest.TestCase):
         finally:
             capture.reset()
 
+    def test_reset_capture_output_twice(self):
+        capture = tee.capture_output()
+        with capture as OUT1:
+            print("test1")
+        capture.reset()
+        capture.reset()
+        with capture as OUT2:
+            print("test2")
+        self.assertEqual(OUT1.getvalue(), "test1\n")
+        self.assertEqual(OUT2.getvalue(), "test2\n")
+
     def test_capture_output_logfile_string(self):
         with TempfileManager.new_context() as tempfile:
             logfile = tempfile.create_tempfile()

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -537,6 +537,14 @@ class TestCapture(unittest.TestCase):
             with T:
                 self.assertEqual(len(T.context_stack), 6)
 
+    def test_closed_stdout(self):
+        with tee.capture_output() as T_outer:
+            sys.stdout.close()
+            with tee.capture_output() as T_inner:
+                print("test")
+        self.assertEqual(T_outer.getvalue(), "")
+        self.assertEqual(T_inner.getvalue(), "test\n")
+
     def test_capture_output_stack_error(self):
         OUT1 = StringIO()
         OUT2 = StringIO()

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -180,15 +180,20 @@ class GurobiSolverMixin:
     _gurobipy_available = gurobipy_available
 
     def available(self):
-        if self._available is not None:
-            return self._available
-        # this triggers the deferred import, and for the persistent
-        # interface, may update the _available flag
-        if not self._gurobipy_available:
-            if self._available is None:
-                self.__class__._available = Availability.NotFound
-        else:
-            self.__class__._available = self._check_license()
+        if self._available is None:
+            # this triggers the deferred import, and for the persistent
+            # interface, may update the _available flag
+            #
+            # Note that we set the _available flag on the *mode derived
+            # class* and not on the instance, or on the base class.  That
+            # allows different derived interfaces to have different
+            # availability (e.g., persistent has a minimum version
+            # requirement that the direct interface doesn't)
+            if not self._gurobipy_available:
+                if self._available is None:
+                    self.__class__._available = Availability.NotFound
+            else:
+                self.__class__._available = self._check_license()
         return self._available
 
     @staticmethod

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -92,7 +92,7 @@ class GurobiDirectSolutionLoader(SolutionLoaderBase):
         self._pyo_cons = pyo_cons
         self._pyo_vars = pyo_vars
         self._pyo_obj = pyo_obj
-        GurobiDirect._num_instances += 1
+        GurobiDirect._register_env_client()
 
     def __del__(self):
         if python_is_shutting_down():
@@ -110,9 +110,7 @@ class GurobiDirectSolutionLoader(SolutionLoaderBase):
         # Release the gurobi license if this is the last reference to
         # the environment (either through a results object or solver
         # interface)
-        GurobiDirect._num_instances -= 1
-        if GurobiDirect._num_instances == 0:
-            GurobiDirect.release_license()
+        GurobiDirect._release_env_client()
 
     def load_vars(self, vars_to_load=None, solution_number=0):
         assert solution_number == 0
@@ -176,6 +174,10 @@ class GurobiSolverMixin:
     duplicate code.
     """
 
+    _num_gurobipy_env_clients = 0
+    _gurobipy_env = None
+    _gurobipy_available = gurobipy_available
+
     def available(self):
         if not gurobipy_available:  # this triggers the deferred import
             return Availability.NotFound
@@ -183,13 +185,42 @@ class GurobiSolverMixin:
             return Availability.BadVersion
         return self._check_license()
 
+    @staticmethod
+    def release_license():
+        if GurobiSolverMixin._gurobipy_env is None:
+            return
+        if GurobiSolverMixin._num_gurobipy_env_clients:
+            logger.warning(
+                "Call to GurobiSolverMixin.release_license() with %s remaining "
+                "environment clients." % (GurobiSolverMixin._num_gurobipy_env_clients,)
+            )
+        GurobiSolverMixin._gurobipy_env.close()
+        GurobiSolverMixin._gurobipy_env = None
+
+    @staticmethod
+    def env():
+        if GurobiSolverMixin._gurobipy_env is None:
+            with capture_output(capture_fd=True):
+                GurobiSolverMixin._gurobipy_env = gurobipy.Env()
+        return GurobiSolverMixin._gurobipy_env
+
+    @staticmethod
+    def _register_env_client():
+        GurobiSolverMixin._num_gurobipy_env_clients += 1
+
+    @staticmethod
+    def _release_env_client():
+        GurobiSolverMixin._num_gurobipy_env_clients -= 1
+        if GurobiSolverMixin._num_gurobipy_env_clients <= 0:
+            # Note that _num_gurobipy_env_clients should never be <0,
+            # but if it is, release_license will issue a warning (that
+            # we want to know about)
+            GurobiSolverMixin.release_license()
+
     def _check_license(self):
         avail = False
         try:
-            # Gurobipy writes out license file information when creating
-            # the environment
-            with capture_output(capture_fd=True):
-                m = gurobipy.Model()
+            m = gurobipy.Model(env=self.env())
             avail = True
         except gurobipy.GurobiError:
             avail = False
@@ -228,25 +259,15 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
 
     CONFIG = GurobiConfig()
 
-    _available = None
-    _num_instances = 0
     _tc_map = None
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
-        GurobiDirect._num_instances += 1
-
-    @staticmethod
-    def release_license():
-        if gurobipy_available:
-            with capture_output(capture_fd=True):
-                gurobipy.disposeDefaultEnv()
+        self._register_env_client()
 
     def __del__(self):
         if not python_is_shutting_down():
-            GurobiDirect._num_instances -= 1
-            if GurobiDirect._num_instances == 0:
-                self.release_license()
+            self._release_env_client()
 
     def solve(self, model, **kwds) -> Results:
         start_timestamp = datetime.datetime.now(datetime.timezone.utc)
@@ -304,7 +325,7 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
             if config.working_dir:
                 os.chdir(config.working_dir)
             with capture_output(TeeStream(*ostreams), capture_fd=False):
-                gurobi_model = gurobipy.Model()
+                gurobi_model = gurobipy.Model(env=self.env())
 
                 timer.start('transfer_model')
                 x = gurobi_model.addMVar(

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -184,7 +184,7 @@ class GurobiSolverMixin:
             # this triggers the deferred import, and for the persistent
             # interface, may update the _available flag
             #
-            # Note that we set the _available flag on the *mode derived
+            # Note that we set the _available flag on the *most derived
             # class* and not on the instance, or on the base class.  That
             # allows different derived interfaces to have different
             # availability (e.g., persistent has a minimum version

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -433,10 +433,7 @@ class GurobiPersistent(
         else:
             self._labeler = NumericLabeler('x')
 
-        if model.name is not None:
-            self._solver_model = gurobipy.Model(model.name, env=self.env())
-        else:
-            self._solver_model = gurobipy.Model(env=self.env())
+        self._solver_model = gurobipy.Model(name=model.name or '', env=self.env())
 
         self.add_block(model)
         if self._objective is None:

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -244,9 +244,7 @@ class GurobiPersistent(
     """
 
     CONFIG = GurobiConfig()
-
-    _available = None
-    _num_instances = 0
+    _gurobipy_available = gurobipy_available
 
     def __init__(self, **kwds):
         treat_fixed_vars_as_params = kwds.pop('treat_fixed_vars_as_params', True)
@@ -254,7 +252,7 @@ class GurobiPersistent(
         PersistentSolverUtils.__init__(
             self, treat_fixed_vars_as_params=treat_fixed_vars_as_params
         )
-        GurobiPersistent._num_instances += 1
+        self._register_env_client()
         self._solver_model = None
         self._symbol_map = SymbolMap()
         self._labeler = None
@@ -276,15 +274,11 @@ class GurobiPersistent(
 
     def release_license(self):
         self._reinit()
-        if gurobipy_available:
-            with capture_output(capture_fd=True):
-                gurobipy.disposeDefaultEnv()
+        self.__class__.release_license()
 
     def __del__(self):
         if not python_is_shutting_down():
-            GurobiPersistent._num_instances -= 1
-            if GurobiPersistent._num_instances == 0:
-                self.release_license()
+            self._release_env_client()
 
     @property
     def symbol_map(self):
@@ -416,6 +410,9 @@ class GurobiPersistent(
         saved_config = self.config
         saved_tmp_config = self._active_config
         self.__init__(treat_fixed_vars_as_params=self._treat_fixed_vars_as_params)
+        # Note that __init__ registers a new env client, so we need to
+        # release it here:
+        self._release_env_client()
         self.config = saved_config
         self._active_config = saved_tmp_config
 
@@ -437,9 +434,9 @@ class GurobiPersistent(
             self._labeler = NumericLabeler('x')
 
         if model.name is not None:
-            self._solver_model = gurobipy.Model(model.name)
+            self._solver_model = gurobipy.Model(model.name, env=self.env())
         else:
-            self._solver_model = gurobipy.Model()
+            self._solver_model = gurobipy.Model(env=self.env())
 
         self.add_block(model)
         if self._objective is None:

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -68,7 +68,7 @@ def _import_gurobipy():
         raise
     if gurobipy.GRB.VERSION_MAJOR < 7:
         GurobiPersistent._available = Availability.BadVersion
-        raise ImportError('The APPSI Gurobi interface requires gurobipy>=7.0.0')
+        raise ImportError('The Persistent Gurobi interface requires gurobipy>=7.0.0')
     return gurobipy
 
 

--- a/pyomo/contrib/solver/solvers/highs.py
+++ b/pyomo/contrib/solver/solvers/highs.py
@@ -288,7 +288,7 @@ class Highs(PersistentSolverMixin, PersistentSolverUtils, PersistentSolverBase):
                 f'({self.available()}).'
             )
 
-        with TeeStream(*ostreams) as t, capture_output(t.STDOUT, capture_fd=True):
+        with capture_output(TeeStream(*ostreams), capture_fd=True):
             self._reinit()
             self._model = model
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
We are continuing to see intermittent deadlocks or attempts to write to closed file descriptors in the HiGHS tests on main.  I think I have (finally) tracked down the root cause to the use of `capture_input()` in the *Gurobi* interface `__del__` method.  It looks like the GC will (randomly) interrupt a HiGHS test to run the collector (which, if it is collecting a Gurobi interface will call `capture_output`.  If this happens during another test's use of `capture_output.__enter__` or `.__exit__`, then the Gurobi interface's use of capture could happen when the underlying output streams are in a transitory state (and could be closed).

This PR resolves that by:
- rework the Gurobi interface to use it's own private Env (which suppresses the output to stdout and removes the need to use `capture_output` in `__del__`.
- Add thread locks so that one call to `capture_output` will not interrupts another fall to `__enter__ / `__exit__`
- improve some implementations within TeeStream / capture_output
- add additional tests that catch some edge cases identified during development

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
