### PR TITLE
Resolve Python 3.14 compatibility issues

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -76,13 +76,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.13.3']  # FIXME: Remove specific 3.13 version once logging tests are fixed
+        python: [3.13]
         other: [""]
         category: [""]
 
         include:
         - os: ubuntu-latest
-          python: '3.13.3'  # FIXME: Remove specific 3.13 version once logging tests are fixed
+          python: 3.13
           test_docs: 1
           TARGET: linux
           PYENV: pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.9, '3.10', 3.11, 3.12, '3.13.3' ]  # FIXME: Remove specific 3.13 version once logging tests are fixed
+        python: [ 3.9, '3.10', 3.11, 3.12, 3.13 ]
         other: [""]
         category: [""]
 

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -439,10 +439,20 @@ class FileDownloader(object):
             # Strip high bits & group/other write bits
             info.mode &= 0o755
             return True
-
+        if sys.version_info[:2] < (3,12):
+            tar_args = {}
+        else:
+            # Add a tar filter to suppress deprecation warning in Python 3.12+
+            #
+            # Note that starting in Python 3.14 the default is 'data',
+            # however, this method is already filtering for many of the
+            # things that 'data' would catch (and raise an exception
+            # for).  For backwards compatibility, we will use the more
+            # permissive "tar" filter.
+            tar_args = {'filter': tarfile.tar_filter}
         with tarfile.open(fileobj=io.BytesIO(self.retrieve_url(url))) as TAR:
             dest = os.path.realpath(self._fname)
-            TAR.extractall(dest, filter(filter_fcn, TAR.getmembers()))
+            TAR.extractall(dest, filter(filter_fcn, TAR.getmembers()), **tar_args)
 
     def get_gzipped_binary_file(self, url):
         if self._fname is None:

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -73,9 +73,8 @@ elif hasattr(getattr(logging.getLogger(), 'manager', None), 'disable'):
         """
         if logger.manager.disable >= _DEBUG:
             return False
-        _level = logger.getEffectiveLevel()
         # Filter out NOTSET and higher levels
-        return _NOTSET < _level <= _DEBUG
+        return _NOTSET < logger.getEffectiveLevel() <= _DEBUG
 
 elif sys.version_info[:3] < (3, 13, 4):
     # This is inefficient (it indirectly checks effective level twice),

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -62,10 +62,10 @@ class TestLegacyLogHandler(unittest.TestCase):
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
         logger.warning("(warn)")
         ans = "WARNING: (warn)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.warning("(warn)")
@@ -74,7 +74,7 @@ class TestLegacyLogHandler(unittest.TestCase):
             'WARNING: "[base]%stest_log.py", %d, test_simple_log\n'
             '    (warn)\n' % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_default_verbosity(self):
         # Testing positional base, configurable verbosity
@@ -91,7 +91,7 @@ class TestLegacyLogHandler(unittest.TestCase):
             'WARNING: "[base]%stest_log.py", %d, test_default_verbosity\n'
             '    (warn)\n' % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
 
 class TestWrappingFormatter(unittest.TestCase):
@@ -109,17 +109,17 @@ class TestWrappingFormatter(unittest.TestCase):
         self.handler.setFormatter(WrappingFormatter(style='%'))
         logger.warning("(warn)")
         ans += "WARNING: (warn)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         self.handler.setFormatter(WrappingFormatter(style='$'))
         logger.warning("(warn)")
         ans += "WARNING: (warn)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         self.handler.setFormatter(WrappingFormatter(style='{'))
         logger.warning("(warn)")
         ans += "WARNING: (warn)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         with self.assertRaisesRegex(ValueError, 'unrecognized style flag "s"'):
             WrappingFormatter(style='s')
@@ -151,10 +151,10 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
         logger.warning("(warn)")
         ans = "WARNING: (warn)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.warning("(warn)")
@@ -163,32 +163,32 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
             'WARNING: "[base]%stest_log.py", %d, test_simple_log\n'
             '    (warn)\n' % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_alternate_base(self):
         self.handler.setFormatter(LegacyPyomoFormatter(base='log_config'))
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
         ans = 'WARNING: "%s", %d, test_alternate_base\n    (warn)\n' % (
             filename,
             lineno,
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_no_base(self):
         self.handler.setFormatter(LegacyPyomoFormatter())
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
         ans = 'WARNING: "%s", %d, test_no_base\n    (warn)\n' % (filename, lineno)
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_no_message(self):
         self.handler.setFormatter(
@@ -200,11 +200,11 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
 
         logger.setLevel(logging.WARNING)
         logger.info("")
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
 
         logger.warning("")
         ans = "WARNING:\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.warning("")
@@ -213,7 +213,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
             os.path.sep,
             lineno,
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_blank_lines(self):
         self.handler.setFormatter(
@@ -225,7 +225,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.WARNING)
         logger.warning("\n\nthis is a message.\n\n\n")
         ans = "WARNING: this is a message.\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.warning("\n\nthis is a message.\n\n\n")
@@ -234,7 +234,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
             'WARNING: "[base]%stest_log.py", %d, test_blank_lines\n'
             "    this is a message.\n" % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_numbered_level(self):
         testname = 'test_numbered_level'
@@ -247,11 +247,11 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.WARNING)
         logger.log(45, "(hi)")
         ans = "Level 45: (hi)\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.log(45, "")
         ans += "Level 45:\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.log(45, "(hi)")
@@ -261,7 +261,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
             lineno,
             testname,
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.log(45, "")
         lineno = getframeinfo(currentframe()).lineno - 1
@@ -270,7 +270,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
             lineno,
             testname,
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_preformatted(self):
         self.handler.setFormatter(
@@ -286,11 +286,11 @@ would be line-wrapped
 
         logger.setLevel(logging.WARNING)
         logger.info(msg)
-        self.assertEqual(self.stream.getvalue(), "")
+        self.assertEqual("", self.stream.getvalue())
 
         logger.warning(Preformatted(msg))
         ans = msg + "\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.warning(msg)
         ans += (
@@ -298,13 +298,13 @@ would be line-wrapped
             "circumstances would\n"
             "be line-wrapped with additional information that normally would be combined.\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
 
         logger.warning(Preformatted(msg))
         ans += msg + "\n"
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.warning(msg)
         lineno = getframeinfo(currentframe()).lineno - 1
@@ -317,7 +317,7 @@ would be line-wrapped
             "circumstances would be\n"
             "    line-wrapped with additional information that normally would be combined.\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_long_messages(self):
         self.handler.setFormatter(
@@ -342,7 +342,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
@@ -355,7 +355,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n" % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         # test trailing newline
         msg += "\n"
@@ -368,7 +368,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
@@ -381,7 +381,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n" % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         # test initial and final blank lines
         msg = "\n" + msg + "\n\n"
@@ -394,7 +394,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
@@ -407,7 +407,7 @@ would be line-wrapped
             "        - including a bulleted list\n"
             "        - list 2\n" % (os.path.sep, lineno)
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
     def test_verbatim(self):
         self.handler.setFormatter(
@@ -508,7 +508,7 @@ would be line-wrapped
             "\n"
             "    quote block\n"
         )
-        self.assertEqual(self.stream.getvalue(), ans)
+        self.assertEqual(ans, self.stream.getvalue())
 
 
 class TestLogStream(unittest.TestCase):
@@ -527,7 +527,7 @@ class TestLogStream(unittest.TestCase):
             # empty writes do not generate log records
             ls.write("")
             ls.flush()
-            self.assertEqual(OUT.getvalue(), "")
+            self.assertEqual("", OUT.getvalue())
 
         with LI as OUT:
             ls.write("line 1\nline 2")
@@ -656,7 +656,7 @@ class TestStdoutHandler(unittest.TestCase):
 
             logger.setLevel(logging.WARNING)
             logger.info("Test1")
-            self.assertEqual(sys.stdout.getvalue(), "")
+            self.assertEqual("", sys.stdout.getvalue())
 
             logger.setLevel(logging.INFO)
             logger.info("Test2")

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -33,6 +33,7 @@ from pyomo.common.log import (
     Preformatted,
     StdoutHandler,
     WrappingFormatter,
+    is_debug_set,
     pyomo_formatter,
 )
 
@@ -54,7 +55,7 @@ class TestLegacyLogHandler(unittest.TestCase):
             self.handler = LogHandler(
                 os.path.dirname(__file__),
                 stream=self.stream,
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                verbosity=lambda: is_debug_set(logger),
             )
         self.assertIn('LogHandler class has been deprecated', log.getvalue())
         logger.addHandler(self.handler)
@@ -144,8 +145,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         # Testing positional base, configurable verbosity
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 
@@ -194,7 +194,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         self.handler.setFormatter(
             LegacyPyomoFormatter(
                 base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                verbosity=lambda: is_debug_set(logger),
             )
         )
 
@@ -218,8 +218,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
     def test_blank_lines(self):
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 
@@ -241,8 +240,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         testname = 'test_numbered_level'
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 
@@ -277,8 +275,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
     def test_preformatted(self):
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 
@@ -325,8 +322,7 @@ would be line-wrapped
     def test_long_messages(self):
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 
@@ -416,8 +412,7 @@ would be line-wrapped
     def test_verbatim(self):
         self.handler.setFormatter(
             LegacyPyomoFormatter(
-                base=os.path.dirname(__file__),
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+                base=os.path.dirname(__file__), verbosity=lambda: is_debug_set(logger)
             )
         )
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves two issues with Python 3.14 (and late Python 3.13) releases
1. Python has changed the behavior of `logger.isEnabledFor()` so that it always returns False when a log record is in flight.  This breaks some of our `pyomo.common.log` tests (related to how the legacy formatter switches verbosity).  This PR removes dependence on `isEnabledFor` when processing log records
2. Starting in Python 3.12, the `tarfile` module will issue a deprecation warning when a `filter` is not provided to `extractall`.  This PR adds filter (for Python>=3.12, where the argument is allowed).  The filter needs to *not* be the same as the default starting in Python 3.14, because the default will trigger undesired exceptions.

## Changes proposed in this PR:
- Rework how the Pyomo log formatter detects if debug logging is enabled 
- Provide a filter to tarfile.extractall (for python>=3.12)
- Release GHA Python 3.13 version pin

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
3. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
