### PR TITLE
Temporarily pinning the scikit-learn and Python 3.13 versions

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -373,7 +373,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -76,13 +76,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.13]
+        python: ['3.13.3']  # FIXME: Remove specific 3.13 version once logging tests are fixed
         other: [""]
         category: [""]
 
         include:
         - os: ubuntu-latest
-          python: 3.13
+          python: '3.13.3'  # FIXME: Remove specific 3.13 version once logging tests are fixed
           test_docs: 1
           TARGET: linux
           PYENV: pip
@@ -348,7 +348,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == "3.13" ]]; then
+        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == 3.13* ]]; then
             # As of Nov 7, 2024, qtconsole is not compatible with python 3.13 on win
             EXCLUDE="qtconsole $EXCLUDE"
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.9, '3.10', 3.11, 3.12, 3.13 ]
+        python: [ 3.9, '3.10', 3.11, 3.12, '3.13.3' ]  # FIXME: Remove specific 3.13 version once logging tests are fixed
         other: [""]
         category: [""]
 
@@ -400,7 +400,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == "3.13" ]]; then
+        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == 3.13* ]]; then
             # As of Nov 7, 2024, qtconsole is not compatible with python 3.13 on win
             EXCLUDE="qtconsole $EXCLUDE"
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -425,7 +425,7 @@ jobs:
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that

--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,9 @@ setup_kwargs = dict(
             'dill',  # No direct use, but improves lambda pickle
             'ipython',  # contrib.viewer
             'linear-tree',  # contrib.piecewise
+            # FIXME: This is a temporary pin that should be removed
+            # when the linear-tree dependency is replaced
+            'scikit-learn<1.7.0',
             # Note: matplotlib 3.6.1 has bug #24127, which breaks
             # seaborn's histplot (triggering parmest failures)
             # Note: minimum version from community_detection use of

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ setup_kwargs = dict(
             'linear-tree',  # contrib.piecewise
             # FIXME: This is a temporary pin that should be removed
             # when the linear-tree dependency is replaced
-            'scikit-learn<1.7.0',
+            'scikit-learn<1.7.0; implementation_name!="pypy"',
             # Note: matplotlib 3.6.1 has bug #24127, which breaks
             # seaborn's histplot (triggering parmest failures)
             # Note: minimum version from community_detection use of


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This sets an upper limit on the scikit-learn version to work around testing failures in `contrib.piecewise` stemming from the unmaintained `linear-tree` package. @emma58 is working on a better solution that will replace the `linear-tree` dependency with something that is being maintained. This PR is a temporary fix until then.

Upon opening this PR we also discovered a new testing issue with cpython 3.13.4. This new Python version introduces a slight change in the formatting of some logging messages which we've tracked to this resolved issue: https://github.com/python/cpython/issues/91555. We need feedback from @jsiirola on how to proceed.

## Changes proposed in this PR:
- Temporarily bound scikit-learn version 
- Temporarily pin Python 3.13 version used for testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
