### PR TITLE
Add an option to skip checking the bounds of fixed variables

### DIFF
--- a/pyomo/repn/ampl.py
+++ b/pyomo/repn/ampl.py
@@ -1168,7 +1168,9 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         val = self.check_constant(child.value, child)
         if self.check_fixed_variable_bounds:
             lb, ub = child.bounds
-            if (lb is not None and lb - val > TOL) or (ub is not None and ub - val < -TOL):
+            if (lb is not None and lb - val > TOL) or (
+                ub is not None and ub - val < -TOL
+            ):
                 raise InfeasibleConstraintException(
                     "model contains a trivially infeasible "
                     f"variable '{child.name}' (fixed value "

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -281,6 +281,18 @@ class NLWriter(object):
         variable elimination (without fill-in).""",
         ),
     )
+    CONFIG.declare(
+        'check_fixed_variable_bounds',
+        ConfigValue(
+            default=True,
+            domain=bool,
+            description='Check the bounds on fixed variables',
+            doc="""
+            If True, the writer will ensure that the values of fixed 
+            variables are within the variable bounds.
+            """,
+        ),
+    )
 
     def __init__(self):
         self.config = self.CONFIG()
@@ -521,6 +533,7 @@ class _NLWriter_impl(object):
             self.symbolic_solver_labels,
             self.config.export_defined_variables,
             self.sorter,
+            check_fixed_variable_bounds=config.check_fixed_variable_bounds,
         )
         self.next_V_line_id = 0
         self.pause_gc = None

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -2839,9 +2839,4 @@ k0
 G0 1
 0 0
 """
-        self.assertEqual(
-            *nl_diff(
-                expected,
-                out.getvalue(),
-            ),
-        )
+        self.assertEqual(*nl_diff(expected, out.getvalue()))

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -24,7 +24,7 @@ from pyomo.repn.util import InvalidNumber
 from pyomo.repn.tests.nl_diff import nl_diff
 
 from pyomo.common.dependencies import numpy, numpy_available
-from pyomo.common.errors import MouseTrap
+from pyomo.common.errors import MouseTrap, InfeasibleConstraintException
 from pyomo.common.gsl import find_GSL
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tee import capture_output
@@ -2796,4 +2796,52 @@ k-1
 """,
                 OUT.getvalue(),
             )
+        )
+
+    def test_fixed_variable_out_of_bounds(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.obj = Objective(expr=m.x**2 + m.y**2)
+        m.x.fix(4)
+        m.x.setlb(-2)
+        m.x.setub(2)
+
+        out = io.StringIO()
+        with self.assertRaises(InfeasibleConstraintException):
+            nl_writer.NLWriter().write(m, out, linear_presolve=False, scale_model=False)
+
+        out = io.StringIO()
+        writer = nl_writer.NLWriter()
+        writer.config.check_fixed_variable_bounds = False
+        writer.write(m, out, linear_presolve=False, scale_model=False)
+        expected = """g3 1 1 0	# problem unknown
+ 1 0 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+O0 0
+o0
+o5
+v0
+n2
+n16
+x0
+r
+b
+3
+k0
+G0 1
+0 0
+"""
+        self.assertEqual(
+            *nl_diff(
+                expected,
+                out.getvalue(),
+            ),
         )


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:
Currently, the NL writer raises an exception if a variable is fixed to a value outside of its bounds. This PR adds an option to skip that check and error.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
