### PR TITLE
Fix `capture_output` management of logger file descriptors

### DIFF
--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -260,7 +260,7 @@ class _GlobalLogFilter(object):
 # debugging.  It has been updated to suppress output if any handlers
 # have been defined at the root level.
 pyomo_logger = logging.getLogger('pyomo')
-pyomo_handler = StdoutHandler()
+pyomo_handler = logging.StreamHandler(sys.stdout)
 pyomo_formatter = LegacyPyomoFormatter(
     base=PYOMO_ROOT_DIR, verbosity=lambda: pyomo_logger.isEnabledFor(logging.DEBUG)
 )

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -208,13 +208,25 @@ class LegacyPyomoFormatter(logging.Formatter):
 class StdoutHandler(logging.StreamHandler):
     """A logging handler that emits to the current value of sys.stdout"""
 
+    def __init__(self):
+        super().__init__()
+        self.stream = None
+
     def flush(self):
-        self.stream = sys.stdout
-        super(StdoutHandler, self).flush()
+        try:
+            orig = self.stream
+            self.stream = sys.stdout
+            super(StdoutHandler, self).flush()
+        finally:
+            self.stream = orig
 
     def emit(self, record):
-        self.stream = sys.stdout
-        super(StdoutHandler, self).emit(record)
+        try:
+            orig = self.stream
+            self.stream = sys.stdout
+            super(StdoutHandler, self).emit(record)
+        finally:
+            self.stream = orig
 
 
 class Preformatted(object):

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -169,7 +169,7 @@ class redirect_fd(object):
 
         if self.synchronize and self.std:
             # Cause Python's stdout to point to our new file
-            self.target_file = os.fdopen(self.fd, 'w', closefd=False)
+            self.target_file = os.fdopen(self.fd, 'a', closefd=False)
             setattr(sys, self.std, self.target_file)
 
         return self
@@ -349,7 +349,7 @@ class capture_output(object):
                 log_stream = self._enter_context(
                     os.fdopen(
                         self._enter_context(_fd_closer(os.dup(old_fd[1] or 2))),
-                        mode="w",
+                        mode="a",
                         closefd=False,
                     )
                 )
@@ -358,7 +358,7 @@ class capture_output(object):
             self._enter_context(LoggingIntercept(log_stream, logger=logger, level=None))
 
             if isinstance(self.output, str):
-                self.output_stream = self._enter_context(open(self.output, 'w'))
+                self.output_stream = self._enter_context(open(self.output, 'a'))
             elif self.output is None:
                 self.output_stream = io.StringIO()
             else:
@@ -415,7 +415,7 @@ class capture_output(object):
                                     _fd_closer(os.dup(fd_redirect[fd].original_fd)),
                                     prior_to=self.tee,
                                 ),
-                                mode="w",
+                                mode="a",
                                 closefd=False,
                             ),
                             prior_to=self.tee,
@@ -673,7 +673,7 @@ class TeeStream(object):
             self._stderr = self.open(buffering=b)
         return self._stderr
 
-    def open(self, mode='w', buffering=-1, encoding=None, newline=None):
+    def open(self, mode='a', buffering=-1, encoding=None, newline=None):
         if encoding is None:
             encoding = self.encoding
         handle = _StreamHandle(mode, buffering, encoding, newline)

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -19,6 +19,7 @@
 
 import logging
 import os
+import sys
 from inspect import currentframe, getframeinfo
 from io import StringIO
 
@@ -30,6 +31,7 @@ from pyomo.common.log import (
     LogHandler,
     LogStream,
     Preformatted,
+    StdoutHandler,
     WrappingFormatter,
     pyomo_formatter,
 )
@@ -619,3 +621,31 @@ class TestLoggingIntercept(unittest.TestCase):
             self.assertEqual(logger.level, 40)
         finally:
             logger.setLevel(30)
+
+
+class TestStdoutHandler(unittest.TestCase):
+    def setUp(self):
+        self.orig = sys.stdout
+
+    def tearDown(self):
+        sys.stdout = self.orig
+
+    def test_emit(self):
+        handler = StdoutHandler()
+        self.assertIsNone(handler.stream)
+
+        sys.stdout = StringIO()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.WARNING,
+            pathname="/path/to/file.py",
+            lineno=42,
+            msg="Test msg",
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+        handler.flush()
+
+        self.assertEqual(sys.stdout.getvalue(), "Test msg\n")
+        self.assertIsNone(handler.stream)

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -649,3 +649,24 @@ class TestStdoutHandler(unittest.TestCase):
 
         self.assertEqual(sys.stdout.getvalue(), "Test msg\n")
         self.assertIsNone(handler.stream)
+
+    def test_handler(self):
+        logger = logging.getLogger(__name__)
+        propagate, level = logger.propagate, logger.level
+        handler = StdoutHandler()
+        try:
+            logger.addHandler(handler)
+            logger.propagate = False
+            sys.stdout = StringIO()
+
+            logger.setLevel(logging.WARNING)
+            logger.info("Test1")
+            self.assertEqual(sys.stdout.getvalue(), "")
+
+            logger.setLevel(logging.INFO)
+            logger.info("Test2")
+            self.assertEqual(sys.stdout.getvalue(), "Test2\n")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagte = propagate
+            logger.setLevel(level)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3210 .

## Summary/Motivation:
This resolves an issue with how `capture_output` manages LogHandlers when they appear in LogStreams that `capture_output` is sending output to, as reported by #3210.  The root cause was a subtle interaction between Pyomo's default log handler (an instance of `pyomo.common.log.StdoutHandler`) and the log handler interception used by `capture_output`.  In that situation, the default Pyomo LogHandler was resetting the handler's `stream` attribute back to the current value of `sys.stdout` when records were emitted by the handler.  This led to `capture_output` trying to fetch and close the wrong file descriptor on exit.

This PR makes several changes to resolve this situation
- Update the Redirector classes used by `capture_output` to explicitly store the file descriptors they open and not rely on the stream to store the fd for them.
- Update the `StdoutHandler` class to not permanently change the output stream within the `emit` / `flush` methods.
- Switch Pyomo to *not* use the `StdoutHandler` and instead now just use a standard streamHndler.

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
