### PR TITLE
Adjust PyROS handling of separation objective evaluation errors

### DIFF
--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -202,7 +202,7 @@ def get_sep_objective_values(separation_data, ss_ineq_cons):
                 f"{var.name}={var.value}" for var in identify_variables(obj.expr)
             )
             config.progress_logger.error(
-                "PyROS encountered exception evaluating "
+                "PyROS encountered an exception evaluating "
                 "expression of second-stage inequality constraint with name "
                 f"{ss_ineq_con.name!r} (separation objective {obj.name!r}) "
                 f"at variable values:\n  {vars_in_expr_str}\n"

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -1242,9 +1242,8 @@ class RegressionTest(unittest.TestCase):
     )
     def test_pyros_math_domain_error(self):
         """
-        Test PyROS on a two-stage problem, discrete
-        set type with a math domain error evaluating
-        second-stage inequality constraint expressions in separation.
+        Test PyROS behavior is as expected when there are errors
+        encountered while evaluating separation problem objectives.
         """
         m = ConcreteModel()
         m.q = Param(initialize=1, mutable=True)
@@ -1259,16 +1258,35 @@ class RegressionTest(unittest.TestCase):
         pyros_solver = SolverFactory("pyros")
 
         with self.assertRaisesRegex(
-            expected_exception=ArithmeticError,
-            expected_regex=(
-                "Evaluation of second-stage inequality constraint.*math domain error.*"
-            ),
-            msg="ValueError arising from math domain error not raised",
+            expected_exception=ValueError,
+            expected_regex="math domain error",
+            msg="Exception arising from math domain error not raised",
         ):
             # should raise math domain error:
             # (1) lower bounding constraint on x2 solved first
-            #     in separation, q = 0 in worst case
-            # (2) now tries to evaluate log(q), but q = 0
+            #     in separation. Solution has q = 0
+            # (2) upon solution of the first separation problem,
+            #     evaluation of x2 - log(q) at q = 0
+            #     results in exception
+            pyros_solver.solve(
+                model=m,
+                first_stage_variables=[m.x1],
+                second_stage_variables=[m.x2],
+                uncertain_params=[m.q],
+                uncertainty_set=box_set,
+                local_solver=local_solver,
+                global_solver=global_solver,
+                decision_rule_order=1,
+                tee=True,
+            )
+
+        # this should result in error stemming from division by zero
+        m.x2.setub(1 / m.q)
+        with self.assertRaisesRegex(
+            expected_exception=ZeroDivisionError,
+            expected_regex="float division by zero",
+            msg="Exception arising from math domain error not raised",
+        ):
             pyros_solver.solve(
                 model=m,
                 first_stage_variables=[m.x1],


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:

Upon the solution of a separation problem, PyROS attempts to evaluate the violations of all second-stage inequality constraints at the optimal solution to that separation problem. In (rare) cases, the evaluation may fail due to an exception encountered/raised by the Pyomo expression evaluators. This exception may be of type `ValueError` or `ArithmeticError`. Currently, PyROS does not handle an exception of type `ArithmeticError` and handles a  `ValueError`-type exception as follows:

- Issue INFO-level logging messages reporting the names and values of all first-stage variables and second-stage variables of the separation model
- Raise an `ArithmeticError` with a message of the form "Evaluation . . . of constraint . . . led to a math domain error. Does the constraint contain . . . functions . . . with tricky domains?"

In this PR, we modify PyROS to handle an exception of type `ValueError` or `ArithmeticError` as follows:

- Issue an ERROR-level logging message reporting that PyROS encountered an evaluation error, and including the names and values of all variables of the separation model (including variables representing uncertain parameters) that appear in the expression
- Reraise the exception

## Changes proposed in this PR:

See above.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
