### PR TITLE
Update range of affected BARON versions

### DIFF
--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -291,7 +291,7 @@ for prob in (
     'QP_simple',
 ):
     ExpectedFailures['baron', 'bar', prob] = (
-        lambda v: v == (25, 7, 16, 0),
+        lambda v: (25, 7, 10) <= v[:3] <= (25, 7, 16),
         "BARON 25.7.16 returns 0 for duals/rc for models solved in preprocessing",
     )
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
BARON just pulled 25.7.16 and replaced it with 25.7.10 - which is also affected by the same duals issue.  This PR updates the range of affected BARON versions.

## Changes proposed in this PR:
- Update range of BARON versions to expect test failures.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
