### PR TITLE
Add independent variable rows to sensitivity toolbox Pynumero-based sensitivity calcs

### DIFF
--- a/pyomo/contrib/sensitivity_toolbox/pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/pynumero.py
@@ -98,6 +98,18 @@ def get_dsdp_dfdp(model, theta):
     _coo_reorder_cols(dfdx, remap=col_remap)
     dfdx = dfdx.tocsc()
     dfdp = dfdx[0, :ns] @ dsdp + dfdx[0, ns:]
+
+    # Add independent variables to the rows as the end
+    dsdp = scipy.sparse.vstack(
+        [
+            dsdp,
+            scipy.sparse.identity(len(column_map), format="csc"),
+        ]
+    )
+    n = len(row_map)
+    for p, i in column_map.items():
+        row_map[p] = i + n
+
     # return sensitivity of the outputs to p and component maps
     return dsdp, dfdp, row_map, column_map
 

--- a/pyomo/contrib/sensitivity_toolbox/pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/pynumero.py
@@ -62,7 +62,7 @@ def get_dsdp_dfdp(model, theta):
     Returns
     -------
     scipy.sparse.csc_matrix, csc_matrix, ComponentMap, ComponentMap
-        ds/dp (ns by np), df/dp (1 by np), row map, column map.
+        ds/dp (ns + np by np), df/dp (1 by np), row map, column map.
         The column map maps Pyomo variables p to columns and the
         row map maps Pyomo variables s to rows.
     """
@@ -101,10 +101,7 @@ def get_dsdp_dfdp(model, theta):
 
     # Add independent variables to the rows as the end
     dsdp = scipy.sparse.vstack(
-        [
-            dsdp,
-            scipy.sparse.identity(len(column_map), format="csc"),
-        ]
+        [dsdp, scipy.sparse.identity(len(column_map), format="csc")]
     )
     n = len(row_map)
     for p, i in column_map.items():

--- a/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
@@ -83,7 +83,6 @@ class TestSeriesData(unittest.TestCase):
         np.testing.assert_almost_equal(dsdp[rmap[m.p1], cmap[m.p1]], 1.0)
         np.testing.assert_almost_equal(dsdp[rmap[m.p2], cmap[m.p1]], 0.0)
 
-
         # if x1 = 2 * p1 and x2 = p2 then
         #   df/dp1 = 6 p1**2 + p2 = 45.0
         #   df/dp2 = 3 p2 + p1 = 85.0

--- a/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
@@ -73,11 +73,16 @@ class TestSeriesData(unittest.TestCase):
         dsdp, dfdp, rmap, cmap = pnsens.get_dsdp_dfdp(m2, theta)
 
         # Since x1 = p1
-        assert dsdp.shape == (2, 2)
+        assert dsdp.shape == (4, 2)
         np.testing.assert_almost_equal(dsdp[rmap[m.x1], cmap[m.p1]], 40.0)
         np.testing.assert_almost_equal(dsdp[rmap[m.x1], cmap[m.p2]], 0.0)
         np.testing.assert_almost_equal(dsdp[rmap[m.x2], cmap[m.p1]], 0.0)
         np.testing.assert_almost_equal(dsdp[rmap[m.x2], cmap[m.p2]], 1.0)
+        np.testing.assert_almost_equal(dsdp[rmap[m.p1], cmap[m.p2]], 0.0)
+        np.testing.assert_almost_equal(dsdp[rmap[m.p2], cmap[m.p2]], 1.0)
+        np.testing.assert_almost_equal(dsdp[rmap[m.p1], cmap[m.p1]], 1.0)
+        np.testing.assert_almost_equal(dsdp[rmap[m.p2], cmap[m.p1]], 0.0)
+
 
         # if x1 = 2 * p1 and x2 = p2 then
         #   df/dp1 = 6 p1**2 + p2 = 45.0


### PR DESCRIPTION
## Summary/Motivation:

Add rows for independent variables to the Pynumero-based sensitivity ds/dp matrix calculation.  Although the rows are trivial (just tacking an identity matrix on the end) they are convenient for some calculations. 

## Changes proposed in this PR:
- Include rows for dp/dp at the end of the ds/dp matrix in the pynumero-based calculation in the sensitivity toolbox. 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
