### PR TITLE
Two tiny changes to `core.relax_integer_vars`

### DIFF
--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -28,6 +28,7 @@ from pyomo.core.base import (
     Constraint,
     Objective,
 )
+from pyomo.core.base.block import SubclassOf
 from pyomo.core.util import target_list
 from pyomo.gdp import Disjunct
 from pyomo.util.vars_from_expressions import get_vars_from_components
@@ -116,7 +117,7 @@ class RelaxIntegerVars(Transformation):
         super().__init__()
 
     def _apply_to(self, model, **kwds):
-        if not model.ctype in (Block, Disjunct):
+        if model.ctype not in SubclassOf(Block):
             raise ValueError(
                 "Transformation called on %s of type %s. 'model' "
                 "must be a ConcreteModel or Block." % (model.name, model.ctype)

--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -66,7 +66,7 @@ class RelaxIntegerVars(Transformation):
             doc="""
             This argument should be the reverse transformation token
             returned by a previous call to this transformation to transform
-            fixed disjunctive state in the given model.
+            fixed discrete state in the given model.
             If this argument is specified, this call to the transformation
             will reverse what the transformation did in the call that returned
             the token. Note that if there are intermediate changes to the model


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

@jsiirola gave me an accidental merge of #3586 last week, but this implements a couple (small) suggestions he had to the rewrite of the `core.relax_integer_vars` transformation

## Changes proposed in this PR:
- Fixes a copy-paste typo in a docstring
- Remembers that subclasses of Block other than Disjunct exist. :P

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
