### PR TITLE
Fix: handle HighsModelStatus.kSolutionLimit like kIterationLimit

### DIFF
--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -684,9 +684,12 @@ class Highs(PersistentBase, PersistentSolver):
             results.termination_condition = TerminationCondition.maxTimeLimit
         elif status == highspy.HighsModelStatus.kIterationLimit:
             results.termination_condition = TerminationCondition.maxIterations
+        elif status == highspy.HighsModelStatus.kSolutionLimit:
+            results.termination_condition = TerminationCondition.maxIterations
         elif status == highspy.HighsModelStatus.kUnknown:
             results.termination_condition = TerminationCondition.unknown
         else:
+            logger.warning(f'Received unhandled {status=} from solver HiGHS.')
             results.termination_condition = TerminationCondition.unknown
 
         timer.start('load solution')


### PR DESCRIPTION
Was previously not handled at all, resulting in termination_condition of unknown, and no further information about whether a solution was found.

kIterationLimit may not be exact, but it's the best fit among the current enum values, I guess.

## Fixes #3632 .

## Summary/Motivation: handle HighsModelStatus.kSolutionLimit like kIterationLimit

## Changes proposed in this PR:
- add case for `kSolutionLimit`
- add warning for the `else` branch

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
