### PR TITLE
Resolve an assortment of infrastructure errors - pkg_resources and GAMS

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -521,7 +521,9 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      # June 24, 2025: Turning off GAMS install until we can get licensing resolved
+      if: false
+      # if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -521,9 +521,7 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      # June 24, 2025: Turning off GAMS install until we can get licensing resolved
-      if: false
-      # if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -536,9 +534,8 @@ jobs:
         echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
-        # We are pinning to 29.1.0 because a license is required for
-        # versions after this in order to run in demo mode.
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
+        # Demo licenses are included for 5mo from the newest release
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/50.1.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -573,9 +573,7 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      # June 24, 2025: Turning off GAMS install until we can get licensing resolved
-      if: false
-      # if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -588,9 +586,8 @@ jobs:
         echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
-        # We are pinning to 29.1.0 because a license is required for
-        # versions after this in order to run in demo mode.
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
+        # Demo licenses are included for 5mo from the newest release
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/50.1.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -573,7 +573,9 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      # June 24, 2025: Turning off GAMS install until we can get licensing resolved
+      if: false
+      # if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -444,15 +444,9 @@ def check_min_version(module, min_version):
         else:
             return False
     if check_min_version._parser is None:
-        try:
-            from packaging import version as _version
+        packaging_version, _ = attempt_import('packaging.version')
 
-            _parser = _version.parse
-        except ImportError:
-            # pkg_resources is an order of magnitude slower to import than
-            # packaging.  Only use it if the preferred (but optional)
-            # packaging library is not present
-            from pkg_resources import parse_version as _parser
+        _parser = packaging_version.parse
         check_min_version._parser = _parser
     else:
         _parser = check_min_version._parser

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -977,6 +977,12 @@ def _finalize_pympler(module, available):
         import pympler.muppy
 
 
+def _finalize_packaging(module, available):
+    if available:
+        # Import key subpackages that we will want to assume are present
+        import packaging.version
+
+
 def _finalize_matplotlib(module, available):
     if not available:
         return
@@ -1080,7 +1086,7 @@ with declare_modules_as_importable(globals()):
 
     # Necessary for minimum version checking for other optional dependencies
     packaging, packaging_available = attempt_import(
-        'packaging', deferred_submodules=['version']
+        'packaging', deferred_submodules=['version'], callback=_finalize_packaging
     )
     # Commonly-used optional dependencies
     dill, dill_available = attempt_import('dill')

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -444,10 +444,7 @@ def check_min_version(module, min_version):
         else:
             return False
     if check_min_version._parser is None:
-        packaging_version, _ = attempt_import('packaging.version')
-
-        _parser = packaging_version.parse
-        check_min_version._parser = _parser
+        check_min_version._parser = packaging_version.parse
     else:
         _parser = check_min_version._parser
 
@@ -1088,6 +1085,8 @@ with declare_modules_as_importable(globals()):
     )
     random, _ = attempt_import('random')
 
+    # Necessary for minimum version checking for other optional dependencies
+    packaging_version, packaging_available = attempt_import('packaging.version')
     # Commonly-used optional dependencies
     dill, dill_available = attempt_import('dill')
     mpi4py, mpi4py_available = attempt_import(

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -443,16 +443,9 @@ def check_min_version(module, min_version):
             module = indicator._module
         else:
             return False
-    if check_min_version._parser is None:
-        check_min_version._parser = packaging_version.parse
-    else:
-        _parser = check_min_version._parser
 
     version = getattr(module, '__version__', '0.0.0')
-    return _parser(min_version) <= _parser(version)
-
-
-check_min_version._parser = None
+    return packaging.version.parse(min_version) <= packaging.version.parse(version)
 
 
 #
@@ -1086,7 +1079,9 @@ with declare_modules_as_importable(globals()):
     random, _ = attempt_import('random')
 
     # Necessary for minimum version checking for other optional dependencies
-    packaging_version, packaging_available = attempt_import('packaging.version')
+    packaging, packaging_available = attempt_import(
+        'packaging', deferred_submodules=['version']
+    )
     # Commonly-used optional dependencies
     dill, dill_available = attempt_import('dill')
     mpi4py, mpi4py_available = attempt_import(

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -31,6 +31,7 @@ from pyomo.common.dependencies import (
     dill,
     dill_available,
     mpi4py_available,
+    packaging_available,
 )
 
 import pyomo.common.tests.dep_mod as dep_mod
@@ -125,6 +126,9 @@ class TestDependencies(unittest.TestCase):
         self.assertIs(dep_mod.bogus_nonexisting_module_available, False)
         self.assertIs(type(dep_mod.bogus_nonexisting_module), ModuleUnavailable)
 
+    @unittest.skipUnless(
+        packaging_available, "min_version tests require packaging module"
+    )
     def test_min_version(self):
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod', minimum_version='1.0', defer_import=False
@@ -177,6 +181,9 @@ class TestDependencies(unittest.TestCase):
         mod, avail = attempt_import('pyomo.common.tests.bogus', minimum_version='1.0')
         self.assertFalse(check_min_version(mod, '1.0'))
 
+    @unittest.skipUnless(
+        packaging_available, "min_version tests require packaging module"
+    )
     def test_and_or(self):
         mod0, avail0 = attempt_import('ply', defer_import=True)
         mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod', defer_import=True)
@@ -231,6 +238,9 @@ class TestDependencies(unittest.TestCase):
         self.assertIsInstance(_ror, _DeferredOr)
         self.assertTrue(_ror)
 
+    @unittest.skipUnless(
+        packaging_available, "min_version tests require packaging module"
+    )
     def test_callbacks(self):
         ans = []
 

--- a/pyomo/contrib/appsi/solvers/maingo.py
+++ b/pyomo/contrib/appsi/solvers/maingo.py
@@ -173,11 +173,18 @@ class MAiNGO(PersistentBase, PersistentSolver):
         return self._available
 
     def version(self):
-        import pkg_resources
+        import importlib.metadata
 
-        version = pkg_resources.get_distribution('maingopy').version
-
-        return tuple(int(k) for k in version.split('.'))
+        try:
+            version = importlib.metadata.version('maingopy').split('.')
+        except ImportError:
+            return None
+        for i, n in enumerate(version):
+            try:
+                version[i] = int(version[i])
+            except:
+                pass
+        return tuple(version)
 
     @property
     def config(self) -> MAiNGOConfig:

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -122,7 +122,12 @@ class kestrelAMPL(object):
         try:
             result = self.neos.ping()
             logger.info("OK.")
-        except (socket.error, xmlrpclib.ProtocolError, http.client.BadStatusLine):
+        except (
+            socket.error,
+            xmlrpclib.ProtocolError,
+            http.client.BadStatusLine,
+            NotImplementedError,
+        ):
             e = sys.exc_info()[1]
             self.neos = None
             logger.info("Fail: %s" % (e,))

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -20,7 +20,13 @@ pyomo_commands = []
 def load_entry_points():
     import importlib.metadata
 
-    for ep in importlib.metadata.entry_points().get('pyomo.command', []):
+    try:
+        # Python >= 3.10
+        ep_list = importlib.metadata.entry_points(group='pyomo.command')
+    except:
+        # Python 3.8 - 3.9
+        ep_list = importlib.metadata.entry_points().get('pyomo.command', [])
+    for ep in ep_list:
         try:
             pyomo_commands.append(ep.load())
         except:

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -14,10 +14,14 @@ import copy
 from pyomo.common.deprecation import deprecation_warning
 
 try:
-    import pkg_resources
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:
+        # REMOVE LATER: Backport for Python < 3.10
+        from importlib_metadata import entry_points
 
-    pyomo_commands = pkg_resources.iter_entry_points('pyomo.command')
-except:
+    pyomo_commands = entry_points().get('pyomo.command', [])
+except Exception:
     pyomo_commands = []
 #
 # Load modules associated with Plugins that are defined in

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -14,11 +14,7 @@ import copy
 from pyomo.common.deprecation import deprecation_warning
 
 try:
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:
-        # REMOVE LATER: Backport for Python < 3.10
-        from importlib_metadata import entry_points
+    from importlib.metadata import entry_points
 
     pyomo_commands = entry_points().get('pyomo.command', [])
 except Exception:

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -20,7 +20,7 @@ pyomo_commands = []
 def load_entry_points():
     import importlib.metadata
 
-    for ep in importlib.metadata.entry_points(group='pyomo.command'):
+    for ep in importlib.metadata.entry_points().get('pyomo.command', []):
         try:
             pyomo_commands.append(ep.load())
         except:

--- a/pyomo/version/tests/test_version.py
+++ b/pyomo/version/tests/test_version.py
@@ -20,17 +20,17 @@ class Tests(unittest.TestCase):
 
     def test_version(self):
         try:
-            import pkg_resources
+            from importlib.metadata import version
 
-            version = pkg_resources.get_distribution('pyomo').version
+            pyomo_version = version('pyomo')
         except:
-            self.skipTest('pkg_resources is not available')
+            self.skipTest('importlib.metadata is not available')
 
         if pyomo_ver.version_info[3] == 'final':
-            self.assertEqual(pyomo_ver.version, version)
+            self.assertEqual(pyomo_ver.version, pyomo_version)
 
         else:
-            tmp_ = version.split('.')
+            tmp_ = pyomo_version.split('.')
             self.assertEqual(str(tmp_[0]), str(pyomo_ver.version_info[0]))
             self.assertEqual(str(tmp_[1]), str(pyomo_ver.version_info[1]))
             if tmp_[-1].startswith('dev'):

--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,7 @@ setup_kwargs = dict(
             'networkx; python_version>="3.9"',
             'numpy',
             'openpyxl',  # dataportals
+            'packaging',  # for checking other dependency versions
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
We have lots of new deprecation warnings showing up in the book examples because the `pyomo_main` script uses `pkg_resources`.

## Changes proposed in this PR:
- Replace `pkg_resources` with `importlib.metadata`
- Turn off GAMS until we can figure out a new licensing plan

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
