### PR TITLE
Bugfix: lp_writer SOS constraints and row_order

### DIFF
--- a/examples/pyomo/sos/sos2_piecewise.py
+++ b/examples/pyomo/sos/sos2_piecewise.py
@@ -22,7 +22,7 @@ import pyomo.environ as pyo
 
 model = pyo.ConcreteModel()
 
-model.index_set = pyo.Set(initialize=[1, 2])
+model.idx_set = pyo.Set(initialize=[1, 2])
 DOMAIN_PTS = {1: [1, 2, 3], 2: [1, 2, 3]}
 F = {1: [1, 4, 9], 2: [1, 4, 9]}
 # Note we can also implement this like below
@@ -37,18 +37,18 @@ def SOS_indices_init(model, t):
 
 
 model.SOS_indices = pyo.Set(
-    model.index_set, dimen=2, ordered=True, initialize=SOS_indices_init
+    model.idx_set, dimen=2, ordered=True, initialize=SOS_indices_init
 )
 
 
 def sos_var_indices_init(model):
-    return [(t, i) for t in model.index_set for i in range(len(DOMAIN_PTS[t]))]
+    return [(t, i) for t in model.idx_set for i in range(len(DOMAIN_PTS[t]))]
 
 
 model.sos_var_indices = pyo.Set(ordered=True, dimen=2, initialize=sos_var_indices_init)
 
-model.x = pyo.Var(model.index_set)  # domain variable
-model.Fx = pyo.Var(model.index_set)  # range variable
+model.x = pyo.Var(model.idx_set)  # domain variable
+model.Fx = pyo.Var(model.idx_set)  # range variable
 model.y = pyo.Var(model.sos_var_indices, within=pyo.NonNegativeReals)  # SOS2 variable
 
 model.obj = pyo.Objective(expr=pyo.sum_product(model.Fx), sense=pyo.maximize)
@@ -73,11 +73,11 @@ def constraint3_rule(model, t):
     return sum(model.y[t, j] for j in range(len(DOMAIN_PTS[t]))) == 1
 
 
-model.constraint1 = pyo.Constraint(model.index_set, rule=constraint1_rule)
-model.constraint2 = pyo.Constraint(model.index_set, rule=constraint2_rule)
-model.constraint3 = pyo.Constraint(model.index_set, rule=constraint3_rule)
+model.constraint1 = pyo.Constraint(model.idx_set, rule=constraint1_rule)
+model.constraint2 = pyo.Constraint(model.idx_set, rule=constraint2_rule)
+model.constraint3 = pyo.Constraint(model.idx_set, rule=constraint3_rule)
 model.SOS_set_constraint = pyo.SOSConstraint(
-    model.index_set, var=model.y, index=model.SOS_indices, sos=2
+    model.idx_set, var=model.y, index=model.SOS_indices, sos=2
 )
 
 # Fix the answer for testing purposes

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -19,6 +19,7 @@ from pyomo.common.config import (
     InEnum,
     document_kwargs_from_configdict,
 )
+from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.timing import TicTocTimer
 
@@ -30,12 +31,10 @@ from pyomo.core.base import (
     Param,
     Expression,
     SOSConstraint,
-    SortComponents,
     Suffix,
     SymbolMap,
     minimize,
 )
-from pyomo.core.base.component import ActiveComponent
 from pyomo.core.base.label import LPFileLabeler, NumericLabeler
 from pyomo.opt import WriterFactory
 from pyomo.repn.linear import LinearRepnVisitor
@@ -48,6 +47,7 @@ from pyomo.repn.util import (
     initialize_var_map_from_column_order,
     int_float,
     ordered_active_constraints,
+    row_order2row_map,
 )
 
 ### FIXME: Remove the following as soon as non-active components no
@@ -555,18 +555,16 @@ class _LPWriter_impl(object):
                     )
                 )
             if self.config.row_order:
-                # sort() is stable (per Python docs), so we can let
-                # all unspecified rows have a row number one bigger than
-                # the number of rows specified by the user ordering.
-                _n = len(row_order)
-                sos.sort(key=lambda x: _row_getter(x, _n))
+                row_map = row_order2row_map(self.config)
+                _n = len(row_map)
+                sos.sort(key=lambda x: row_map.get(id(x), _n))
 
             ostream.write("\nSOS\n")
             for soscon in sos:
                 ostream.write(f'\n{getSymbol(soscon)}: S{soscon.level}::\n')
                 for v, w in getattr(soscon, 'get_items', soscon.items)():
                     if w.__class__ not in int_float:
-                        w = float(f)
+                        w = float(w)
                     ostream.write(f"  {getSymbol(v)}:{w!s}\n")
 
         ostream.write("\nend\n")

--- a/pyomo/repn/tests/cpxlp/test_lpv2.py
+++ b/pyomo/repn/tests/cpxlp/test_lpv2.py
@@ -21,69 +21,31 @@ from pyomo.repn.plugins.lp_writer import LPWriter
 
 
 def create_sos_model():
-    """
-    Borrowed from examples/pyomo/sos/sos2_piecewise.py
-    """
-    model = pyo.ConcreteModel()
+    m = pyo.ConcreteModel()
 
-    model.idx_set = pyo.Set(initialize=[1, 2])
-    DOMAIN_PTS = {1: [1, 2, 3], 2: [1, 2, 3]}
-    F = {1: [1, 4, 9], 2: [1, 4, 9]}
-    # Note we can also implement this like below
-    # F = lambda x: x**2
-    # Update the return value for constraint2_rule if
-    # F is defined using the function above
+    m.IDX = pyo.Set(initialize=[1, 2])
+    m.SOS2_VARS = pyo.Set(m.IDX, initialize={1: [1, 2, 3], 2: [4, 5, 6]})
+    m.SOS3_VARS = pyo.Set(m.IDX, initialize={1: [1, 3, 5], 2: [2, 4, 6]})
 
-    # Indexing set required for the SOSConstraint declaration
-    def SOS_indices_init(model, t):
-        return [(t, i) for i in range(len(DOMAIN_PTS[t]))]
+    m.x = pyo.Var(pyo.RangeSet(6))
 
-    model.SOS_indices = pyo.Set(
-        model.idx_set, dimen=2, ordered=True, initialize=SOS_indices_init
-    )
+    m.sos1 = pyo.SOSConstraint(var=m.x, sos=2)
+    m.sos2 = pyo.SOSConstraint(m.IDX, var=m.x, index=m.SOS2_VARS, sos=1)
+    m.sos3 = pyo.SOSConstraint(m.IDX, var=m.x, index=m.SOS3_VARS, sos=2)
 
-    def sos_var_indices_init(model):
-        return [(t, i) for t in model.idx_set for i in range(len(DOMAIN_PTS[t]))]
+    @m.Constraint()
+    def con1(m, i):
+        return sum(m.x[i] for i in m.x) == 0
 
-    model.sos_var_indices = pyo.Set(
-        ordered=True, dimen=2, initialize=sos_var_indices_init
-    )
+    @m.Constraint(m.IDX)
+    def con2(m, i):
+        return m.x[i] >= 20 + i
 
-    model.x = pyo.Var(model.idx_set)  # domain variable
-    model.Fx = pyo.Var(model.idx_set)  # range variable
-    model.y = pyo.Var(
-        model.sos_var_indices, within=pyo.NonNegativeReals
-    )  # SOS2 variable
+    @m.Constraint(m.IDX)
+    def con3(m, i):
+        return m.x[i] >= 30 + i
 
-    model.obj = pyo.Objective(expr=pyo.sum_product(model.Fx), sense=pyo.maximize)
-
-    def constraint1_rule(model, t):
-        return model.x[t] == sum(
-            model.y[t, i] * DOMAIN_PTS[t][i] for i in range(len(DOMAIN_PTS[t]))
-        )
-
-    def constraint2_rule(model, t):
-        # Uncomment below for F defined as dictionary
-        return model.Fx[t] == sum(
-            model.y[t, i] * F[t][i] for i in range(len(DOMAIN_PTS[t]))
-        )
-        # Uncomment below for F defined as lambda function
-        # return model.Fx[t] == sum(model.y[t,i]*F(DOMAIN_PTS[t][i]) for i in range(len(DOMAIN_PTS[t])) )
-
-    def constraint3_rule(model, t):
-        return sum(model.y[t, j] for j in range(len(DOMAIN_PTS[t]))) == 1
-
-    model.constraint1 = pyo.Constraint(model.idx_set, rule=constraint1_rule)
-    model.constraint2 = pyo.Constraint(model.idx_set, rule=constraint2_rule)
-    model.constraint3 = pyo.Constraint(model.idx_set, rule=constraint3_rule)
-    model.SOS_set_constraint = pyo.SOSConstraint(
-        model.idx_set, var=model.y, index=model.SOS_indices, sos=2
-    )
-
-    # Fix the answer for testing purposes
-    model.set_answer_constraint1 = pyo.Constraint(expr=model.x[1] == 2.5)
-    model.set_answer_constraint2 = pyo.Constraint(expr=model.x[2] == 2.0)
-    return model
+    return m
 
 
 class TestLPv2(unittest.TestCase):
@@ -206,179 +168,180 @@ end
 
         self.assertEqual(ref, OUT.getvalue())
 
-    def test_SOS_ordering_bug(self):
+    def test_SOS_ordering(self):
         # This is in response to a bug that was identified with
         # config.row_order with SOS constraints. If an SOS constraint
         # was added and the `config.row_order` option selected,
         # bug would ensue.
-        ref_no_row_order = r"""\* Source Pyomo model name=unknown *\
 
-max 
-x1:
-+1 x2
-+1 x3
-
-s.t.
-
-c_e_x4_:
-+1 x5
--1 x6
--2 x7
--3 x8
-= 0
-
-c_e_x9_:
-+1 x10
--1 x11
--2 x12
--3 x13
-= 0
-
-c_e_x14_:
-+1 x2
--1 x6
--4 x7
--9 x8
-= 0
-
-c_e_x15_:
-+1 x3
--1 x11
--4 x12
--9 x13
-= 0
-
-c_e_x16_:
-+1 x6
-+1 x7
-+1 x8
-= 1
-
-c_e_x17_:
-+1 x11
-+1 x12
-+1 x13
-= 1
-
-c_e_x18_:
-+1 x5
-= 2.5
-
-c_e_x19_:
-+1 x10
-= 2.0
-
-bounds
-   -inf <= x2 <= +inf
-   -inf <= x3 <= +inf
-   -inf <= x5 <= +inf
-   -inf <= x10 <= +inf
-   0 <= x6 <= +inf
-   0 <= x7 <= +inf
-   0 <= x8 <= +inf
-   0 <= x11 <= +inf
-   0 <= x12 <= +inf
-   0 <= x13 <= +inf
-SOS
-
-x20: S2::
-  x6:1
-  x7:2
-  x8:3
-
-x21: S2::
-  x11:1
-  x12:2
-  x13:3
-
-end
-"""
-        ref_row_order = r"""\* Source Pyomo model name=unknown *\
-
-max 
-x1:
-+1 x2
-+1 x3
-
-s.t.
-
-c_e_x4_:
-+1 x5
-+1 x6
-+1 x7
-= 1
-
-c_e_x8_:
-+1 x9
-+1 x10
-+1 x11
-= 1
-
-c_e_x12_:
--1 x5
--2 x6
--3 x7
-+1 x13
-= 0
-
-c_e_x14_:
--1 x9
--2 x10
--3 x11
-+1 x15
-= 0
-
-c_e_x16_:
-+1 x2
--1 x5
--4 x6
--9 x7
-= 0
-
-c_e_x17_:
-+1 x3
--1 x9
--4 x10
--9 x11
-= 0
-
-c_e_x18_:
-+1 x13
-= 2.5
-
-c_e_x19_:
-+1 x15
-= 2.0
-
-bounds
-   -inf <= x2 <= +inf
-   -inf <= x3 <= +inf
-   0 <= x5 <= +inf
-   0 <= x6 <= +inf
-   0 <= x7 <= +inf
-   0 <= x9 <= +inf
-   0 <= x10 <= +inf
-   0 <= x11 <= +inf
-   -inf <= x13 <= +inf
-   -inf <= x15 <= +inf
-SOS
-
-x20: S2::
-  x5:1
-  x6:2
-  x7:3
-
-x21: S2::
-  x9:1
-  x10:2
-  x11:3
-
-end
-"""
         model = create_sos_model()
-        with LoggingIntercept() as OUT1:
-            LPWriter().write(model, OUT1)
-        self.assertEqual(OUT1.getvalue(), ref_no_row_order)
-        with LoggingIntercept() as OUT2:
-            LPWriter().write(model, OUT2, row_order=[model.constraint3])
-        self.assertEqual(OUT2.getvalue(), ref_row_order)
+
+        OUT = StringIO()
+        LPWriter().write(model, OUT, symbolic_solver_labels=True)
+        self.assertEqual(
+            r"""\* Source Pyomo model name=unknown *\
+
+min 
+ScalarObjective:
++1.0 ONE_VAR_CONSTANT
+
+s.t.
+
+c_e_con1_:
++1 x(1)
++1 x(2)
++1 x(3)
++1 x(4)
++1 x(5)
++1 x(6)
+= 0
+
+c_l_con2(1)_:
++1 x(1)
+>= 21
+
+c_l_con2(2)_:
++1 x(2)
+>= 22
+
+c_l_con3(1)_:
++1 x(1)
+>= 31
+
+c_l_con3(2)_:
++1 x(2)
+>= 32
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   -inf <= x(1) <= +inf
+   -inf <= x(2) <= +inf
+   -inf <= x(3) <= +inf
+   -inf <= x(4) <= +inf
+   -inf <= x(5) <= +inf
+   -inf <= x(6) <= +inf
+SOS
+
+sos1: S2::
+  x(1):1
+  x(2):2
+  x(3):3
+  x(4):4
+  x(5):5
+  x(6):6
+
+sos2(1): S1::
+  x(1):1
+  x(2):2
+  x(3):3
+
+sos2(2): S1::
+  x(4):1
+  x(5):2
+  x(6):3
+
+sos3(1): S2::
+  x(1):1
+  x(3):2
+  x(5):3
+
+sos3(2): S2::
+  x(2):1
+  x(4):2
+  x(6):3
+
+end
+""",
+            OUT.getvalue(),
+        )
+
+        OUT = StringIO()
+        LPWriter().write(
+            model,
+            OUT,
+            symbolic_solver_labels=True,
+            row_order=[
+                model.sos3[2],
+                model.con3[2],
+                model.con2,
+                model.sos2,
+                model.sos1,
+                model.con1,
+            ],
+        )
+        self.assertEqual(
+            r"""\* Source Pyomo model name=unknown *\
+
+min 
+ScalarObjective:
++1.0 ONE_VAR_CONSTANT
+
+s.t.
+
+c_l_con3(2)_:
++1 x(2)
+>= 32
+
+c_l_con2(1)_:
++1 x(1)
+>= 21
+
+c_l_con2(2)_:
++1 x(2)
+>= 22
+
+c_e_con1_:
++1 x(1)
++1 x(2)
++1 x(3)
++1 x(4)
++1 x(5)
++1 x(6)
+= 0
+
+c_l_con3(1)_:
++1 x(1)
+>= 31
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   -inf <= x(1) <= +inf
+   -inf <= x(2) <= +inf
+   -inf <= x(3) <= +inf
+   -inf <= x(4) <= +inf
+   -inf <= x(5) <= +inf
+   -inf <= x(6) <= +inf
+SOS
+
+sos3(2): S2::
+  x(2):1
+  x(4):2
+  x(6):3
+
+sos2(1): S1::
+  x(1):1
+  x(2):2
+  x(3):3
+
+sos2(2): S1::
+  x(4):1
+  x(5):2
+  x(6):3
+
+sos1: S2::
+  x(1):1
+  x(2):2
+  x(3):3
+  x(4):4
+  x(5):5
+  x(6):6
+
+sos3(1): S2::
+  x(1):1
+  x(3):2
+  x(5):3
+
+end
+""",
+            OUT.getvalue(),
+        )

--- a/pyomo/repn/tests/cpxlp/test_lpv2.py
+++ b/pyomo/repn/tests/cpxlp/test_lpv2.py
@@ -20,6 +20,72 @@ import pyomo.environ as pyo
 from pyomo.repn.plugins.lp_writer import LPWriter
 
 
+def create_sos_model():
+    """
+    Borrowed from examples/pyomo/sos/sos2_piecewise.py
+    """
+    model = pyo.ConcreteModel()
+
+    model.idx_set = pyo.Set(initialize=[1, 2])
+    DOMAIN_PTS = {1: [1, 2, 3], 2: [1, 2, 3]}
+    F = {1: [1, 4, 9], 2: [1, 4, 9]}
+    # Note we can also implement this like below
+    # F = lambda x: x**2
+    # Update the return value for constraint2_rule if
+    # F is defined using the function above
+
+    # Indexing set required for the SOSConstraint declaration
+    def SOS_indices_init(model, t):
+        return [(t, i) for i in range(len(DOMAIN_PTS[t]))]
+
+    model.SOS_indices = pyo.Set(
+        model.idx_set, dimen=2, ordered=True, initialize=SOS_indices_init
+    )
+
+    def sos_var_indices_init(model):
+        return [(t, i) for t in model.idx_set for i in range(len(DOMAIN_PTS[t]))]
+
+    model.sos_var_indices = pyo.Set(
+        ordered=True, dimen=2, initialize=sos_var_indices_init
+    )
+
+    model.x = pyo.Var(model.idx_set)  # domain variable
+    model.Fx = pyo.Var(model.idx_set)  # range variable
+    model.y = pyo.Var(
+        model.sos_var_indices, within=pyo.NonNegativeReals
+    )  # SOS2 variable
+
+    model.obj = pyo.Objective(expr=pyo.sum_product(model.Fx), sense=pyo.maximize)
+
+    def constraint1_rule(model, t):
+        return model.x[t] == sum(
+            model.y[t, i] * DOMAIN_PTS[t][i] for i in range(len(DOMAIN_PTS[t]))
+        )
+
+    def constraint2_rule(model, t):
+        # Uncomment below for F defined as dictionary
+        return model.Fx[t] == sum(
+            model.y[t, i] * F[t][i] for i in range(len(DOMAIN_PTS[t]))
+        )
+        # Uncomment below for F defined as lambda function
+        # return model.Fx[t] == sum(model.y[t,i]*F(DOMAIN_PTS[t][i]) for i in range(len(DOMAIN_PTS[t])) )
+
+    def constraint3_rule(model, t):
+        return sum(model.y[t, j] for j in range(len(DOMAIN_PTS[t]))) == 1
+
+    model.constraint1 = pyo.Constraint(model.idx_set, rule=constraint1_rule)
+    model.constraint2 = pyo.Constraint(model.idx_set, rule=constraint2_rule)
+    model.constraint3 = pyo.Constraint(model.idx_set, rule=constraint3_rule)
+    model.SOS_set_constraint = pyo.SOSConstraint(
+        model.idx_set, var=model.y, index=model.SOS_indices, sos=2
+    )
+
+    # Fix the answer for testing purposes
+    model.set_answer_constraint1 = pyo.Constraint(expr=model.x[1] == 2.5)
+    model.set_answer_constraint2 = pyo.Constraint(expr=model.x[2] == 2.0)
+    return model
+
+
 class TestLPv2(unittest.TestCase):
     def test_warn_export_suffixes(self):
         m = pyo.ConcreteModel()
@@ -139,3 +205,180 @@ end
         self.assertEqual(LOG.getvalue(), "")
 
         self.assertEqual(ref, OUT.getvalue())
+
+    def test_SOS_ordering_bug(self):
+        # This is in response to a bug that was identified with
+        # config.row_order with SOS constraints. If an SOS constraint
+        # was added and the `config.row_order` option selected,
+        # bug would ensue.
+        ref_no_row_order = r"""\* Source Pyomo model name=unknown *\
+
+max 
+x1:
++1 x2
++1 x3
+
+s.t.
+
+c_e_x4_:
++1 x5
+-1 x6
+-2 x7
+-3 x8
+= 0
+
+c_e_x9_:
++1 x10
+-1 x11
+-2 x12
+-3 x13
+= 0
+
+c_e_x14_:
++1 x2
+-1 x6
+-4 x7
+-9 x8
+= 0
+
+c_e_x15_:
++1 x3
+-1 x11
+-4 x12
+-9 x13
+= 0
+
+c_e_x16_:
++1 x6
++1 x7
++1 x8
+= 1
+
+c_e_x17_:
++1 x11
++1 x12
++1 x13
+= 1
+
+c_e_x18_:
++1 x5
+= 2.5
+
+c_e_x19_:
++1 x10
+= 2.0
+
+bounds
+   -inf <= x2 <= +inf
+   -inf <= x3 <= +inf
+   -inf <= x5 <= +inf
+   -inf <= x10 <= +inf
+   0 <= x6 <= +inf
+   0 <= x7 <= +inf
+   0 <= x8 <= +inf
+   0 <= x11 <= +inf
+   0 <= x12 <= +inf
+   0 <= x13 <= +inf
+SOS
+
+x20: S2::
+  x6:1
+  x7:2
+  x8:3
+
+x21: S2::
+  x11:1
+  x12:2
+  x13:3
+
+end
+"""
+        ref_row_order = r"""\* Source Pyomo model name=unknown *\
+
+max 
+x1:
++1 x2
++1 x3
+
+s.t.
+
+c_e_x4_:
++1 x5
++1 x6
++1 x7
+= 1
+
+c_e_x8_:
++1 x9
++1 x10
++1 x11
+= 1
+
+c_e_x12_:
+-1 x5
+-2 x6
+-3 x7
++1 x13
+= 0
+
+c_e_x14_:
+-1 x9
+-2 x10
+-3 x11
++1 x15
+= 0
+
+c_e_x16_:
++1 x2
+-1 x5
+-4 x6
+-9 x7
+= 0
+
+c_e_x17_:
++1 x3
+-1 x9
+-4 x10
+-9 x11
+= 0
+
+c_e_x18_:
++1 x13
+= 2.5
+
+c_e_x19_:
++1 x15
+= 2.0
+
+bounds
+   -inf <= x2 <= +inf
+   -inf <= x3 <= +inf
+   0 <= x5 <= +inf
+   0 <= x6 <= +inf
+   0 <= x7 <= +inf
+   0 <= x9 <= +inf
+   0 <= x10 <= +inf
+   0 <= x11 <= +inf
+   -inf <= x13 <= +inf
+   -inf <= x15 <= +inf
+SOS
+
+x20: S2::
+  x5:1
+  x6:2
+  x7:3
+
+x21: S2::
+  x9:1
+  x10:2
+  x11:3
+
+end
+"""
+        model = create_sos_model()
+        with LoggingIntercept() as OUT1:
+            LPWriter().write(model, OUT1)
+        self.assertEqual(OUT1.getvalue(), ref_no_row_order)
+        with LoggingIntercept() as OUT2:
+            LPWriter().write(model, OUT2, row_order=[model.constraint3])
+        self.assertEqual(OUT2.getvalue(), ref_row_order)

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -748,17 +748,17 @@ def initialize_var_map_from_column_order(model, config, var_map):
     return var_map
 
 
-def ordered_active_constraints(model, config):
-    sorter = FileDeterminism_to_SortComponents(config.file_determinism)
-    constraints = model.component_data_objects(Constraint, active=True, sort=sorter)
-
+def row_order2row_map(config):
+    """Convert a row_order (list or ComponentMap) into a dict mapping
+    constraint id -> row index. Returns an empty dict if no ordering."""
     row_order = config.row_order
-    if row_order is None or row_order.__class__ is bool:
-        return constraints
-    elif isinstance(row_order, ComponentMap):
-        # The row order has historically also supported a ComponentMap of
-        # component to position in addition to the simple list of
-        # components.  Convert it to the simple list
+    if row_order is None or isinstance(row_order, bool):
+        return {}
+
+    sorter = FileDeterminism_to_SortComponents(config.file_determinism)
+
+    if isinstance(row_order, ComponentMap):
+        # Convert ComponentMap to sorted list based on its values
         row_order = sorted(row_order, key=row_order.__getitem__)
 
     row_map = {}
@@ -768,16 +768,26 @@ def ordered_active_constraints(model, config):
                 row_map[id(c)] = c
         else:
             row_map[id(con)] = con
+
+    if not row_map:
+        return {}
+
+    # Map the implicit dict ordering to an explicit 0..n ordering
+    return {_id: i for i, _id in enumerate(row_map)}
+
+
+def ordered_active_constraints(model, config):
+    sorter = FileDeterminism_to_SortComponents(config.file_determinism)
+    constraints = model.component_data_objects(Constraint, active=True, sort=sorter)
+
+    row_map = row_order2row_map(config)
     if not row_map:
         return constraints
-    # map the implicit dict ordering to an explicit 0..n ordering
-    row_map = {_id: i for i, _id in enumerate(row_map)}
     # sorted() is stable (per Python docs), so we can let all
     # unspecified rows have a row number one bigger than the
     # number of rows specified by the user ordering.
     _n = len(row_map)
-    _row_getter = row_map.get
-    return sorted(constraints, key=lambda x: _row_getter(id(x), _n))
+    return sorted(constraints, key=lambda x: row_map.get(id(x), _n))
 
 
 class VarRecorder(object):

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -769,9 +769,6 @@ def row_order2row_map(config):
         else:
             row_map[id(con)] = con
 
-    if not row_map:
-        return {}
-
     # Map the implicit dict ordering to an explicit 0..n ordering
     return {_id: i for i, _id in enumerate(row_map)}
 

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -787,7 +787,8 @@ def ordered_active_constraints(model, config):
     # unspecified rows have a row number one bigger than the
     # number of rows specified by the user ordering.
     _n = len(row_map)
-    return sorted(constraints, key=lambda x: row_map.get(id(x), _n))
+    _row_getter = row_map.get
+    return sorted(constraints, key=lambda x: _row_getter(id(x), _n))
 
 
 class VarRecorder(object):


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
In starting work on the new `bar_writer`, I stumbled across a few bugs in `lp_v2` that no one has hit yet but definitely don't work. Primarily, the bugs were:

- Missing import statement
- Accidentally misused letter
- Entirely skipped edge case to correct handle when a model has SOS constraints and is using `row_order` in the writer config.

## Changes proposed in this PR:
- Fix two small bugs
- Refactor `ordered_active_constraints` to pull out `row_map` logic (for reusability)
- Bugfix using new `row_order2row_map` function
- `index_set` is now a reserved name, so SOS example fixed so it'll actually run
- Test using SOS example as a baseline

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
