### PR TITLE
Exclude gnu.org from the URL checker tests

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -157,7 +157,6 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 		<!--         GLPK                                              -->
 		<!--      </packageName>                                       -->
 		<!--      <packageURL>                                         -->
-		<!--         http://www.gnu.org/software/glpk/                 -->
 		<!--      </packageURL>                                        -->
 		<!--      <requiredOrOptional>                                 -->
 		<!--         Optional                                          -->

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -64,9 +64,13 @@ jobs:
         verbose: true
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
-        # Exclude Jenkins because it's behind a firewall; ignore RTD because
-        # a magically-generated string is triggering a failure
+        # Exclude:
+        #  - Jenkins because it's behind a firewall
+        #  - RTD because a magically-generated string triggers failures
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
+        # Exclude:
+        #  - All gnu.org links because they consistently fail the checker
+        exclude_patterns: https://www.gnu.org
 
 
   build:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -75,9 +75,13 @@ jobs:
         verbose: true
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
-        # Exclude Jenkins because it's behind a firewall; ignore RTD because
-        # a magically-generated string is triggering a failure
+        # Exclude:
+        #  - Jenkins because it's behind a firewall
+        #  - RTD because a magically-generated string triggers failures
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
+        # Exclude:
+        #  - All gnu.org links because they consistently fail the checker
+        exclude_patterns: https://www.gnu.org
 
 
   build:

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -30,3 +30,6 @@ jobs:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
+        # Exclude:
+        #  - All gnu.org links because they consistently fail the checker
+        exclude_patterns: https://www.gnu.org


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The `gnu.org` URLs are consistently failing the URL checker, even though the links are correct and the website is up.  This PR gives up on checking those links.

## Changes proposed in this PR:
- Exclude all gnu.org links from URL checker

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
