### PR TITLE
Fixing SSE objective function for all theta_est methods.

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -920,7 +920,7 @@ class Estimator(object):
             calc_cov=calc_cov,
             cov_n=cov_n,
         )
-
+    # Need to fix to allow use of obj_function = 'SSE'
     def theta_est_bootstrap(
         self,
         bootstrap_samples,
@@ -994,7 +994,7 @@ class Estimator(object):
             del bootstrap_theta['samples']
 
         return bootstrap_theta
-
+    # Need to fix to allow use of obj_function = 'SSE'
     def theta_est_leaveNout(
         self, lNo, lNo_samples=None, seed=None, return_samples=False
     ):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
I am fixing the functions (theta_est_bootstrap and theta_est_leaveNout) 'obj_function = "SSE"' to also accept this input as the objective function, instead of manually needing to define one within the model.

## Summary/Motivation:
Currently, the 'obj_function = "SSE"' input into the experiment class can only be used for the default theta_est.

## Changes proposed in this PR:
- Modify theta_est_bootstrap and theta_est_leaveNout to accept the obj_function='SSE' input to the experiment class function.
- Create an example to display this
- Add testing

## TODO before converting from draft:
- [ ] Write out fix with pseudocode, receive feedback
- [ ] Convert finalized pseudocode
- [ ] Test and debug
- [ ] Confirm function with examples

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
