### PR TITLE
Make exporting of PyROS subproblems more customizable

### DIFF
--- a/pyomo/contrib/pyros/config.py
+++ b/pyomo/contrib/pyros/config.py
@@ -855,6 +855,23 @@ def pyros_config():
             ),
         ),
     )
+    CONFIG.declare(
+        "subproblem_format_options",
+        ConfigValue(
+            default={"bar": {"symbolic_solver_labels": True}},
+            domain=dict,
+            description=(
+                """
+                File format options for writing/exporting subproblems
+                that were not solved to an acceptable level.
+                Each entry of the dict should map a Pyomo WriterFactory
+                format (e.g., 'bar' for BARON, 'gams' for GAMS)
+                to a value for the argument ``io_options``
+                to the method ``BlockData.write()``.
+                """
+            ),
+        ),
+    )
 
     # ================================================
     # === Advanced Options

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -13,8 +13,6 @@
 Functions for construction and solution of the PyROS master problem.
 """
 
-import os
-
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.common.modeling import unique_component_name
 from pyomo.core import TransformationFactory
@@ -37,6 +35,7 @@ from pyomo.contrib.pyros.util import (
     ObjectiveType,
     pyrosTerminationCondition,
     TIC_TOC_SOLVE_TIME_ATTR,
+    write_subproblem,
 )
 
 
@@ -828,31 +827,8 @@ def solver_call_master(master_data):
 
     # all solvers have failed to return an acceptable status.
     # we will terminate PyROS with subsolver error status.
-    # at this point, export subproblem to file, if desired.
-    # NOTE: subproblem is written with variables set to their
-    #       initial values (not the final subsolver iterate)
-    save_dir = config.subproblem_file_directory
-    serialization_msg = ""
-    if save_dir and config.keepfiles:
-        output_problem_path = os.path.join(
-            save_dir,
-            (
-                config.uncertainty_set.type
-                + "_"
-                + master_data.original_model_name
-                + "_master_"
-                + str(master_data.iteration)
-                + ".bar"
-            ),
-        )
-        master_model.write(
-            output_problem_path, io_options={'symbolic_solver_labels': True}
-        )
-        serialization_msg = (
-            " For debugging, problem has been serialized to the file "
-            f"{output_problem_path!r}."
-        )
 
+    # log subproblem solve failure warning
     deterministic_model_qual = (
         " (i.e., the deterministic model)" if master_data.iteration == 0 else ""
     )
@@ -867,7 +843,6 @@ def solver_call_master(master_data):
         if master_data.iteration == 0
         else ""
     )
-
     master_soln.pyros_termination_condition = pyrosTerminationCondition.subsolver_error
     subsolver_termination_conditions = [
         res.solver.termination_condition for res in master_soln.master_results_list
@@ -879,8 +854,21 @@ def solver_call_master(master_data):
         f"(Termination statuses: "
         f"{[term_cond for term_cond in subsolver_termination_conditions]}.)"
         f"{deterministic_msg}"
-        f"{serialization_msg}"
     )
+
+    # at this point, export subproblem to file, if desired.
+    # NOTE: subproblem is written with variables set to their
+    #       initial values (not the final subsolver iterate)
+    if config.keepfiles and config.subproblem_file_directory is not None:
+        write_subproblem(
+            model=master_model,
+            fname=(
+                f"{config.uncertainty_set.type}"
+                f"_{master_data.original_model_name}"
+                f"_master_{master_data.iteration}"
+            ),
+            config=config,
+        )
 
     return master_soln
 

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -15,7 +15,6 @@ and related objects.
 """
 
 from itertools import product
-import os
 
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.common.dependencies import numpy as np
@@ -39,6 +38,7 @@ from pyomo.contrib.pyros.util import (
     call_solver,
     check_time_limit_reached,
     get_all_first_stage_eq_cons,
+    write_subproblem,
 )
 
 
@@ -1097,30 +1097,6 @@ def solver_call_separation(
     # termination condition. PyROS will terminate with subsolver
     # error. At this point, export model if desired
     solve_call_results.subsolver_error = True
-    save_dir = config.subproblem_file_directory
-    serialization_msg = ""
-    if save_dir and config.keepfiles:
-        objective = separation_obj.name
-        output_problem_path = os.path.join(
-            save_dir,
-            (
-                config.uncertainty_set.type
-                + "_"
-                + separation_model.name
-                + "_separation_"
-                + str(separation_data.iteration)
-                + "_obj_"
-                + objective
-                + ".bar"
-            ),
-        )
-        separation_model.write(
-            output_problem_path, io_options={'symbolic_solver_labels': True}
-        )
-        serialization_msg = (
-            " For debugging, problem has been serialized to the file "
-            f"{output_problem_path!r}."
-        )
     solve_call_results.message = (
         "Could not successfully solve separation problem of iteration "
         f"{separation_data.iteration} "
@@ -1128,9 +1104,19 @@ def solver_call_separation(
         f"provided subordinate {solve_mode} optimizers. "
         f"(Termination statuses: "
         f"{[str(term_cond) for term_cond in solver_status_dict.values()]}.)"
-        f"{serialization_msg}"
     )
     config.progress_logger.warning(solve_call_results.message)
+
+    if config.keepfiles and config.subproblem_file_directory is not None:
+        write_subproblem(
+            model=separation_model,
+            fname=(
+                f"{config.uncertainty_set.type}_{separation_model.name}"
+                f"_separation_{separation_data.iteration}"
+                f"_obj_{separation_obj.name}"
+            ),
+            config=config,
+        )
 
     separation_obj.deactivate()
 

--- a/pyomo/contrib/pyros/tests/test_config.py
+++ b/pyomo/contrib/pyros/tests/test_config.py
@@ -32,7 +32,7 @@ from pyomo.contrib.pyros.config import (
     SolverResolvable,
 )
 from pyomo.contrib.pyros.util import ObjectiveType
-from pyomo.opt import SolverFactory, SolverResults
+from pyomo.opt import SolverFactory, SolverResults, WriterFactory
 
 
 class TestInputDataStandardizer(unittest.TestCase):
@@ -695,6 +695,34 @@ class TestPyROSConfig(unittest.TestCase):
         exc_str = f".*{invalid_focus!r} is not a valid ObjectiveType"
         with self.assertRaisesRegex(ValueError, exc_str):
             config.objective_focus = invalid_focus
+
+    def test_config_subproblem_formats(self):
+        config = self.CONFIG()
+
+        # test default
+        self.assertEqual(
+            config.subproblem_format_options,
+            {"bar": {"symbolic_solver_labels": True}},
+            msg=(
+                "Default value for PyROS config option "
+                "subproblem_format_options' not as expected."
+            ),
+        )
+
+        config.subproblem_format_options = {}
+        self.assertEqual(config.subproblem_format_options, {})
+
+        nondefault_test_val = {"fmt1": {"symbolic_solver_labels": False}, "fmt2": {}}
+        config.subproblem_format_options = nondefault_test_val
+        self.assertEqual(config.subproblem_format_options, nondefault_test_val)
+
+        # anything castable to dict should also be acceptable
+        config.subproblem_format_options = list(nondefault_test_val.items())
+        self.assertEqual(config.subproblem_format_options, nondefault_test_val)
+
+        exc_str = "cannot convert dictionary update sequence.*"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            config.subproblem_format_options = [1, 2, 3]
 
 
 class TestPositiveIntOrMinusOne(unittest.TestCase):

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -3712,12 +3712,11 @@ class TestPyROSSubproblemWriter(unittest.TestCase):
                 keepfiles=True,
                 subproblem_file_directory=tmpdir,
                 subproblem_format_options={
-                    "bar": {}, "gams": {"symbolic_solver_labels": True}
+                    "bar": {},
+                    "gams": {"symbolic_solver_labels": True},
                 },
             )
-            expected_subproblem_file = os.path.join(
-                tmpdir, "box_unknown_master_0"
-            )
+            expected_subproblem_file = os.path.join(tmpdir, "box_unknown_master_0")
             format_files_exist_dict = {
                 "bar": os.path.exists(f"{expected_subproblem_file}.bar"),
                 "gams": os.path.exists(f"{expected_subproblem_file}.gams"),
@@ -3727,23 +3726,22 @@ class TestPyROSSubproblemWriter(unittest.TestCase):
         self.assertTrue(format_files_exist_dict["gams"])
         self.assertEqual(res.iterations, 1)
         self.assertEqual(
-            res.pyros_termination_condition,
-            pyrosTerminationCondition.subsolver_error,
+            res.pyros_termination_condition, pyrosTerminationCondition.subsolver_error
         )
 
     @unittest.skipUnless(baron_available, "BARON not available.")
     def test_separation_problem_failure(self):
         m = build_leyffer()
         subproblem_format_options = {
-            "bar": {}, "gams": {"symbolic_solver_labels": True}
+            "bar": {},
+            "gams": {"symbolic_solver_labels": True},
         }
 
         with TempfileManager.new_context() as TMP:
             tmpdir = TMP.create_tempdir()
             expected_subproblem_filenames = [
                 os.path.join(
-                    tmpdir,
-                    f"box_unknown_separation_0_obj_separation_obj_0.{fmt}",
+                    tmpdir, f"box_unknown_separation_0_obj_separation_obj_0.{fmt}"
                 )
                 for fmt in subproblem_format_options.keys()
             ]
@@ -3769,13 +3767,11 @@ class TestPyROSSubproblemWriter(unittest.TestCase):
 
         for fname, file_created in subproblem_files_created.items():
             self.assertTrue(
-                file_created,
-                msg=f"Subproblem was not written to file {fname}.",
+                file_created, msg=f"Subproblem was not written to file {fname}."
             )
         self.assertEqual(res.iterations, 1)
         self.assertEqual(
-            res.pyros_termination_condition,
-            pyrosTerminationCondition.subsolver_error,
+            res.pyros_termination_condition, pyrosTerminationCondition.subsolver_error
         )
 
 

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -3695,7 +3695,7 @@ class TestPyROSSubproblemWriter(unittest.TestCase):
     """
 
     @unittest.skipUnless(baron_available, "BARON not available.")
-    def test_master_problem_failure(self):
+    def test_pyros_write_master_problem(self):
         m = build_leyffer()
 
         with TempfileManager.new_context() as TMP:
@@ -3730,7 +3730,7 @@ class TestPyROSSubproblemWriter(unittest.TestCase):
         )
 
     @unittest.skipUnless(baron_available, "BARON not available.")
-    def test_separation_problem_failure(self):
+    def test_pyros_write_separation_problem(self):
         m = build_leyffer()
         subproblem_format_options = {
             "bar": {},

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -15,6 +15,7 @@ Tests for the PyROS solver.
 
 import logging
 import math
+import os
 import time
 
 import pyomo.common.unittest as unittest
@@ -32,6 +33,7 @@ from pyomo.common.dependencies import (
     scipy_available,
 )
 from pyomo.common.errors import ApplicationError, InfeasibleConstraintException
+from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.expr import replace_expressions
 from pyomo.environ import assert_optimal_termination, maximize as pyo_max, units as u
 from pyomo.opt import (
@@ -3399,6 +3401,7 @@ class TestPyROSSolverLogIntros(unittest.TestCase):
             " backup_local_solvers=[]\n"
             " backup_global_solvers=[]\n"
             " subproblem_file_directory=None\n"
+            " subproblem_format_options={'bar': {'symbolic_solver_labels': True}}\n"
             " bypass_local_separation=False\n"
             " bypass_global_separation=False\n"
             " p_robustness={}\n" + "-" * 78 + "\n"
@@ -3683,6 +3686,97 @@ class SimpleTestSolver:
         res.solver.termination_condition = TerminationCondition.unknown
 
         return res
+
+
+class TestPyROSSubproblemWriter(unittest.TestCase):
+    """
+    Test PyROS subproblem writers behave as expected when
+    solution of a subproblem fails.
+    """
+
+    @unittest.skipUnless(baron_available, "BARON not available.")
+    def test_master_problem_failure(self):
+        m = build_leyffer()
+
+        with TempfileManager.new_context() as TMP:
+            tmpdir = TMP.create_tempdir()
+            res = SolverFactory("pyros").solve(
+                model=m,
+                first_stage_variables=[m.x1, m.x2],
+                second_stage_variables=[],
+                uncertain_params=[m.u],
+                uncertainty_set=BoxSet([[1, 2]]),
+                local_solver=SimpleTestSolver(),
+                global_solver=SolverFactory("baron"),
+                solve_master_globally=False,
+                keepfiles=True,
+                subproblem_file_directory=tmpdir,
+                subproblem_format_options={
+                    "bar": {}, "gams": {"symbolic_solver_labels": True}
+                },
+            )
+            expected_subproblem_file = os.path.join(
+                tmpdir, "box_unknown_master_0"
+            )
+            format_files_exist_dict = {
+                "bar": os.path.exists(f"{expected_subproblem_file}.bar"),
+                "gams": os.path.exists(f"{expected_subproblem_file}.gams"),
+            }
+
+        self.assertTrue(format_files_exist_dict["bar"])
+        self.assertTrue(format_files_exist_dict["gams"])
+        self.assertEqual(res.iterations, 1)
+        self.assertEqual(
+            res.pyros_termination_condition,
+            pyrosTerminationCondition.subsolver_error,
+        )
+
+    @unittest.skipUnless(baron_available, "BARON not available.")
+    def test_separation_problem_failure(self):
+        m = build_leyffer()
+        subproblem_format_options = {
+            "bar": {}, "gams": {"symbolic_solver_labels": True}
+        }
+
+        with TempfileManager.new_context() as TMP:
+            tmpdir = TMP.create_tempdir()
+            expected_subproblem_filenames = [
+                os.path.join(
+                    tmpdir,
+                    f"box_unknown_separation_0_obj_separation_obj_0.{fmt}",
+                )
+                for fmt in subproblem_format_options.keys()
+            ]
+
+            res = SolverFactory("pyros").solve(
+                model=m,
+                first_stage_variables=[m.x1, m.x2],
+                second_stage_variables=[],
+                uncertain_params=[m.u],
+                uncertainty_set=BoxSet([[1, 2]]),
+                local_solver=SimpleTestSolver(),
+                global_solver=SolverFactory("baron"),
+                solve_master_globally=True,
+                bypass_global_separation=True,
+                keepfiles=True,
+                subproblem_file_directory=tmpdir,
+                subproblem_format_options=subproblem_format_options,
+            )
+
+            subproblem_files_created = {
+                fname: os.path.exists(fname) for fname in expected_subproblem_filenames
+            }
+
+        for fname, file_created in subproblem_files_created.items():
+            self.assertTrue(
+                file_created,
+                msg=f"Subproblem was not written to file {fname}.",
+            )
+        self.assertEqual(res.iterations, 1)
+        self.assertEqual(
+            res.pyros_termination_condition,
+            pyrosTerminationCondition.subsolver_error,
+        )
 
 
 class TestPyROSSolverAdvancedValidation(unittest.TestCase):

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -21,6 +21,7 @@ import functools
 import itertools as it
 import logging
 import math
+import os
 import timeit
 
 from pyomo.common.collections import ComponentMap, ComponentSet
@@ -3182,6 +3183,31 @@ def load_final_solution(model_data, master_soln, original_user_var_partitioning)
     )
     for orig_var, master_blk_var in zip(original_model_vars, master_soln_vars):
         orig_var.set_value(master_blk_var.value, skip_validation=True)
+
+
+def write_subproblem(model, fname, config):
+    """
+    Write/export a subproblem to one or more files.
+
+    Parameters
+    ----------
+    model : ConcreteModel
+        Subproblem to be written/exported.
+    fname : str
+        Base name of the file(s) to be written.
+        Should not include any prefix directories.
+    config : ConfigDict
+        PyROS solver options.
+        A file will be written for each format provided in
+        ``config.subproblem_format_options``,
+        and in the directory ``config.subproblem_file_directory``.
+    """
+    for fmt, io_options in config.subproblem_format_options.items():
+        full_filename = os.path.join(config.subproblem_file_directory, f"{fname}.{fmt}")
+        model.write(filename=full_filename, format=fmt)
+        config.progress_logger.warning(
+            f"For debugging, subproblem has been written to the file {full_filename!r}."
+        )
 
 
 def call_solver(model, solver, config, timing_obj, timer_name, err_msg):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:

The PyROS solver provides two optional arguments `keepfiles` and `subproblem_file_directory` for specifying whether and where subproblems that were not solved to an acceptable level are to be written. However, when subproblems are written, they are exclusively written in `'bar'` format. Other formats (`'gams'`, `'nl'`, etc.) may be of interest to the user.

## Changes proposed in this PR:
- Add a new optional PyROS solver argument `subproblem_format_options`. This argument should be (castable to) a `dict` object, of which each entry maps a Pyomo `WriterFactory` format (e.g., `'bar'`, `'gams'`) to a value for the argument `io_options` to `BlockData.write()`.
- Add tests to check that PyROS writes subproblems as expected.

## TODO (after #3646 merged)
- [ ] Update version number, changelog

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
