### PR TITLE
Added 'gams' as an additional field in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -262,6 +262,7 @@ setup_kwargs = dict(
             'numpy',  # Needed by autodoc for pynumero
             'scipy',  # Needed by autodoc for pynumero
         ],
+        'gams':['gamsapi'],
         'optional': [
             'dill',  # No direct use, but improves lambda pickle
             'ipython',  # contrib.viewer


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary / Motivation

Adding gams as an additional extra_require installation field to utilize `gamsapi`.

### Rationale
The current `GAMS.py` (under pyomo/solvers/plugins/solvers) uses 

```attempt_import('gdxcc')```

Current users need to install gamsapi separately after installing Pyomo. We propose that future users be able to use `pip install pyomo[gams]` to resolve dependencies for a better user experience.

## Changes proposed in this PR:
- Added 'gams' in setup.py

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
