### PR TITLE
Resolve `capture_output(capture_fd=True)` deadlock on Windows

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -497,7 +497,9 @@ class capture_output(object):
     def reset(self):
         return self.__exit__(None, None, None)
 
+
 CREATE_WIN_PYHANDLE = False
+
 
 class _StreamHandle(object):
     """A stream handler object used by TeeStream

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -505,8 +505,8 @@ class _StreamHandle(object):
             # the outset, we reduce the likelihood of needing to
             # reallocate the buffer.
             self.read_pyhandle, self.write_pyhandle = CreatePipe(None, 65536)
-            self.read_pipe = open_osfhandle(self.read_pyhandle.handle, os.O_RDONLY)
-            self.write_pipe = open_osfhandle(self.write_pyhandle.handle, os.O_WRONLY)
+            self.read_pipe = open_osfhandle(self.read_pyhandle.handle, os.O_RDONLY | os.O_NOINHERIT)
+            self.write_pipe = open_osfhandle(self.write_pyhandle.handle, os.O_WRONLY | os.O_NOINHERIT)
             # Because reallocating the pipe buffer can cause deadlock
             # (at least in the context in which we are using pipes
             # here), we will set the write pipe to NOWAIT.  This will

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -37,7 +37,7 @@ _poll_rampup = 10
 # ~(13.1 * #threads) seconds
 _poll_timeout = 1  # 14 rounds: 0.0001 * 2**14 == 1.6384
 _poll_timeout_deadlock = 100  # seconds
-
+_pipe_buffersize = 1 << 16  # 65536
 _noop = lambda: None
 _mswindows = sys.platform.startswith('win')
 try:
@@ -555,7 +555,7 @@ class _StreamHandle(object):
             # from the outset, we reduce the likelihood of needing to
             # reallocate the buffer.
             self.read_pipe, self.write_pipe = FdCreatePipe(
-                None, 65536, os.O_BINARY if 'b' in mode else os.O_TEXT
+                None, _pipe_buffersize, os.O_BINARY if 'b' in mode else os.O_TEXT
             )
             self.read_pyhandle = get_osfhandle(self.read_pipe)
             self.write_pyhandle = get_osfhandle(self.write_pipe)

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -453,8 +453,16 @@ class capture_output(object):
                     % (self.tee._stdout, sys.stdout)
                 )
         # Flush all streams
-        sys.stderr.flush()
-        sys.stdout.flush()
+        try:
+            sys.stderr.flush()
+        except ValueError:
+            # I/O on a closed file
+            pass
+        try:
+            sys.stdout.flush()
+        except ValueError:
+            # I/O on a closed file
+            pass
         # Exit all context managers.  This includes
         #  - Restore any file descriptors we commandeered
         #  - Close / join the TeeStream

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -587,7 +587,10 @@ class _StreamHandle(object):
         self.decodeIncomingBuffer()
         if ostreams:
             self.writeOutputBuffer(ostreams, True)
-        os.close(self.read_pipe)
+        try:
+            os.close(self.read_pipe)
+        except OSError:
+            pass
 
         if self.decoder_buffer:
             logger.error(

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -505,8 +505,12 @@ class _StreamHandle(object):
             # the outset, we reduce the likelihood of needing to
             # reallocate the buffer.
             self.read_pyhandle, self.write_pyhandle = CreatePipe(None, 65536)
-            self.read_pipe = open_osfhandle(self.read_pyhandle.handle, os.O_RDONLY | os.O_NOINHERIT)
-            self.write_pipe = open_osfhandle(self.write_pyhandle.handle, os.O_WRONLY | os.O_NOINHERIT)
+            self.read_pipe = open_osfhandle(
+                self.read_pyhandle.handle, os.O_RDONLY | os.O_NOINHERIT
+            )
+            self.write_pipe = open_osfhandle(
+                self.write_pyhandle.handle, os.O_WRONLY | os.O_NOINHERIT
+            )
             # Because reallocating the pipe buffer can cause deadlock
             # (at least in the context in which we are using pipes
             # here), we will set the write pipe to NOWAIT.  This will

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -452,17 +452,6 @@ class capture_output(object):
                     'Captured output (%s) does not match sys.stderr (%s).'
                     % (self.tee._stdout, sys.stdout)
                 )
-        # Flush all streams
-        try:
-            sys.stderr.flush()
-        except ValueError:
-            # I/O on a closed file
-            pass
-        try:
-            sys.stdout.flush()
-        except ValueError:
-            # I/O on a closed file
-            pass
         # Exit all context managers.  This includes
         #  - Restore any file descriptors we commandeered
         #  - Close / join the TeeStream
@@ -587,10 +576,7 @@ class _StreamHandle(object):
         self.decodeIncomingBuffer()
         if ostreams:
             self.writeOutputBuffer(ostreams, True)
-        try:
-            os.close(self.read_pipe)
-        except OSError:
-            pass
+        os.close(self.read_pipe)
 
         if self.decoder_buffer:
             logger.error(

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -51,16 +51,16 @@ class timestamper:
 
     def check(self, *bases):
         """Map the recorded times to {0, 1} based on the range of times
-        recorded: anything in the first half of the range is mapped to
-        0, and anything in the second half is mapped to 1.  This
+        recorded: anything in the first two-thirds of the range is mapped to
+        0, and anything in the last third is mapped to 1.  This
         "discretizes" the times so that we can reliably compare to
         baselines.
 
         """
 
         n = list(itertools.chain(*self.buf))
-        mid = (min(n) + max(n)) / 2.0
-        result = [tuple(0 if i < mid else 1 for i in _) for _ in self.buf]
+        cutoff = min(n) + (max(n) - min(n)) * 2.0 / 3.0
+        result = [tuple(0 if i < cutoff else 1 for i in _) for _ in self.buf]
         if result not in bases:
             base = ' or '.join(str(_) for _ in bases)
             self.error = f"result {result} != baseline {base}\nRaw timing: {self.buf}"

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -303,6 +303,7 @@ class TestTeeStream(unittest.TestCase):
 class TestCapture(unittest.TestCase):
     def setUp(self):
         self.streams = sys.stdout, sys.stderr
+        self.fd = [os.dup(stream.fileno()) for stream in self.streams]
         self.reenable_gc = gc.isenabled()
         gc.disable()
         gc.collect()
@@ -313,6 +314,8 @@ class TestCapture(unittest.TestCase):
 
     def tearDown(self):
         sys.stdout, sys.stderr = self.streams
+        os.dup2(self.fd[0], self.streams[0].fileno())
+        os.dup2(self.fd[1], self.streams[1].fileno())
         sys.setswitchinterval(self.switchinterval)
         if self.reenable_gc:
             gc.enable()

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -531,14 +531,14 @@ class TestCapture(unittest.TestCase):
             self.assertEqual(len(T.context_stack), 2)
         T = tee.capture_output(capture_fd=True)
         # out & err point to something other than fd 1 and 2
-        sys.stdout = os.fdopen(os.dup(1), closefd=True)
-        sys.stderr = os.fdopen(os.dup(2), closefd=True)
+        sys.stdout = os.fdopen(os.dup(1), 'w', closefd=True)
+        sys.stderr = os.fdopen(os.dup(2), 'w', closefd=True)
         with sys.stdout, sys.stderr:
             with T:
                 self.assertEqual(len(T.context_stack), 8)
         # out & err point to fd 1 and 2
-        sys.stdout = os.fdopen(1, closefd=False)
-        sys.stderr = os.fdopen(2, closefd=False)
+        sys.stdout = os.fdopen(1, 'w', closefd=False)
+        sys.stderr = os.fdopen(2, 'w', closefd=False)
         with sys.stdout, sys.stderr:
             with T:
                 self.assertEqual(len(T.context_stack), 6)

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -784,8 +784,8 @@ class BufferTester(object):
         ts = timestamper()
         ts.write(f"{time.time()}")
         with tee.TeeStream(ts, ts) as t, tee.capture_output(t.STDOUT, capture_fd=fd):
-            # Note: bigger than the 64k buffer we allocate on Windows.
-            sys.stdout.write(f"{time.time()}" + ' ' * 1024 * 64 + "\n")
+            # Note: bigger than the buffer we allocate on Windows.
+            sys.stdout.write(f"{time.time()}" + ' ' * tee._pipe_buffersize + "\n")
             time.sleep(self.dt)
         ts.write(f"{time.time()}")
         if not ts.check([(0, 0), (0, 0), (0, 0), (1, 1)]):

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -784,7 +784,8 @@ class BufferTester(object):
         ts = timestamper()
         ts.write(f"{time.time()}")
         with tee.TeeStream(ts, ts) as t, tee.capture_output(t.STDOUT, capture_fd=fd):
-            sys.stdout.write(f"{time.time()}" + '    ' * 4096 + "\n")
+            # Note: bigger than the 64k buffer we allocate on Windows.
+            sys.stdout.write(f"{time.time()}" + ' ' * 1024 * 64 + "\n")
             time.sleep(self.dt)
         ts.write(f"{time.time()}")
         if not ts.check([(0, 0), (0, 0), (0, 0), (1, 1)]):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3658 

## Summary/Motivation:
The recent rework of `capture_output` to make it more robust (#3583, #3588, #3601, #3633, #3640) led to a situation where using `capture_output(capture_fd=True)` on Windows would cause the process to deadlock (see #3658).  We tracked it down to what appears to be Window's procedure for reallocating (growing) the buffer that underlies `os.pipe()`.  This PR proposes a two-fold solution:
1. Request a larger pipe buffer (64kb), to reduce the chances that the OS will ever need to reallocate the buffer
2. Mark the pipe as being non-blocking (PIPE_NOWAIT), on the theory that losing log data is better than deadlocking the process

## Changes proposed in this PR:
- Provide windows-specific implementation of `os.pipe()` to request a larger buffer
- Make the pipe underlying `capture_output` non-blocking

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
3. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
