### PR TITLE
Add project-level default configuration for black to pyproject.toml

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -44,9 +44,10 @@ jobs:
         python-version: '3.10'
     - name: Black Formatting Check
       run: |
-        # Note v24.4.1 fails due to a bug in the parser
+        # Note v24.4.1 fails due to a bug in the parser. Project-level
+        # configuration is inherited from pyproject.toml.
         pip install 'black!=24.4.1'
-        black . -S -C --check --diff --exclude examples/pyomobook/python-ch/BadIndent.py
+        black . --check --diff
     - name: Spell Check
       uses: crate-ci/typos@master
       with: 

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -55,9 +55,10 @@ jobs:
         python-version: '3.10'
     - name: Black Formatting Check
       run: |
-        # Note v24.4.1 fails due to a bug in the parser
+        # Note v24.4.1 fails due to a bug in the parser. Project-level
+        # configuration is inherited from pyproject.toml.
         pip install 'black!=24.4.1'
-        black . -S -C --check --diff --exclude examples/pyomobook/python-ch/BadIndent.py
+        black . --check --diff
     - name: Spell Check
       uses: crate-ci/typos@master
       with: 

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -37,13 +37,17 @@ run:
 
     # Auto-apply correct formatting
    pip install black
-   black -S -C <path> --exclude examples/pyomobook/python-ch/BadIndent.py
+   black <path>
    # Find typos in files
    conda install typos
    typos --config .github/workflows/typos.toml <path>
    
-If the spell-checker returns a failure for a word that is spelled correctly,
-please add the word to the ``.github/workflows/typos.toml`` file.
+If the spell-checker returns a failure for a word that is spelled
+correctly, please add the word to the ``.github/workflows/typos.toml``
+file. Note also that ``black`` reads from ``pyproject.toml`` to
+determine correct configuration, so if you are running ``black``
+indirectly (for example, using an IDE integration), please ensure you
+are not overriding the project-level configuration set in that file.
 
 Online Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
 with the ``napoleon`` extension enabled. For API documentation we use of one of these 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,9 @@ markers = [
     "bar: marks bar tests",
     "builders: tests that should be run when testing custom (extension) builders",
 ]
+
+[tool.black]
+line-length = 88
+skip-string-normalization = true
+skip-magic-trailing-comma = true
+extend-exclude = 'examples/pyomobook/python-ch/BadIndent.py'


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # (n/a)

## Summary/Motivation:
Make it easier to use black and harder to accidentally mess it up

## Changes proposed in this PR:
Add [tool.black] section to pyproject.toml. This will cause a command-line invocation like `black .` to correctly use Pyomo's black options without needing to set them yourself.

Notes:
 - Black walks up the filesystem looking for this file starting from the file being formatted, so it will still work if you run it from an unrelated working directory
 - You can also set the intended python version, but it infers this anyways based on the requires-python field under [project] above.
 - The difference between exclude and extend-exclude is that with extend-exclude it also excludes gitignored files (which are the default excluded files). This is meaningful because some of our tests generate python code and leave the gitignored, non-black-compliant files behind.
 - It's still possible to mess this up if you set conflicting command-line flags, as they override this. This is most likely to happen if you are using an ide integration and you set a conflicting option there (as this is almost certainly implemented by changing the flags).

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
