### PR TITLE
Resolve bugs when comparing results objects to other types

### DIFF
--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -80,7 +80,7 @@ class ScalarData(object):
         self._active = False
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return self.__dict__ == getattr(other, '__dict__', None)
 
     def get_value(self):
         if isinstance(self.value, enum.Enum):
@@ -191,7 +191,7 @@ class ListContainer(object):
         return self._list[i]
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return self.__dict__ == getattr(other, '__dict__', None)
 
     def clear(self):
         self._list = []
@@ -279,7 +279,12 @@ class MapContainer(dict):
         # underlying dict data (which doesn't show up in the __dict__).
         # So we will use the base __eq__ in addition to checking
         # __dict__.
-        return super().__eq__(other) and self.__dict__ == other.__dict__
+        #
+        # Note: __eq__ can return True, False, or NotImplemented
+        base = super().__eq__(other)
+        if base == True:
+            return self.__dict__ == getattr(other, '__dict__', None)
+        return base
 
     def __getattr__(self, name):
         try:

--- a/pyomo/opt/tests/base/test_soln.py
+++ b/pyomo/opt/tests/base/test_soln.py
@@ -615,6 +615,34 @@ J:
         self.assertIs(d.b, e.b)
         self.assertEqual(d.c, e.c)
 
+    def test_eq(self):
+        d = container.MapContainer()
+        d.declare('x', value=1)
+        d.declare('y', value='a')
+        d.declare('z', value=container.ListContainer(container.MapContainer))
+        self.assertFalse(d == container.MapContainer())
+        self.assertFalse(d == "Something else")
+
+        e = container.ListContainer(container.UndefinedData)
+        self.assertFalse(d == e)
+
+        dd = container.MapContainer()
+        dd.declare('x', value=1)
+        dd.declare('y', value=1)
+        dd.declare('z', value=container.ListContainer(container.UndefinedData))
+        self.assertFalse(d == dd)
+        d.y = 'b'
+        dd.y = 'b'
+        dd.declare('z', value=container.ListContainer(container.MapContainer))
+        self.assertTrue(d == dd)
+
+        d.z.add()
+        d.z[0].declare('a', value=0)
+        self.assertFalse(d == dd)
+        dd.z.add()
+        dd.z[0].declare('a', value=0)
+        self.assertTrue(d == dd)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
IDAES integration tests pointed out the new implementation of `MapContainer.__eq__` was fragile and would fail when comparing results objects to other (slotized) types.  This PR resolves those errors and improves container testing.

## Changes proposed in this PR:
- Catch cases when comparing Container objects to non-Container objects.
- Add additional tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
