### PR TITLE
NFC: Correct Missed setup.py installation instructions

### DIFF
--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -336,7 +336,7 @@ Finally, move to the directory containing the clone of your Pyomo fork and run:
 
 ::
 
-  python setup.py develop
+  pip install -e .
 
 These commands register the cloned code with the active python environment
 (``pyomodev``). This way, your changes to the source code for ``pyomo`` are


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
We realized that we missed one instance of `python setup.py develop` in the `pyproject.toml` changeover. Whoops.

## Changes proposed in this PR:
- Fix incorrect docs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
