### PR TITLE
Update Viewer for PyQt6, improve load time

### DIFF
--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -168,8 +168,12 @@ class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
         self.treeView.setModel(datmodel)
         self.treeView.setColumnWidth(0, 400)
         # Selection behavior: select a whole row, can select multiple rows.
-        self.treeView.setSelectionBehavior(myqt.QAbstractItemView.SelectRows)
-        self.treeView.setSelectionMode(myqt.QAbstractItemView.ExtendedSelection)
+        self.treeView.setSelectionBehavior(
+            myqt.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.treeView.setSelectionMode(
+            myqt.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
 
     def refresh(self):
         added = self.datmodel._update_tree()
@@ -595,9 +599,9 @@ class ComponentDataModel(myqt.QAbstractItemModel):
             if isinstance(
                 index.internalPointer().data, (Block, Block._ComponentDataClass)
             ):
-                return myqt.QColor(myqt.QtCore.Qt.black)
+                return myqt.QColor(myqt.QtCore.Qt.GlobalColor.black)
             else:
-                return myqt.QColor(myqt.QtCore.Qt.blue)
+                return myqt.QColor(myqt.QtCore.Qt.GlobalColor.blue)
         else:
             return
 

--- a/pyomo/contrib/viewer/pyomo_qtapp.py
+++ b/pyomo/contrib/viewer/pyomo_qtapp.py
@@ -20,11 +20,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import qtconsole.qtconsoleapp
 import pyomo.contrib.viewer.qt as myqt
+from pyomo.contrib.viewer.pyomo_viewer import qtconsole_app, qtconsole_available
 
 
-class QtApp(qtconsole.qtconsoleapp.JupyterQtConsoleApp):
+class QtApp(qtconsole_app.JupyterQtConsoleApp if qtconsole_available else object):
     _kernel_cmd_show_ui = """try:
     ui.show()
 except NameError:

--- a/pyomo/contrib/viewer/pyomo_qtapp.py
+++ b/pyomo/contrib/viewer/pyomo_qtapp.py
@@ -1,0 +1,107 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2025
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  ___________________________________________________________________________
+#
+#  This module was originally developed as part of the IDAES PSE Framework
+#
+#  Institute for the Design of Advanced Energy Systems Process Systems
+#  Engineering Framework (IDAES PSE Framework) Copyright (c) 2018-2019, by the
+#  software owners: The Regents of the University of California, through
+#  Lawrence Berkeley National Laboratory,  National Technology & Engineering
+#  Solutions of Sandia, LLC, Carnegie Mellon University, West Virginia
+#  University Research Corporation, et al. All rights reserved.
+#
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import qtconsole.qtconsoleapp
+import pyomo.contrib.viewer.qt as myqt
+
+
+class QtApp(qtconsole.qtconsoleapp.JupyterQtConsoleApp):
+    _kernel_cmd_show_ui = """try:
+    ui.show()
+except NameError:
+    try:
+        model
+    except NameError:
+        model=None
+    ui = get_mainwindow(model=model, ask_close=False)
+ui.setWindowTitle('Pyomo Model Viewer -- {}')"""
+
+    _kernel_cmd_hide_ui = """try:
+    ui.hide()
+except NameError:
+    pass"""
+
+    _kernel_cmd_import_qt_magic = r"%gui qt"
+
+    _kernel_cmd_import_ui = "from pyomo.contrib.viewer.ui import get_mainwindow"
+
+    _kernel_cmd_import_pyomo_env = "import pyomo.environ as pyo"
+
+    def active_widget_name(self):
+        current_widget = self.window.tab_widget.currentWidget()
+        current_widget_index = self.window.tab_widget.indexOf(current_widget)
+        return self.window.tab_widget.tabText(current_widget_index).replace("'", '"')
+
+    def show_ui(self):
+        kc = self.window.active_frontend.kernel_client
+        kc.execute(
+            self._kernel_cmd_show_ui.format(self.active_widget_name()), silent=True
+        )
+
+    def hide_ui(self):
+        kc = self.window.active_frontend.kernel_client
+        kc.execute(self._kernel_cmd_hide_ui, silent=True)
+
+    def run_script(self, checked=False, filename=None):
+        """Run a python script in the current kernel."""
+        if filename is None:
+            # Show a dialog box for user to select working directory
+            filename = myqt.QtWidgets.QFileDialog.getOpenFileName(
+                self.window,
+                "Run Script",
+                os.getcwd(),
+                "py (*.py);;text (*.txt);;all (*)",
+            )
+            if filename[0]:  # returns a tuple of file and filter or ("","")
+                filename = filename[0]
+            else:
+                filename = None
+        # Run script if one was selected
+        if filename is not None:
+            kc = self.window.active_frontend.kernel_client
+            kc.execute("%run {}".format(filename))
+
+    def kernel_pyomo_init(self, kc):
+        kc.execute(self._kernel_cmd_import_qt_magic, silent=True)
+        kc.execute(self._kernel_cmd_import_ui, silent=True)
+        kc.execute(self._kernel_cmd_import_pyomo_env, silent=False)
+
+    def init_qt_elements(self):
+        super().init_qt_elements()
+        self.kernel_pyomo_init(self.widget.kernel_client)
+        self.run_script_act = myqt.QAction("&Run Script...", self.window)
+        self.show_ui_act = myqt.QAction("&Show Pyomo Model Viewer", self.window)
+        self.hide_ui_act = myqt.QAction("&Hide Pyomo Model Viewer", self.window)
+        self.window.file_menu.addSeparator()
+        self.window.file_menu.addAction(self.run_script_act)
+        self.window.view_menu.addSeparator()
+        self.window.view_menu.addAction(self.show_ui_act)
+        self.window.view_menu.addAction(self.hide_ui_act)
+        self.window.view_menu.addSeparator()
+        self.run_script_act.triggered.connect(self.run_script)
+        self.show_ui_act.triggered.connect(self.show_ui)
+        self.hide_ui_act.triggered.connect(self.hide_ui)
+
+    def new_frontend_master(self):
+        widget = super().new_frontend_master()
+        self.kernel_pyomo_init(widget.kernel_client)
+        return widget

--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -20,109 +20,35 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import os
-
-from pyomo.common.dependencies import attempt_import, UnavailableClass
+from pyomo.common.dependencies import attempt_import
+from pyomo.common.deprecation import relocated_module_attribute
 from pyomo.scripting.pyomo_parser import add_subparser
-import pyomo.contrib.viewer.qt as myqt
 
-qtconsole_app, qtconsole_available = attempt_import("qtconsole.qtconsoleapp")
-
-
-class QtApp(
-    qtconsole_app.JupyterQtConsoleApp
-    if qtconsole_available
-    else UnavailableClass(qtconsole_app)
-):
-    _kernel_cmd_show_ui = """try:
-    ui.show()
-except NameError:
-    try:
-        model
-    except NameError:
-        model=None
-    ui = get_mainwindow(model=model, ask_close=False)
-ui.setWindowTitle('Pyomo Model Viewer -- {}')"""
-
-    _kernel_cmd_hide_ui = """try:
-    ui.hide()
-except NameError:
-    pass"""
-
-    _kernel_cmd_import_qt_magic = r"%gui qt"
-
-    _kernel_cmd_import_ui = "from pyomo.contrib.viewer.ui import get_mainwindow"
-
-    _kernel_cmd_import_pyomo_env = "import pyomo.environ as pyo"
-
-    def active_widget_name(self):
-        current_widget = self.window.tab_widget.currentWidget()
-        current_widget_index = self.window.tab_widget.indexOf(current_widget)
-        return self.window.tab_widget.tabText(current_widget_index)
-
-    def show_ui(self):
-        kc = self.window.active_frontend.kernel_client
-        kc.execute(
-            self._kernel_cmd_show_ui.format(self.active_widget_name()), silent=True
-        )
-
-    def hide_ui(self):
-        kc = self.window.active_frontend.kernel_client
-        kc.execute(self._kernel_cmd_hide_ui, silent=True)
-
-    def run_script(self, checked=False, filename=None):
-        """Run a python script in the current kernel."""
-        if filename is None:
-            # Show a dialog box for user to select working directory
-            filename = myqt.QtWidgets.QFileDialog.getOpenFileName(
-                self.window,
-                "Run Script",
-                os.getcwd(),
-                "py (*.py);;text (*.txt);;all (*)",
-            )
-            if filename[0]:  # returns a tuple of file and filter or ("","")
-                filename = filename[0]
-            else:
-                filename = None
-        # Run script if one was selected
-        if filename is not None:
-            kc = self.window.active_frontend.kernel_client
-            kc.execute("%run {}".format(filename))
-
-    def kernel_pyomo_init(self, kc):
-        kc.execute(self._kernel_cmd_import_qt_magic, silent=True)
-        kc.execute(self._kernel_cmd_import_ui, silent=True)
-        kc.execute(self._kernel_cmd_import_pyomo_env, silent=False)
-
-    def init_qt_elements(self):
-        super().init_qt_elements()
-        self.kernel_pyomo_init(self.widget.kernel_client)
-        self.run_script_act = myqt.QAction("&Run Script...", self.window)
-        self.show_ui_act = myqt.QAction("&Show Pyomo Model Viewer", self.window)
-        self.hide_ui_act = myqt.QAction("&Hide Pyomo Model Viewer", self.window)
-        self.window.file_menu.addSeparator()
-        self.window.file_menu.addAction(self.run_script_act)
-        self.window.view_menu.addSeparator()
-        self.window.view_menu.addAction(self.show_ui_act)
-        self.window.view_menu.addAction(self.hide_ui_act)
-        self.window.view_menu.addSeparator()
-        self.run_script_act.triggered.connect(self.run_script)
-        self.show_ui_act.triggered.connect(self.show_ui)
-        self.hide_ui_act.triggered.connect(self.hide_ui)
-
-    def new_frontend_master(self):
-        widget = super().new_frontend_master()
-        self.kernel_pyomo_init(widget.kernel_client)
-        return widget
+relocated_module_attribute(
+    'QtApp', 'pyomo.contrib.viewer.pyomo_qtapp.QtApp', version='6.9.3.dev0'
+)
 
 
 def main(*args):
+    # Import the Qt infrastructure (if it exists)
+    qtconsole_app, qtconsole_available = attempt_import(
+        "qtconsole.qtconsoleapp", defer_import=False
+    )
+    import pyomo.contrib.viewer.qt as myqt
+
     if not myqt.available or not qtconsole_available:
         errors = list(myqt.import_errors)
         if not qtconsole_available:
             errors.append(qtconsole_app._moduleunavailable_message())
         print("qt not available\n    " + "\n    ".join(errors))
         return
+
+    # Ensure that all Pyomo plugins have been registered
+    import pyomo.environ
+
+    # Import & run the Qt application
+    from pyomo.contrib.viewer.pyomo_qtapp import QtApp
+
     QtApp.launch_instance()
 
 
@@ -134,3 +60,6 @@ add_subparser(
     add_help=False,
     description="This runs the Pyomo model viewer",
 )
+
+if __name__ == '__main__':
+    main()

--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -28,12 +28,13 @@ relocated_module_attribute(
     'QtApp', 'pyomo.contrib.viewer.pyomo_qtapp.QtApp', version='6.9.3.dev0'
 )
 
+qtconsole_app, qtconsole_available = attempt_import(
+    "qtconsole.qtconsoleapp", defer_import=False
+)
+
 
 def main(*args):
     # Import the Qt infrastructure (if it exists)
-    qtconsole_app, qtconsole_available = attempt_import(
-        "qtconsole.qtconsoleapp", defer_import=False
-    )
     import pyomo.contrib.viewer.qt as myqt
 
     if not myqt.available or not qtconsole_available:

--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -48,6 +48,7 @@ for module_str in supported:
         available = module_str
         break
     except Exception as e:
+        qt_package = QtWidgets = QtCore = QtGui = None
         import_errors.append(f"{e}")
 
 if not available:
@@ -103,7 +104,6 @@ if not available:
 else:
     QAbstractItemView = QtWidgets.QAbstractItemView
     QFileDialog = QtWidgets.QFileDialog
-    QMainWindow = QtWidgets.QMainWindow
     QMainWindow = QtWidgets.QMainWindow
     QMdiArea = QtWidgets.QMdiArea
     QApplication = QtWidgets.QApplication

--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -26,18 +26,26 @@ try PyQt5 if that doesn't work. If no compatible Qt Python interface is found,
 use some dummy classes to allow some testing.
 """
 __author__ = "John Eslick"
-
+import sys
 import enum
 import importlib
 
+from pyomo.common.collections import Bunch
 from pyomo.common.flags import building_documentation
 
 # Supported Qt wrappers in preferred order
-supported = ["PySide6", "PyQt5"]
+supported = ["PySide6", "PyQt6", "PyQt5"]
 # Import errors encountered, delay logging for testing reasons
 import_errors = []
 # Set this to the Qt wrapper module is available
 available = False
+
+# You can only have one Qt interface loaded at a time.  If something
+# like IPython has already loaded an interface, then we will use that
+# one.
+_loaded = list(filter(sys.modules.__contains__, supported))
+if _loaded:
+    supported = _loaded
 
 for module_str in supported:
     try:
@@ -119,17 +127,31 @@ else:
     QColor = QtGui.QColor
     QAbstractItemModel = QtCore.QAbstractItemModel
     QAbstractTableModel = QtCore.QAbstractTableModel
-    QMetaType = QtCore.QMetaType
     Qt = QtCore.Qt
+    QMetaType = Bunch()
     if available == "PySide6":
         from PySide6.QtGui import QAction
         from PySide6.QtCore import Signal
         from PySide6 import QtUiTools as uic
+
+        QMetaType.Int = QtCore.QMetaType.Type.Int.value
+        QMetaType.Double = QtCore.QMetaType.Type.Double.value
+    elif available == "PyQt6":
+        from PyQt6.QtGui import QAction
+        from PyQt6.QtCore import pyqtSignal as Signal
+        from PyQt6 import uic
+
+        QMetaType.Int = QtCore.QMetaType.Type.Int.value
+        QMetaType.Double = QtCore.QMetaType.Type.Double.value
     elif available == "PyQt5":
         from PyQt5.QtWidgets import QAction
         from PyQt5.QtCore import pyqtSignal as Signal
         from PyQt5 import uic
 
+        QMetaType.Int = QtCore.QMetaType.Type.Int
+        QMetaType.Double = QtCore.QMetaType.Type.Double
+    else:
+        raise RuntimeError(f"Unknown Qt engine: {available}")
     # Note that QAbstractTableModel and QAbstractItemModel have
     # signatures that are not parsable by Sphinx, so we will hide them
     # if we are building the API documentation.

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -164,13 +164,13 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self.actionTabs.triggered.connect(self.toggle_tabs)
         self._dialog = None  # dialog displayed so can access it easier for tests
         self._dialog_test_button = None  # button clicked on dialog in test mode
-        self.mdiArea.setViewMode(myqt.QMdiArea.TabbedView)
+        self.mdiArea.setViewMode(myqt.QMdiArea.ViewMode.TabbedView)
 
     def toggle_tabs(self):
-        if self.mdiArea.viewMode() == myqt.QMdiArea.SubWindowView:
-            self.mdiArea.setViewMode(myqt.QMdiArea.TabbedView)
-        elif self.mdiArea.viewMode() == myqt.QMdiArea.TabbedView:
-            self.mdiArea.setViewMode(myqt.QMdiArea.SubWindowView)
+        if self.mdiArea.viewMode() == myqt.QMdiArea.ViewMode.SubWindowView:
+            self.mdiArea.setViewMode(myqt.QMdiArea.ViewMode.TabbedView)
+        elif self.mdiArea.viewMode() == myqt.QMdiArea.ViewMode.TabbedView:
+            self.mdiArea.setViewMode(myqt.QMdiArea.ViewMode.SubWindowView)
         else:
             # There are no other modes unless there is a change in Qt so pass
             pass
@@ -277,7 +277,7 @@ class MainWindow(_MainWindow, _MainWindowUI):
                 cons, active_eq, free_vars, dof, doftext
             )
         )
-        msg.setStandardButtons(myqt.QMessageBox.Ok)
+        msg.setStandardButtons(myqt.QMessageBox.StandardButton.Ok)
         msg.setModal(False)
         msg.show()
 
@@ -326,18 +326,20 @@ class MainWindow(_MainWindow, _MainWindowUI):
             return
         msg = myqt.QMessageBox()
         self._dialog = msg
-        msg.setIcon(myqt.QMessageBox.Question)
+        msg.setIcon(myqt.QMessageBox.Icon.Question)
         msg.setText(
             "Are you sure you want to close this window?"
             " You can reopen it with ui.show()."
         )
         msg.setWindowTitle("Close?")
-        msg.setStandardButtons(myqt.QMessageBox.Yes | myqt.QMessageBox.No)
+        msg.setStandardButtons(
+            myqt.QMessageBox.StandardButton.Yes | myqt.QMessageBox.StandardButton.No
+        )
         if self.testing:  # don't even show dialog just pretend button clicked
             result = self._dialog_test_button
         else:
-            result = msg.exec_()
-        if result == myqt.QMessageBox.Yes:
+            result = msg.exec()
+        if result == myqt.QMessageBox.StandardButton.Yes:
             event.accept()
         else:
             event.ignore()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The implementation of the Model Viewer's extension point for the `pyomo` command caused Qt (and all the dependent libraries) to be imported when the `pyomo` command loaded the `pyomo.command` extension points (taking nearly 14 seconds!).  This PR reworks the extension point so that Qt (et al.) are not imported when initializing the `pyomo` script environment.

This PR also adds support for using PyQt6 (in addition to PySide6 and PyQt5).

## Changes proposed in this PR:
- Rework how the model Viewer is registered with the Pyomo command (split the QtApp out from the command registration)
- Add support for PyQt6

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
