### PR TITLE
Support using Expressions in numpy matrix operations

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -30,7 +30,11 @@ from pyomo.core.expr.expr_common import _type_check_exception_arg
 import pyomo.core.expr.numeric_expr as numeric_expr
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
-from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
+from pyomo.core.base.indexed_component import (
+    IndexedComponent,
+    UnindexedComponent_set,
+    IndexedComponent_NDArrayMixin,
+)
 from pyomo.core.expr.numvalue import as_numeric
 from pyomo.core.base.initializer import Initializer
 
@@ -235,7 +239,7 @@ class _GeneralExpressionData(metaclass=RenamedClass):
 @ModelComponentFactory.register(
     "Named expressions that can be used in other expressions."
 )
-class Expression(IndexedComponent):
+class Expression(IndexedComponent, IndexedComponent_NDArrayMixin):
     """A shared expression container, which may be defined over an index.
 
     Parameters

--- a/pyomo/core/tests/unit/test_expr_numpy.py
+++ b/pyomo/core/tests/unit/test_expr_numpy.py
@@ -92,8 +92,6 @@ class TestNumpyExpr(unittest.TestCase):
 
     def test_expression_vector_operations(self):
         m = ConcreteModel()
-        # m.x = Var(range(3))
-        # m.y = Var(range(2))
         m.p = Param(range(3), range(2), initialize=lambda m, i, j: 10 * i + j)
 
         m.e = Expression(range(3))

--- a/pyomo/core/tests/unit/test_expr_numpy.py
+++ b/pyomo/core/tests/unit/test_expr_numpy.py
@@ -12,7 +12,7 @@
 import pyomo.common.unittest as unittest
 
 from pyomo.common.dependencies import numpy as np, numpy_available
-from pyomo.environ import ConcreteModel, Var, Constraint
+from pyomo.environ import ConcreteModel, Var, Constraint, Param, Expression
 
 
 @unittest.skipUnless(numpy_available, "tests require numpy")
@@ -37,7 +37,7 @@ class TestNumpyExpr(unittest.TestCase):
         self.assertExpressionsEqual(np.array([5, 6]) * m.x, [5 * m.x, 6 * m.x])
         self.assertExpressionsEqual(np.array([8, m.x]) * m.x, [8 * m.x, m.x * m.x])
 
-    def test_vector_operations(self):
+    def test_variable_vector_operations(self):
         m = ConcreteModel()
         m.x = Var()
         m.y = Var([0, 1, 2])
@@ -89,6 +89,23 @@ class TestNumpyExpr(unittest.TestCase):
             self.assertExpressionsEqual(
                 m.x * m.y * a, [5 * m.y[0] * m.x, 5 * m.y[1] * m.x, 5 * m.y[2] * m.x]
             )
+
+    def test_expression_vector_operations(self):
+        m = ConcreteModel()
+        # m.x = Var(range(3))
+        # m.y = Var(range(2))
+        m.p = Param(range(3), range(2), initialize=lambda m, i, j: 10 * i + j)
+
+        m.e = Expression(range(3))
+        m.f = Expression(range(2))
+
+        expr = np.transpose(m.e) @ m.p @ m.f
+        print(expr)
+        self.assertExpressionsEqual(
+            expr,
+            (m.e[0] * 0 + m.e[1] * 10 + m.e[2] * 20) * m.f[0]
+            + (m.e[0] * 1 + m.e[1] * 11 + m.e[2] * 21) * m.f[1],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
#2027 and #2070 added support for using variables and parameters in numpy matrix operations.  Unfortunately, it failed to include Expression objects (which was recently pointed out by @eslickj).  This PR resolves that oversight (including a simple test of the functionality).

## Changes proposed in this PR:
- Support conversion of `Expression` objects into `numpy.ndarray(dtype=object)` objects

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
