### PR TITLE
Fix simulator bug

### DIFF
--- a/pyomo/dae/simulator.py
+++ b/pyomo/dae/simulator.py
@@ -175,9 +175,7 @@ def _check_viewsumexpression(expr, i):
         ):
             dv = item
         elif type(item) is EXPR.ProductExpression:
-            # This will contain the constant coefficient if there is one
             lhs = item.arg(0)
-            # This is a potentially variable expression
             rhs = item.arg(1)
             if (
                 type(lhs) in native_numeric_types or not lhs.is_potentially_variable()
@@ -187,6 +185,14 @@ def _check_viewsumexpression(expr, i):
             ):
                 dv = rhs
                 dvcoef = lhs
+            elif (
+                type(rhs) in native_numeric_types or not rhs.is_potentially_variable()
+            ) and (
+                isinstance(lhs, EXPR.GetItemExpression)
+                and type(lhs.arg(0)) is DerivativeVar
+            ):
+                dv = lhs
+                dvcoef = rhs
         else:
             items.append(item)
 

--- a/pyomo/dae/tests/test_simulator.py
+++ b/pyomo/dae/tests/test_simulator.py
@@ -411,6 +411,33 @@ class TestSimulator(unittest.TestCase):
         m.del_component('deqw')
         m.del_component('deqv_index')
         m.del_component('deqw_index')
+
+        def _deqv(m, i):
+            return m.v[i] ** 2 + m.v[i] == 10 * m.dv[i] + m.y
+
+        m.deqv = Constraint(m.t, rule=_deqv)
+
+        def _deqw(m, i, j):
+            return m.w[i, j] ** 2 + m.w[i, j] == m.y + m.dw[i, j] * 10
+
+        m.deqw = Constraint(m.t, m.s, rule=_deqw)
+
+        mysim = Simulator(m)
+
+        self.assertEqual(len(mysim._diffvars), 4)
+        self.assertEqual(mysim._diffvars[0], _GetItemIndexer(m.v[t]))
+        self.assertEqual(mysim._diffvars[1], _GetItemIndexer(m.w[t, 1]))
+        self.assertEqual(mysim._diffvars[2], _GetItemIndexer(m.w[t, 2]))
+        self.assertEqual(len(mysim._derivlist), 4)
+        self.assertEqual(mysim._derivlist[0], _GetItemIndexer(m.dv[t]))
+        self.assertEqual(mysim._derivlist[1], _GetItemIndexer(m.dw[t, 1]))
+        self.assertEqual(mysim._derivlist[2], _GetItemIndexer(m.dw[t, 2]))
+        self.assertEqual(len(mysim._rhsdict), 4)
+        m.del_component('deqv')
+        m.del_component('deqw')
+        m.del_component('deqv_index')
+        m.del_component('deqw_index')
+
         m.del_component('w')
         m.del_component('dw')
         m.del_component('p')


### PR DESCRIPTION
## Fixes #3690

## Summary/Motivation:
#3690 reported a bug in the simulator where if you had a differential equation of the form `A*dxdt + B == RHS` it would be handled differently than `dxdt*A + B == RHS`. Pyomo.DAE checks for certain forms that a differential equation may have been written in and tries to permute those forms to a standard separable format expected by the integrators. At one point I think product expressions would have been rearranged such that if `A` was not potentially variable it would have ALWAYS been moved to `arg[0]` in the `ProductExpression` so the Simulator only ever checked for `A*dxdt`. When we stopped doing automatic expression mangling in core Pyomo the assumption that the simulator didn't have to check for `dxdt*A` was no longer valid and the bug was introduced. This PR fixes it by ensuring the Simulator is checking for both cases.

## Changes proposed in this PR:
- Fix bug in simulator code for identifying separable differential equations.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
