### PR TITLE
Add reporting of SCIP node count to solver results

### DIFF
--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -255,6 +255,7 @@ class SCIPAMPL(SystemCallSolver):
 
                     results.solver.time = log_dict['solving_time']
                     results.solver.gap = log_dict['gap']
+                    results.solver.nodes = log_dict['solving_nodes']
                     results.solver.primal_bound = log_dict['primal_bound']
                     results.solver.dual_bound = log_dict['dual_bound']
 

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -255,7 +255,7 @@ class SCIPAMPL(SystemCallSolver):
 
                     results.solver.time = log_dict['solving_time']
                     results.solver.gap = log_dict['gap']
-                    results.solver.nodes = log_dict['solving_nodes']
+                    results.solver.node_count = log_dict['solving_nodes']
                     results.solver.primal_bound = log_dict['primal_bound']
                     results.solver.dual_bound = log_dict['dual_bound']
 

--- a/pyomo/solvers/tests/mip/test_scip_log_data.py
+++ b/pyomo/solvers/tests/mip/test_scip_log_data.py
@@ -198,11 +198,23 @@ def test_scip_some_more():
     list_extra_data_expected = [
         (),  # problem_lp_unbounded(),
         (),  # problem_lp_infeasible(),
-        ('Time', 'Gap', 'Primal bound', 'Dual bound'),  # problem_lp_optimal(),
+        ('Time', 'Gap', 'Nodes', 'Primal bound', 'Dual bound'),  # problem_lp_optimal(),
         (),  # problem_milp_unbounded(),
         (),  # problem_milp_infeasible(),
-        ('Time', 'Gap', 'Primal bound', 'Dual bound'),  # problem_milp_optimal(),
-        ('Time', 'Gap', 'Primal bound', 'Dual bound'),  # problem_milp_feasible()
+        (
+            'Time',
+            'Gap',
+            'Nodes',
+            'Primal bound',
+            'Dual bound',
+        ),  # problem_milp_optimal(),
+        (
+            'Time',
+            'Gap',
+            'Nodes',
+            'Primal bound',
+            'Dual bound',
+        ),  # problem_milp_feasible()
     ]
 
     # **************************************************************************

--- a/pyomo/solvers/tests/mip/test_scip_log_data.py
+++ b/pyomo/solvers/tests/mip/test_scip_log_data.py
@@ -198,20 +198,26 @@ def test_scip_some_more():
     list_extra_data_expected = [
         (),  # problem_lp_unbounded(),
         (),  # problem_lp_infeasible(),
-        ('Time', 'Gap', 'Nodes', 'Primal bound', 'Dual bound'),  # problem_lp_optimal(),
+        (
+            'Time',
+            'Gap',
+            'Node count',
+            'Primal bound',
+            'Dual bound',
+        ),  # problem_lp_optimal(),
         (),  # problem_milp_unbounded(),
         (),  # problem_milp_infeasible(),
         (
             'Time',
             'Gap',
-            'Nodes',
+            'Node count',
             'Primal bound',
             'Dual bound',
         ),  # problem_milp_optimal(),
         (
             'Time',
             'Gap',
-            'Nodes',
+            'Node count',
             'Primal bound',
             'Dual bound',
         ),  # problem_milp_feasible()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes
N/A

## Summary/Motivation:
When running `pyomo solve` with the SCIP solver, the serialized results files don't show the number of nodes explored. The SCIPAMPL handler parses the number of nodes in the SCIP solver log and returns it from `read_scip_log`, but not in the solver results returned from `_postsolve`. Including it would make it easier to assess changes in tree size when benchmarking.

## Changes proposed in this PR:
- Report the node count in the SolverResults
- Update tests to expect this field

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
