### PR TITLE
Added support for Highs solver in contrib.Benders

### DIFF
--- a/pyomo/contrib/benders/benders_cuts.py
+++ b/pyomo/contrib/benders/benders_cuts.py
@@ -110,6 +110,7 @@ solver_dual_sign_convention['glpk'] = -1
 solver_dual_sign_convention['cbc'] = -1
 solver_dual_sign_convention['xpress_direct'] = -1
 solver_dual_sign_convention['xpress_persistent'] = -1
+solver_dual_sign_convention['highs'] = -1
 
 
 def _del_con(c):

--- a/pyomo/contrib/benders/tests/test_benders.py
+++ b/pyomo/contrib/benders/tests/test_benders.py
@@ -17,7 +17,15 @@ from pyomo.contrib.benders.benders_cuts import BendersCutGenerator
 
 ipopt_available = pyo.SolverFactory('ipopt').available(exception_flag=False)
 
-for mip_name in ('cplex_direct', 'gurobi_direct', 'gurobi', 'cplex', 'glpk', 'cbc'):
+for mip_name in (
+    'cplex_direct',
+    'gurobi_direct',
+    'gurobi',
+    'cplex',
+    'glpk',
+    'cbc',
+    'highs',
+):
     mip_available = pyo.SolverFactory(mip_name).available(exception_flag=False)
     if mip_available:
         break


### PR DESCRIPTION

<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3684 

## Summary/Motivation:
Add the ability to use the Highs solver in contrib.Benders.

## Changes proposed in this PR:
- Adds Highs to the supported solvers list for the Benders contrib solver
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
