### PR TITLE
Add sgnsqr external function f(X) = sgn(x)*x^2

### DIFF
--- a/pyomo/contrib/ampl_function_demo/build.py
+++ b/pyomo/contrib/ampl_function_demo/build.py
@@ -15,10 +15,10 @@ from pyomo.common.cmake_builder import build_cmake_project
 
 def build_ampl_function_demo(user_args=[], parallel=None):
     return build_cmake_project(
-        targets=['src'],
-        package_name='asl_external_demo',
-        description='AMPL External function demo library',
-        user_args=['-DBUILD_AMPLASL_IF_NEEDED=ON'] + user_args,
+        targets=["src"],
+        package_name="asl_external_demo",
+        description="AMPL External function demo library",
+        user_args=["-DBUILD_AMPLASL_IF_NEEDED=ON"] + user_args,
         parallel=parallel,
     )
 

--- a/pyomo/contrib/ampl_function_demo/plugins.py
+++ b/pyomo/contrib/ampl_function_demo/plugins.py
@@ -14,4 +14,4 @@ from pyomo.contrib.ampl_function_demo.build import AMPLFunctionDemoBuilder
 
 
 def load():
-    ExtensionBuilderFactory.register('ampl_function_demo')(AMPLFunctionDemoBuilder)
+    ExtensionBuilderFactory.register("ampl_function_demo")(AMPLFunctionDemoBuilder)

--- a/pyomo/contrib/ampl_function_demo/src/functions.c
+++ b/pyomo/contrib/ampl_function_demo/src/functions.c
@@ -168,7 +168,7 @@ extern real sgnsqr(arglist *al){
 
    // Compute the first derivative, if requested.
    if (al->derivs!=NULL) {
-      al->derivs[0] = copysign(2 * x, x);
+      al->derivs[0] = copysign(1, x) * 2 * x;
    }
 
    // Compute the second derivative, if requested.

--- a/pyomo/contrib/ampl_function_demo/src/functions.c
+++ b/pyomo/contrib/ampl_function_demo/src/functions.c
@@ -159,6 +159,27 @@ extern real scbrt(arglist *al){
 }
 
 
+/* A function where f(x) = sgn(x)x^2  
+ */
+extern real sgnsqr(arglist *al){
+   real x = al->ra[al->at[0]];
+
+   real y = copysign(x * x, x);
+
+   // Compute the first derivative, if requested.
+   if (al->derivs!=NULL) {
+      al->derivs[0] = copysign(2 * x, x);
+   }
+
+   // Compute the second derivative, if requested.
+   if (al->hes!=NULL) {
+      al->hes[0] = copysign(2, x);
+   }
+
+   return y;
+}
+
+
 // Register external functions defined in this library with the ASL
 void funcadd(AmplExports *ae){
     /* Arguments for addfunc (this is not fully detailed; see funcadd.h)
@@ -172,6 +193,8 @@ void funcadd(AmplExports *ae){
      * 5) Void pointer to function info
      */
     addfunc("safe_cbrt", (rfunc)scbrt,
+            FUNCADD_REAL_VALUED, 1, NULL);
+    addfunc("sgnsqr", (rfunc)sgnsqr,
             FUNCADD_REAL_VALUED, 1, NULL);
     addfunc("demo_function", (rfunc)demo_function,
             FUNCADD_REAL_VALUED|FUNCADD_STRING_ARGS, -2, NULL);

--- a/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
+++ b/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
@@ -68,3 +68,18 @@ class TestAMPLExternalFunction(unittest.TestCase):
         solver = pyo.SolverFactory("ipopt")
         solver.solve(m, tee=True)
         self.assertAlmostEqual(m.x(), 6, 4)
+
+    @unittest.skipIf(is_pypy, 'Cannot evaluate external functions under pypy')
+    def test_eval_sqnsqr_function_fgh(self):
+        m = pyo.ConcreteModel()
+        m.tf = pyo.ExternalFunction(library=flib, function="sgnsqr")
+
+        f, g, h = m.tf.evaluate_fgh((2,))
+        self.assertEqual(f, 4)
+        self.assertEqual(g, [4])
+        self.assertEqual(h, [2])
+
+        f, g, h = m.tf.evaluate_fgh((-2,))
+        self.assertAlmostEqual(f, -4)
+        self.assertStructuredAlmostEqual(g, [-4])
+        self.assertStructuredAlmostEqual(h, [-2])

--- a/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
+++ b/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
@@ -17,12 +17,12 @@ from pyomo.opt import check_available_solvers
 from pyomo.core.base.external import nan
 
 flib = find_library("asl_external_demo")
-is_pypy = platform.python_implementation().lower().startswith('pypy')
+is_pypy = platform.python_implementation().lower().startswith("pypy")
 
 
 @unittest.skipUnless(flib, 'Could not find the "asl_external_demo.so" library')
 class TestAMPLExternalFunction(unittest.TestCase):
-    @unittest.skipIf(is_pypy, 'Cannot evaluate external functions under pypy')
+    @unittest.skipIf(is_pypy, "Cannot evaluate external functions under pypy")
     def test_eval_function(self):
         m = pyo.ConcreteModel()
         m.tf = pyo.ExternalFunction(library=flib, function="demo_function")
@@ -34,7 +34,7 @@ class TestAMPLExternalFunction(unittest.TestCase):
             m.cbrt.evaluate_fgh([0]), (0, [100951], [-1.121679e13]), reltol=1e-5
         )
 
-    @unittest.skipIf(is_pypy, 'Cannot evaluate external functions under pypy')
+    @unittest.skipIf(is_pypy, "Cannot evaluate external functions under pypy")
     def test_eval_function_fgh(self):
         m = pyo.ConcreteModel()
         m.tf = pyo.ExternalFunction(library=flib, function="demo_function")
@@ -52,7 +52,7 @@ class TestAMPLExternalFunction(unittest.TestCase):
         )
 
     @unittest.skipUnless(
-        check_available_solvers('ipopt'), "The 'ipopt' solver is not available"
+        check_available_solvers("ipopt"), "The 'ipopt' solver is not available"
     )
     def test_solve_function(self):
         m = pyo.ConcreteModel()
@@ -69,7 +69,7 @@ class TestAMPLExternalFunction(unittest.TestCase):
         solver.solve(m, tee=True)
         self.assertAlmostEqual(m.x(), 6, 4)
 
-    @unittest.skipIf(is_pypy, 'Cannot evaluate external functions under pypy')
+    @unittest.skipIf(is_pypy, "Cannot evaluate external functions under pypy")
     def test_eval_sqnsqr_function_fgh(self):
         m = pyo.ConcreteModel()
         m.tf = pyo.ExternalFunction(library=flib, function="sgnsqr")
@@ -81,5 +81,5 @@ class TestAMPLExternalFunction(unittest.TestCase):
 
         f, g, h = m.tf.evaluate_fgh((-2,))
         self.assertAlmostEqual(f, -4)
-        self.assertStructuredAlmostEqual(g, [-4])
+        self.assertStructuredAlmostEqual(g, [4])
         self.assertStructuredAlmostEqual(h, [-2])


### PR DESCRIPTION
## Fixes None

## Summary/Motivation:

This adds a signed square function to the contributed external function demonstration.  

### Here is an example of where this can be useful.

Say you have a pressure-flow relationship that says the mass flow is proportional to the square root of pressure drop, where pa is inlet pressure and pb is outlet pressure.  Like this: mdot^2 = k(pb - pa).

The direction of flow is forward if the pressure drop is positive or backward if the pressure drop is negative.  There are both positive and negative solutions to the equation.  If we use the proposed sgnsqr function, there is now only one solution to the equation, and the sign of flow matches the sign of pressure drop. 

The sign squared function is still smooth and replacing square with sgnsqr still gives us solutions to the original equation.  It just limits us to one correct solution instead of two possibilities.  I expect there could be many situations where it would be useful to limit the solutions of y = x^2 to a single solution.   

## Changes proposed in this PR:
- add sgnsqr external function to the ampl_external_demo library.
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
