### PR TITLE
Remove Leftover Files After Testing

### DIFF
--- a/pyomo/contrib/sensitivity_toolbox/tests/test_sens_unit.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_sens_unit.py
@@ -9,24 +9,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-# ____________________________________________________________________________
-#
-# Pyomo: Python Optimization Modeling Objects
-# Copyright (c) 2008-2025
-#  National Technology and Engineering Solutions of Sandia, LLC
-# Under the terms of Contract DE-NA0003525 with National Technology and
-# Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
-# rights in this software.
-# This software is distributed under the 3-clause BSD License.
-# ____________________________________________________________________________
-
 """
 Unit Tests for interfacing with sIPOPT and k_aug
 """
 
 import pyomo.common.unittest as unittest
-from io import StringIO
-import logging
 
 from pyomo.environ import (
     ConcreteModel,
@@ -35,7 +22,6 @@ from pyomo.environ import (
     Var,
     Block,
     Suffix,
-    value,
     Constraint,
     inequality,
     NonNegativeReals,
@@ -44,8 +30,8 @@ from pyomo.environ import (
 )
 from pyomo.core.base.component import ComponentData
 from pyomo.common.dependencies import scipy_available
-from pyomo.common.log import LoggingIntercept
 from pyomo.common.collections import ComponentMap, ComponentSet
+from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.expr.visitor import identify_variables, identify_mutable_parameters
 from pyomo.contrib.sensitivity_toolbox.sens import (
     SensitivityInterface,
@@ -860,30 +846,32 @@ class TestSensitivityInterface(unittest.TestCase):
         '''
         It tests the function line_num
         '''
-        import os
 
-        file_name = "test_col.col"
-        with open(file_name, "w") as file:
-            file.write("var1\n")
-            file.write("var3\n")
-        i = line_num(file_name, 'var1')
-        j = line_num(file_name, 'var3')
-        self.assertEqual(i, 1)
-        self.assertEqual(j, 2)
+        with TempfileManager.new_context() as TMP:
+            file_name = TMP.create_tempfile('test_col.col')
+            with open(file_name, "w") as file:
+                file.write("var1\n")
+                file.write("var3\n")
+            i = line_num(file_name, 'var1')
+            j = line_num(file_name, 'var3')
+            self.assertEqual(i, 1)
+            self.assertEqual(j, 2)
 
     def test_line_num2(self):
         '''
         It tests an exception error when file does not include target
         '''
-        import os
 
-        file_name = "test_col.col"
-        with open(file_name, "w") as file:
-            file.write("var1\n")
-            file.write("var3\n")
-        with self.assertRaises(Exception) as context:
-            i = line_num(file_name, 'var2')
-        self.assertTrue('test_col.col does not include var2' in str(context.exception))
+        with TempfileManager.new_context() as TMP:
+            file_name = TMP.create_tempfile('test_col.col')
+            with open(file_name, "w") as file:
+                file.write("var1\n")
+                file.write("var3\n")
+            with self.assertRaises(Exception) as context:
+                i = line_num(file_name, 'var2')
+            self.assertTrue(
+                'test_col.col does not include var2' in str(context.exception)
+            )
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/tests/mip/test_asl.py
+++ b/pyomo/solvers/tests/mip/test_asl.py
@@ -77,7 +77,6 @@ class mock_all(unittest.TestCase):
 
     def test_solve4(self):
         """Test ASL - test4.nl"""
-        TempfileManager.push()
         _log = TempfileManager.create_tempfile(".test_solve4.log")
         _out = TempfileManager.create_tempfile(".test_solve4.txt")
         TempfileManager.add_tempfile(join(currdir, 'test4.soln'), exists=False)
@@ -91,7 +90,6 @@ class mock_all(unittest.TestCase):
             self.assertStructuredAlmostEqual(
                 json.load(txt), json.load(out), abstol=1e-4, allow_second_superset=True
             )
-        TempfileManager.pop()
 
     #
     # This test is disabled, but it's useful for interactively exercising

--- a/pyomo/solvers/tests/mip/test_asl.py
+++ b/pyomo/solvers/tests/mip/test_asl.py
@@ -77,8 +77,10 @@ class mock_all(unittest.TestCase):
 
     def test_solve4(self):
         """Test ASL - test4.nl"""
+        TempfileManager.push()
         _log = TempfileManager.create_tempfile(".test_solve4.log")
         _out = TempfileManager.create_tempfile(".test_solve4.txt")
+        TempfileManager.add_tempfile(join(currdir, 'test4.soln'), exists=False)
 
         results = self.asl.solve(
             join(currdir, "test4.nl"), logfile=_log, suffixes=['.*']
@@ -89,6 +91,7 @@ class mock_all(unittest.TestCase):
             self.assertStructuredAlmostEqual(
                 json.load(txt), json.load(out), abstol=1e-4, allow_second_superset=True
             )
+        TempfileManager.pop()
 
     #
     # This test is disabled, but it's useful for interactively exercising


### PR DESCRIPTION


## Fixes #3668 

## Summary/Motivation:
#3668 pointed out that we have some residual files that fail to be deleted after running tests. Because `pyomo.duality` is entirely deprecated, I'm not touching it, but everything else is resolved.

## Changes proposed in this PR:
- Effectively use TempfileManager across tests that were not using it in the past
- There was a double-copyright statement in contrib/sensitivity_toolbox; removed duplicate copyright

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
