### PR TITLE
Mark expected failures for BARON 25.7.16

### DIFF
--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -280,6 +280,20 @@ for prob in ('LP_unbounded', 'LP_unbounded_kernel'):
         lambda v: v[:3] == (22, 1, 19),
         'BARON 22.1.19 reports model as optimal',
     )
+for prob in (
+    'LP_block',
+    'LP_duals_maximize',
+    'LP_duals_minimize',
+    'LP_inactive_index',
+    'LP_simple',
+    'LP_trivial_constraints',
+    'QCP_simple',
+    'QP_simple',
+):
+    ExpectedFailures['baron', 'bar', prob] = (
+        lambda v: v == (25, 7, 16, 0),
+        "BARON 25.7.16 returns 0 for duals/rc for models solved in preprocessing",
+    )
 
 
 #


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
BARON 25.7.16 has a couple regressions for how it processes models that are solved in preprocessing.  This skips those tests for this specific version.  The regressions have been reported upstream, and a new release is expected very soon.

## Changes proposed in this PR:
- Skip several trivial writer tests under BARON 25.7.16

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
