### PR TITLE
Introduce Retries into `download-extensions`

### DIFF
--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -14,6 +14,8 @@ import sys
 from pyomo.common.download import FileDownloader, DownloadFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
+MAX_RETRIES = 3
+
 
 class GroupDownloader(object):
     def __init__(self):
@@ -35,43 +37,61 @@ class GroupDownloader(object):
         results = []
         result_fmt = "[%s]  %s"
         returncode = 0
+
         self.downloader.cacert = args.cacert
         self.downloader.insecure = args.insecure
+
         logger.info(
-            "As of February 9, 2023, AMPL GSL can no longer be downloaded \
-            through download-extensions. Visit https://portal.ampl.com/ \
-            to download the AMPL GSL binaries."
+            "As of February 9, 2023, AMPL GSL can no longer be downloaded "
+            "through download-extensions. Visit https://portal.ampl.com/ "
+            "to download the AMPL GSL binaries."
         )
+
         for target in DownloadFactory:
-            try:
-                ext = DownloadFactory(target, downloader=self.downloader)
-                if hasattr(ext, 'skip') and ext.skip():
-                    result = 'SKIP'
-                elif hasattr(ext, '__call__'):
-                    ext()
-                    result = ' OK '
-                else:
-                    # Extension was a simple function and already ran
-                    result = ' OK '
-            except SystemExit:
-                _info = sys.exc_info()
-                _cls = (
-                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
-                    + ": "
-                )
-                logger.error(_cls + str(_info[1]))
-                result = 'FAIL'
-                returncode |= 2
-            except:
-                _info = sys.exc_info()
-                _cls = (
-                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
-                    + ": "
-                )
-                logger.error(_cls + str(_info[1]))
-                result = 'FAIL'
-                returncode |= 1
+            attempt = 0
+            result = "FAIL"
+
+            while attempt < MAX_RETRIES:
+                try:
+                    ext = DownloadFactory(target, downloader=self.downloader)
+
+                    if hasattr(ext, "skip") and ext.skip():
+                        result = "SKIP"
+                    elif hasattr(ext, "__call__"):
+                        ext()
+                        result = " OK "
+                    else:
+                        result = " OK "
+
+                    break
+
+                except SystemExit:
+                    _info = sys.exc_info()
+                    _cls = (
+                        f"{_info[0].__name__ if _info[0] is not None else 'NoneType'}: "
+                    )
+                    logger.error(_cls + str(_info[1]))
+                    if attempt + 1 == MAX_RETRIES:
+                        returncode |= 2
+                except Exception:
+                    _info = sys.exc_info()
+                    _cls = (
+                        f"{_info[0].__name__ if _info[0] is not None else 'NoneType'}: "
+                    )
+                    logger.error(_cls + str(_info[1]))
+                    if attempt + 1 == MAX_RETRIES:
+                        returncode |= 1
+                finally:
+                    if result != " OK ":
+                        attempt += 1
+                        if attempt < MAX_RETRIES:
+                            logger.info(
+                                f"Retrying download of '{target}' "
+                                f"({attempt + 1}/{MAX_RETRIES})…"
+                            )
+
             results.append(result_fmt % (result, target))
+
         logger.info("Finished downloading Pyomo extensions.")
         logger.info(
             "The following extensions were downloaded:\n    " + "\n    ".join(results)

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -11,10 +11,12 @@
 
 import logging
 import sys
+import time
 from pyomo.common.download import FileDownloader, DownloadFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
 MAX_RETRIES = 3
+RETRY_SLEEP_SECONDS = 1
 
 
 class GroupDownloader(object):
@@ -89,6 +91,7 @@ class GroupDownloader(object):
                                 f"Retrying download of '{target}' "
                                 f"({attempt + 1}/{MAX_RETRIES})…"
                             )
+                            time.sleep(RETRY_SLEEP_SECONDS)
 
             results.append(result_fmt % (result, target))
 


### PR DESCRIPTION


## Fixes N/A

## Summary/Motivation:
I'm personally losing my mind w.r.t. `download-extensions` because `gjh` is somewhat unreliable lately when downloading (but then will sometimes be fine if you try again). This introduces retries (default 3) into `download-extensions` with a short sleep of 1 second between each one.

## Changes proposed in this PR:
- 3 retries if there is a failure in `download-extension`
- 1 second sleep between retries

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
