### PR TITLE
Remove debugging accidentally committed to appsi_highs

### DIFF
--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -272,7 +272,6 @@ class Highs(PersistentBase, PersistentSolver):
             if config.warmstart:
                 self._warm_start()
             timer.start('optimize')
-            ostreams[-1].write("RUN!\n")
             if self.version()[:2] >= (1, 8):
                 self._solver_model.HandleKeyboardInterrupt = True
             self._solver_model.run()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This PR removes a debugging statement accidentally committed to the `appsi_highs` interface and merged into `Pyomo/main`

## Changes proposed in this PR:
- Remove debugging

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
