### PR TITLE
Modified _parse_gdx_results in GAMS.py to replace _parse_special_value and Updated Import Statement

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -44,7 +44,7 @@ import struct
 
 def _gams_importer():
     try:
-        import gams.core.gdx as gdxAdd
+        import gams.core.gdx as gdx
         return gdx
     except ImportError:
         try:

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -41,7 +41,21 @@ from pyomo.opt.results import (
 
 from pyomo.common.dependencies import attempt_import
 
-gdxcc, gdxcc_available = attempt_import('gdxcc')
+def _gams_importer():
+    try:
+        import gams.core.gdx as gdxAdd
+        return gdx
+    except ImportError:
+        try:
+            # fall back to the pre-GAMS-45.0 API
+            import gdxcc
+            return gdxcc
+        except:
+            # suppress the error from the old API and reraise the current API import error
+            pass
+        raise
+
+gdxcc, gdxcc_available = attempt_import('gdxcc', importer=_gams_importer)
 
 logger = logging.getLogger('pyomo.solvers')
 

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -747,18 +747,6 @@ class GAMSShell(_GAMSSolver):
             )
             return _extract_version(results.stdout)
 
-    @staticmethod
-    def _parse_special_values(value):
-        if value == 1.0e300 or value == 2.0e300:
-            return float('nan')
-        if value == 3.0e300:
-            return float('inf')
-        if value == 4.0e300:
-            return -float('inf')
-        if value == 5.0e300:
-            return sys.float_info.epsilon
-        return value
-
     def _rewrite_path_win8p3(self, path):
         """
         Return the 8.3 short path on Windows; unchanged elsewhere.

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -40,7 +40,6 @@ from pyomo.opt.results import (
 )
 
 from pyomo.common.dependencies import attempt_import
-import numpy as np
 import struct
 
 def _gams_importer():
@@ -1296,8 +1295,8 @@ class GAMSShell(_GAMSSolver):
             
             specVals = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
             rc = gdxcc.gdxGetSpecialValues(pgdx, specVals)
-
-            specVals[gdxcc.GMS_SVIDX_EPS] = np.finfo(np.float64).tiny
+            
+            specVals[gdxcc.GMS_SVIDX_EPS] = sys.float_info.min
             specVals[gdxcc.GMS_SVIDX_UNDEF] = float("nan")
             specVals[gdxcc.GMS_SVIDX_PINF] = float("inf")
             specVals[gdxcc.GMS_SVIDX_MINF] = float("-inf")
@@ -1340,7 +1339,7 @@ class GAMSShell(_GAMSSolver):
             specVals = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
             rc = gdxcc.gdxGetSpecialValues(pgdx, specVals)
 
-            specVals[gdxcc.GMS_SVIDX_EPS] = np.finfo(np.float64).tiny
+            specVals[gdxcc.GMS_SVIDX_EPS] = sys.float_info.min
             specVals[gdxcc.GMS_SVIDX_UNDEF] = float("nan")
             specVals[gdxcc.GMS_SVIDX_PINF] = float("inf")
             specVals[gdxcc.GMS_SVIDX_MINF] = float("-inf")

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -42,19 +42,23 @@ from pyomo.opt.results import (
 from pyomo.common.dependencies import attempt_import
 import struct
 
+
 def _gams_importer():
     try:
         import gams.core.gdx as gdx
+
         return gdx
     except ImportError:
         try:
             # fall back to the pre-GAMS-45.0 API
             import gdxcc
+
             return gdxcc
         except:
             # suppress the error from the old API and reraise the current API import error
             pass
         raise
+
 
 gdxcc, gdxcc_available = attempt_import('gdxcc', importer=_gams_importer)
 
@@ -1292,15 +1296,17 @@ class GAMSShell(_GAMSSolver):
             ret = gdxcc.gdxOpenRead(pgdx, statresults_filename)
             if not ret[0]:
                 raise RuntimeError("GAMS GDX failure (gdxOpenRead): %d." % ret[1])
-            
+
             specVals = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
             rc = gdxcc.gdxGetSpecialValues(pgdx, specVals)
-            
+
             specVals[gdxcc.GMS_SVIDX_EPS] = sys.float_info.min
             specVals[gdxcc.GMS_SVIDX_UNDEF] = float("nan")
             specVals[gdxcc.GMS_SVIDX_PINF] = float("inf")
             specVals[gdxcc.GMS_SVIDX_MINF] = float("-inf")
-            specVals[gdxcc.GMS_SVIDX_NA] = struct.unpack(">d", bytes.fromhex("fffffffffffffffe"))[0]
+            specVals[gdxcc.GMS_SVIDX_NA] = struct.unpack(
+                ">d", bytes.fromhex("fffffffffffffffe")
+            )[0]
             gdxcc.gdxSetSpecialValues(pgdx, specVals)
 
             i = 0
@@ -1343,9 +1349,11 @@ class GAMSShell(_GAMSSolver):
             specVals[gdxcc.GMS_SVIDX_UNDEF] = float("nan")
             specVals[gdxcc.GMS_SVIDX_PINF] = float("inf")
             specVals[gdxcc.GMS_SVIDX_MINF] = float("-inf")
-            specVals[gdxcc.GMS_SVIDX_NA] = struct.unpack(">d", bytes.fromhex("fffffffffffffffe"))[0]
+            specVals[gdxcc.GMS_SVIDX_NA] = struct.unpack(
+                ">d", bytes.fromhex("fffffffffffffffe")
+            )[0]
             gdxcc.gdxSetSpecialValues(pgdx, specVals)
-            
+
             i = 0
             while True:
                 i += 1


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3624

## Summary/Motivation:
When parsing the results of a model after it has been solved, the level and dual value are obtained through a series of `if` statements in `_parse_special_values` that may cause slowdowns. This PR added GAMS existing functions to handle data parser for these special values in `_parse_gdx_results`.

## Changes proposed in this PR:
- Replaced `_parse_special_values` with GAMS special value parser in `_parse_gdx_results`.
- Updated `attempt_import` to have fallback to pre-GAMS-45.0 API if `gams.core.gdx` is not available.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.