### PR TITLE
Minor numpy2 compatibility / testing cleanup

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -1197,7 +1197,17 @@ class IndexedComponent_NDArrayMixin(object):
 
     """
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
+        if dtype not in (None, object):
+            raise ValueError(
+                "Pyomo IndexedComponents can only be converted to NumPy "
+                f"arrays with dtype=object (received {dtype=})"
+            )
+        if copy is not None and not copy:
+            raise ValueError(
+                "Pyomo IndexedComponents do not support conversion to NumPy "
+                "arrays without generating a new array"
+            )
         if not self.is_indexed():
             ans = _ndarray.NumericNDArray(shape=(1,), dtype=object)
             ans[0] = self

--- a/pyomo/core/tests/examples/test_kernel_examples.py
+++ b/pyomo/core/tests/examples/test_kernel_examples.py
@@ -14,26 +14,21 @@
 #
 
 import glob
-import sys
-from os.path import basename, dirname, abspath, join
-
+import os
+import platform
 import subprocess
+import sys
+
 import pyomo.common.unittest as unittest
+import pyomo.environ
 
 from pyomo.common.dependencies import numpy_available, scipy_available
-
-import platform
+from pyomo.common.fileutils import PYOMO_ROOT_DIR
+from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
 if platform.python_implementation() == "PyPy":
     # The scipy is importable into PyPy, but ODE integrators don't work. (2/ 18)
     scipy_available = False
-
-currdir = dirname(abspath(__file__))
-topdir = dirname(dirname(dirname(dirname(dirname(abspath(__file__))))))
-examplesdir = join(topdir, "examples", "kernel")
-
-examples = glob.glob(join(examplesdir, "*.py"))
-examples.extend(glob.glob(join(examplesdir, "mosek", "*.py")))
 
 testing_solvers = {}
 testing_solvers['ipopt', 'nl'] = False
@@ -42,10 +37,6 @@ testing_solvers['mosek_direct', 'python'] = False
 
 
 def setUpModule():
-    global testing_solvers
-    import pyomo.environ
-    from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
-
     for _solver, _io in _test_solver_cases():
         if (_solver, _io) in testing_solvers and _test_solver_cases(
             _solver, _io
@@ -60,19 +51,6 @@ def create_method(example):
     # this is the case since we are returning the function object
     # and placing it on the class with a different name.
     def testmethod(self):
-        if basename(example) == "piecewise_nd_functions.py":
-            if (
-                (not numpy_available)
-                or (not scipy_available)
-                or (not testing_solvers['ipopt', 'nl'])
-                or (not testing_solvers['glpk', 'lp'])
-            ):
-                self.skipTest("Numpy or Scipy or Ipopt or Glpk is not available")
-        elif "mosek" in example:
-            if (not testing_solvers['ipopt', 'nl']) or (
-                not testing_solvers['mosek_direct', 'python']
-            ):
-                self.skipTest("Ipopt or Mosek is not available")
         result = subprocess.run(
             [sys.executable, example],
             stdout=subprocess.PIPE,
@@ -81,15 +59,35 @@ def create_method(example):
         )
         self.assertEqual(result.returncode, 0, msg=result.stdout)
 
-    return testmethod
+    tm = testmethod
+    if os.path.basename(example) == "piecewise_nd_functions.py":
+        tm = unittest.skipUnless(numpy_available, "Test requires numpy")(tm)
+        tm = unittest.skipUnless(scipy_available, "Test requires scipy")(tm)
+        tm = unittest.skipUnless(testing_solvers['ipopt', 'nl'], "Test requires ipopt")(
+            tm
+        )
+        tm = unittest.skipUnless(testing_solvers['glpk', 'lp'], "Test requires glpk")(
+            tm
+        )
+    elif "mosek" in example:
+        tm = unittest.skipUnless(testing_solvers['ipopt', 'nl'], "Test requires ipopt")(
+            tm
+        )
+        tm = unittest.skipUnless(
+            testing_solvers['mosek_direct', 'python'], "Test requires mosek"
+        )(tm)
+    return tm
 
 
 class TestKernelExamples(unittest.TestCase):
     pass
 
 
+examplesdir = os.path.join(PYOMO_ROOT_DIR, "examples", "kernel")
+examples = glob.glob(os.path.join(examplesdir, "*.py"))
+examples.extend(glob.glob(os.path.join(examplesdir, "mosek", "*.py")))
 for filename in examples:
-    testname = basename(filename)
+    testname = os.path.basename(filename)
     assert testname.endswith(".py")
     testname = "test_" + testname[:-3] + "_example"
     setattr(TestKernelExamples, testname, create_method(filename))

--- a/pyomo/core/tests/unit/test_numpy_expr.py
+++ b/pyomo/core/tests/unit/test_numpy_expr.py
@@ -262,8 +262,11 @@ class TestNumPy(unittest.TestCase):
             )
         )
 
-    @unittest.skipUnless(int(np.__version__.split('.')[0]) >= 2, "requires numpy>=2")
     def test_numpy_array_copy_errors(self):
+        # Defer testing until here to avoid the unconditional numpy dereference
+        if int(np.__version__.split('.')[0]) < 2:
+            self.SkipTest("requires numpy>=2")
+
         m = ConcreteModel()
         m.x = Var([0, 1, 2])
         with self.assertRaisesRegex(

--- a/pyomo/core/tests/unit/test_numpy_expr.py
+++ b/pyomo/core/tests/unit/test_numpy_expr.py
@@ -265,7 +265,7 @@ class TestNumPy(unittest.TestCase):
     def test_numpy_array_copy_errors(self):
         # Defer testing until here to avoid the unconditional numpy dereference
         if int(np.__version__.split('.')[0]) < 2:
-            self.SkipTest("requires numpy>=2")
+            self.skipTest("requires numpy>=2")
 
         m = ConcreteModel()
         m.x = Var([0, 1, 2])

--- a/pyomo/core/tests/unit/test_numpy_expr.py
+++ b/pyomo/core/tests/unit/test_numpy_expr.py
@@ -262,6 +262,34 @@ class TestNumPy(unittest.TestCase):
             )
         )
 
+    @unittest.skipUnless(int(np.__version__.split('.')[0]) >= 2, "requires numpy>=2")
+    def test_numpy_array_copy_errors(self):
+        m = ConcreteModel()
+        m.x = Var([0, 1, 2])
+        with self.assertRaisesRegex(
+            ValueError,
+            "Pyomo IndexedComponents do not support conversion to NumPy "
+            "arrays without generating a new array",
+        ):
+            np.asarray(m.x, copy=False)
+
+    def test_numpy_array_dtype_errors(self):
+        m = ConcreteModel()
+        m.x = Var([0, 1, 2])
+        # object is OK
+        a = np.asarray(m.x, object)
+        self.assertEqual(a.shape, (3,))
+        # None is OK
+        a = np.asarray(m.x, None)
+        self.assertEqual(a.shape, (3,))
+        # Anything else is an error
+        with self.assertRaisesRegex(
+            ValueError,
+            "Pyomo IndexedComponents can only be converted to NumPy arrays "
+            r"with dtype=object \(received dtype=.*int32",
+        ):
+            a = np.asarray(m.x, np.int32)
+
     def test_init_param_from_ndarray(self):
         # Test issue #2033
         m = ConcreteModel()

--- a/pyomo/repn/ampl.py
+++ b/pyomo/repn/ampl.py
@@ -1137,6 +1137,16 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
                 # attempt to convert the value to a float before
                 # proceeding.
                 #
+                # Note that as of NumPy 1.25, blindly casting a
+                # 1-element ndarray to a float will generate a
+                # deprecation warning.  We will explicitly test for
+                # that, but want to do the test without triggering the
+                # numpy import
+                for cls in ans.__class__.__mro__:
+                    if cls.__name__ == 'ndarray' and cls.__module__ == 'numpy':
+                        if len(ans) == 1:
+                            ans = ans[0]
+                        break
                 # TODO: we should check bool and warn/error (while bool is
                 # convertible to float in Python, they have very
                 # different semantic meanings in Pyomo).

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -274,13 +274,6 @@ def test_solver_cases(*args):
             io_options={"skip_objective_sense": True},
         )
 
-        _test_solver_cases['glpk', 'python'] = initialize(
-            name='glpk',
-            io='python',
-            capabilities=_glpk_capabilities,
-            import_suffixes=[],
-        )
-
         #
         # CBC
         #


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This PR resolves a number of minor problems:
- This cleans up the driver for testing the Kernel examples (move it to use some of the utilities from `pyomo.common` and streamline the definition of the test cases).
- This removes GLPK direct from the test driver (the interface was removed from Pyomo a long time ago)
- This resolves warnings generated by NumPy within the AMPL repn compiler
- This makes the IndexedComponent `__array__` interface compatible with the NumPy2 API

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
