### PR TITLE
Hotfix: Don't require __version__ for performance driver

### DIFF
--- a/scripts/performance/main.py
+++ b/scripts/performance/main.py
@@ -130,7 +130,7 @@ def getProjectInfo(project):
         diffs = os.popen('git diff-index --name-only HEAD').read()
         diffs = diffs.strip().split()
         branch = os.popen('git symbolic-ref -q --short HEAD').read().strip()
-        version = _module.__version__
+        version = getattr(_module, "__version__", "unknown")
     finally:
         os.chdir(cwd)
     return {'branch': branch, 'sha': sha, 'diffs': diffs, 'version': version}


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
In working with @dallan-keylogic on some performance testing for IDAES examples, we found that the performance driver from Pyomo requires that the `__version__` attribute is set, which it is not always. This now makes it optional.

## Changes proposed in this PR:
- No longer make `__version__` a required attribute

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
