### PR TITLE
NL writer: resolve model scaling bug writing `Expression` objects

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -610,6 +610,7 @@ class _NLWriter_impl(object):
             del suffix_data['scaling_factor']
         else:
             scaling_factor = _NoScalingFactor()
+            scaling_cache = None
         scale_model = scaling_factor.scale
 
         timer.toc("Collected suffixes", level=logging.DEBUG)
@@ -1361,7 +1362,7 @@ class _NLWriter_impl(object):
                 # Note: checking target_expr == 0 is equivalent to
                 # testing "(_con_id is not None and _obj_id is not None)
                 # or _con_id == 0 or _obj_id == 0"
-                self._write_v_line(_id, 0)
+                self._write_v_line(_id, 0, scale_model, scaling_cache)
             else:
                 if target_expr not in single_use_subexpressions:
                     single_use_subexpressions[target_expr] = []
@@ -1396,7 +1397,7 @@ class _NLWriter_impl(object):
                 break
             if single_use_subexpressions:
                 for _id in single_use_subexpressions.get(id(info[0]), ()):
-                    self._write_v_line(_id, row_idx + 1)
+                    self._write_v_line(_id, row_idx + 1, scale_model, scaling_cache)
             ostream.write(f'C{row_idx}{row_comments[row_idx]}\n')
             self._write_nl_expression(info[1], False)
 
@@ -1409,7 +1410,9 @@ class _NLWriter_impl(object):
                     # Note that "Writing .nl files" (2005) is incorrectly
                     # missing the "+ 1" in the description of V lines
                     # appearing in only Objectives (bottom of page 9).
-                    self._write_v_line(_id, n_cons + n_lcons + obj_idx + 1)
+                    self._write_v_line(
+                        _id, n_cons + n_lcons + obj_idx + 1, scale_model, scaling_cache
+                    )
             lbl = row_comments[n_cons + obj_idx]
             sense = 0 if info[0].sense == minimize else 1
             ostream.write(f'O{obj_idx} {sense}{lbl}\n')
@@ -1983,7 +1986,7 @@ class _NLWriter_impl(object):
         else:
             self.ostream.write(self.template.const % 0)
 
-    def _write_v_line(self, expr_id, k):
+    def _write_v_line(self, expr_id, k, scale_model, scaling_cache):
         ostream = self.ostream
         column_order = self.column_order
         info = self.subexpression_cache[expr_id]
@@ -1995,10 +1998,14 @@ class _NLWriter_impl(object):
         # Do NOT write out 0 coefficients here: doing so fouls up the
         # ASL's logic for calculating derivatives, leading to 'nan' in
         # the Hessian results.
-        linear = dict(item for item in info[1].linear.items() if item[1])
+        linear = info[1].linear
+        linear_ids = list(_id for _id, coef in linear.items() if coef)
+        if scale_model:
+            for _id in linear_ids:
+                linear[_id] /= scaling_cache[_id]
         #
-        ostream.write(f'V{self.next_V_line_id} {len(linear)} {k}{lbl}\n')
-        for _id in sorted(linear, key=column_order.__getitem__):
+        ostream.write(f'V{self.next_V_line_id} {len(linear_ids)} {k}{lbl}\n')
+        for _id in sorted(linear_ids, key=column_order.__getitem__):
             ostream.write(f'{column_order[_id]} {linear[_id]!s}\n')
         self._write_nl_expression(info[1], True)
         self.next_V_line_id += 1


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
@dallan-keylogic found a particularly nefarious bug where turning on the handling of scaling in the NLv2 writer would fail to scale the linear coefficients of named expressions (`Expression` components) used in nonlinear contexts.  This PR resolves the bug and adds a test for scaling named `Expression` objects in nonlinear contexts (slightly modified from @dallan-keylogic's MWE).

## Changes proposed in this PR:
- update `_write_v_line` to scale the linear term coefficients.
- add a test covering this error

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
