### PR TITLE
Revert `fdopen` mode from `'a'` to `'w'`

### DIFF
--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -469,7 +469,7 @@ class _StreamRedirector(object):
         # #3587), so we will just handle it explicitly ourselves.
         self.local_fd = os.dup(self.fd)
         self.handler.stream = os.fdopen(
-            self.local_fd, mode="a", closefd=False
+            self.local_fd, mode="w", closefd=False
         ).__enter__()
 
     def __exit__(self, et, ev, tb):
@@ -495,7 +495,7 @@ class _LastResortRedirector(object):
         # #3587), so we will just handle it explicitly ourselves.
         self.local_fd = os.dup(self.fd)
         logging.lastResort = logging.StreamHandler(
-            os.fdopen(self.local_fd, mode="a", closefd=False).__enter__()
+            os.fdopen(self.local_fd, mode="w", closefd=False).__enter__()
         )
 
     def __exit__(self, et, ev, tb):

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -169,7 +169,7 @@ class redirect_fd(object):
 
         if self.synchronize and self.std:
             # Cause Python's stdout to point to our new file
-            self.target_file = os.fdopen(self.fd, 'a', closefd=False)
+            self.target_file = os.fdopen(self.fd, "w", closefd=False)
             setattr(sys, self.std, self.target_file)
 
         return self
@@ -349,7 +349,7 @@ class capture_output(object):
                 log_stream = self._enter_context(
                     os.fdopen(
                         self._enter_context(_fd_closer(os.dup(old_fd[1] or 2))),
-                        mode="a",
+                        mode="w",
                         closefd=False,
                     )
                 )
@@ -358,7 +358,7 @@ class capture_output(object):
             self._enter_context(LoggingIntercept(log_stream, logger=logger, level=None))
 
             if isinstance(self.output, str):
-                self.output_stream = self._enter_context(open(self.output, 'a'))
+                self.output_stream = self._enter_context(open(self.output, "a"))
             elif self.output is None:
                 self.output_stream = io.StringIO()
             else:
@@ -415,7 +415,7 @@ class capture_output(object):
                                     _fd_closer(os.dup(fd_redirect[fd].original_fd)),
                                     prior_to=self.tee,
                                 ),
-                                mode="a",
+                                mode="w",
                                 closefd=False,
                             ),
                             prior_to=self.tee,
@@ -673,7 +673,7 @@ class TeeStream(object):
             self._stderr = self.open(buffering=b)
         return self._stderr
 
-    def open(self, mode='a', buffering=-1, encoding=None, newline=None):
+    def open(self, mode="w", buffering=-1, encoding=None, newline=None):
         if encoding is None:
             encoding = self.encoding
         handle = _StreamHandle(mode, buffering, encoding, newline)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This reverts part of #3633.   @avdudchenko reported that the use of `"a"` was leading to errors on Windows when running
```
pytest -s pyomo\contrib\pynumero\examples\tests\test_cyipopt_examples.py
```
or 
```
python pyomo\contrib\pynumero\examples\external_grey_box\react_example\maximize_cb_outputs.py
```
Giving errors like:
```
ERROR: Exception encountered during cyipopt solve:
Traceback (most recent call last):
  File "d:\github\pyomo\pyomo\contrib\pynumero\algorithms\solvers\cyipopt_solver.py", line 386, in solve
    with capture_output(sys.stdout if config.tee else None, capture_fd=True):
  File "d:\github\pyomo\pyomo\common\tee.py", line 305, in __enter__
    return self._enter_impl()
           ^^^^^^^^^^^^^^^^^^
  File "d:\github\pyomo\pyomo\common\tee.py", line 350, in _enter_impl
    os.fdopen(
  File "<frozen os>", line 1031, in fdopen
ValueError: Must have exactly one of read or write mode
Traceback (most recent call last):
  File "D:\github\pyomo\pyomo\contrib\pynumero\examples\external_grey_box\react_example\maximize_cb_outputs.py", line 47, in <module>
    m = maximize_cb_outputs(show_solver_log=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\github\pyomo\pyomo\contrib\pynumero\examples\external_grey_box\react_example\maximize_cb_outputs.py", line 41, in maximize_cb_outputs
    results = solver.solve(m, tee=show_solver_log)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\github\pyomo\pyomo\contrib\pynumero\algorithms\solvers\cyipopt_solver.py", line 386, in solve
    with capture_output(sys.stdout if config.tee else None, capture_fd=True):
  File "d:\github\pyomo\pyomo\common\tee.py", line 305, in __enter__
    return self._enter_impl()
           ^^^^^^^^^^^^^^^^^^
  File "d:\github\pyomo\pyomo\common\tee.py", line 350, in _enter_impl
    os.fdopen(
  File "<frozen os>", line 1031, in fdopen
ValueError: Must have exactly one of read or write mode
```

It was not clear how to reproduce / test this error in GHA.  These examples are currently being tested without error.  It might be that we would have to change how the examples were being run by pytest (i.e., adding `-s`)?

## Changes proposed in this PR:
- Open file descriptors in "w" mode for Windows compatibility

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
