### PR TITLE
Newer version of GiNaC - URL failure resolution

### DIFF
--- a/pyomo/contrib/simplification/build.py
+++ b/pyomo/contrib/simplification/build.py
@@ -63,7 +63,7 @@ def build_ginac_library(parallel=None, argv=None, env=None):
         assert subprocess.run(make_cmd, cwd=cln_dir, env=env).returncode == 0
         assert subprocess.run(install_cmd, cwd=cln_dir, env=env).returncode == 0
 
-        url = 'https://www.ginac.de/ginac-1.8.8.tar.bz2'
+        url = 'https://www.ginac.de/ginac-1.8.9.tar.bz2'
         ginac_dir = os.path.join(tmpdir, 'ginac')
         downloader.set_destination_filename(ginac_dir)
         logger.info(


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:
Our weekly URL checker failed because of a GiNaC version update. This updates the URL in `contrib/simplification` to point to the right URL.

## Changes proposed in this PR:
- Update to GiNaC 1.8.9

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
