### PR TITLE
Sensitivity calculation for named expressions

### DIFF
--- a/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_pynumero.py
@@ -17,7 +17,7 @@ from pyomo.common.dependencies import scipy_available, attempt_import
 import pyomo.environ as pyo
 
 # Use attempt_import here due to unguarded NumPy import in this file
-nlp = attempt_import('pyomo.contrib.pynumero.interfaces.pyomo_nlp')[0]
+nlp = attempt_import("pyomo.contrib.pynumero.interfaces.pyomo_nlp")[0]
 import pyomo.contrib.sensitivity_toolbox.pynumero as pnsens
 from pyomo.contrib.pynumero.asl import AmplInterface
 
@@ -97,11 +97,36 @@ class TestSeriesData(unittest.TestCase):
         )
         m.c1 = pyo.Constraint(expr=m.x1 == 2 * m.p1**2)
         m.c2 = pyo.Constraint(expr=m.x2 == m.p2)
+
+        m.e1 = pyo.Expression(expr=2 * m.p1**2)
+        m.e2 = pyo.Expression(expr=m.p2)
+        m.e3 = pyo.Expression(expr=m.x1 * m.p1 + m.x2 * m.x2 * m.p2 + m.p1 * m.p2)
+
         theta = [m.p1, m.p2]
         dsdp, dfdp, rmap, cmap = pnsens.get_dsdp_dfdp(m, theta)
 
-        dydp, rmap = pnsens.get_dydp([m.x2], dsdp, rmap)
+        dydp, rmap = pnsens.get_dydp(
+            [m.e1, m.x1, m.e2, m.x2, m.e3],
+            dsdp,
+            rmap,
+            cmap,
+        )
 
+        assert dydp.shape == (5, 2)
+        np.testing.assert_almost_equal(dydp[rmap[m.x1], cmap[m.p1]], 40.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.e1], cmap[m.p1]], 40.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.x1], cmap[m.p2]], 0.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.e1], cmap[m.p2]], 0.0)
         np.testing.assert_almost_equal(dydp[rmap[m.x2], cmap[m.p1]], 0.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.e2], cmap[m.p1]], 0.0)
         np.testing.assert_almost_equal(dydp[rmap[m.x2], cmap[m.p2]], 1.0)
-        assert dydp.shape == (1, 2)
+        np.testing.assert_almost_equal(dydp[rmap[m.e2], cmap[m.p2]], 1.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.e3], cmap[m.p1]], 605.0)
+        np.testing.assert_almost_equal(dydp[rmap[m.e3], cmap[m.p2]], 85.0)
+
+        # make sure the rows are in the order of y_list
+        assert rmap[m.e1] == 0
+        assert rmap[m.x1] == 1
+        assert rmap[m.e2] == 2
+        assert rmap[m.x2] == 3
+        assert rmap[m.e3] == 4


### PR DESCRIPTION
## Fixes None

## Summary/Motivation:

This adds sensitivity calculations for named expressions to the pynumero sensitivity calculations in the sensitivity toolbox.  Usually, it is probably better to add a variable to the model, but on rare occasions that can cause trouble.

## Changes proposed in this PR:
- Add ability to include named expressions in sensitivity matrix 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
