### PR TITLE
Ipopt_v2: update options processing

### DIFF
--- a/pyomo/common/envvar.py
+++ b/pyomo/common/envvar.py
@@ -9,12 +9,39 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+"""Attributes describing the current platform and user configuration.
+
+This module provides standardized attributes that other parts of Pyomo
+can use to interrogate aspects of the current platform, and to find
+information about the current user configuration (including where to
+locate the main Pyomo configuration directory).
+
+"""
+
 import os
 import platform
 
+_platform = platform.system().lower()
+#: bool : True if running in a "native" Windows environment
+is_native_windows = _platform.startswith('windows')
+#: bool : True if running on Windows (native or cygwin)
+is_windows = is_native_windows or _platform.startswith('cygwin')
+#: bool : True if running on Mac/OSX
+is_osx = _platform.startswith('darwin')
+#: bool: True if running under the PyPy interpreter
+is_pypy = platform.python_implementation().lower().startswith('pypy')
+
+#: str : Absolute path to the user's Pyomo Configuration Directory.
+#:
+#:     By default, this is ``~/.pyomo`` on Linux and OSX and
+#:     ``%LOCALAPPDATA%/Pyomo`` on Windows.  It can be overridden by
+#:     setting the ``PYOMO_CONFIG_DIR`` environment variable before
+#:     importing Pyomo.
+PYOMO_CONFIG_DIR = None
+
 if 'PYOMO_CONFIG_DIR' in os.environ:
     PYOMO_CONFIG_DIR = os.path.abspath(os.environ['PYOMO_CONFIG_DIR'])
-elif platform.system().lower().startswith(('windows', 'cygwin')):
+elif is_windows:
     PYOMO_CONFIG_DIR = os.path.abspath(
         os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Pyomo')
     )

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -523,7 +523,7 @@ def to_legal_filename(name, universal=False) -> str:
     universal : bool
 
         If True, this will attempt a form of "universal" standardization
-        that uses the mose restrictive set of character translations and
+        that uses the most restrictive set of character translations and
         rules.  Currently, ``universal=True`` is equivalent to running
         the Windows translations.
 

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -505,6 +505,50 @@ def import_file(path, clear_cache=False, infer_package=True, module_name=None):
     return module
 
 
+def to_legal_filename(name, universal=False) -> str:
+    """Convert a string to a legal filename on the current platform.
+
+    This converts a candidate file name (not a path) and converts it to
+    a legal file name on the current platform.  This includes replacing
+    any unallowable characters (including the path separator) with
+    underscores (``_``), and on some platforms, enforcing restrictions
+    on the allowable final character.
+
+    Parameters
+    ----------
+    name : str
+
+        The original (desired) file name
+
+    universal : bool
+
+        If True, this will attempt a form of "universal" standardization
+        that uses the mose restrictive set of character translations and
+        rules.  Currently, ``universal=True`` is equivalent to running
+        the Windows translations.
+
+    """
+    if envvar.is_windows or universal:
+        tr = getattr(to_legal_filename, 'tr', None)
+        if tr is None:
+            # Windows illegal characters: 0-31, plus < > : " / \ | ? *
+            _illegal = r'<>:"/\|?*' + ''.join(map(chr, range(32)))
+            tr = to_legal_filename.tr = str.maketrans(_illegal, '_' * len(_illegal))
+        # Remove illegal characters
+        name = name.translate(tr)
+        if name:
+            # Windows allows filenames to end with space or dot, but the
+            # file explorer can't interact with them
+            if name[-1] in ' .':
+                name = name[:-1] + '_'
+            # Similarly, starting with a space is generally a bad idea
+            if name[0] == ' ':
+                name = '_' + name[1:]
+    else:
+        name = name.replace('/', '_').replace(chr(0), '_')
+    return name
+
+
 class PathData(object):
     """An object for storing and managing a :py:class:`PathManager` path"""
 

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -38,6 +38,7 @@ from pyomo.common.fileutils import (
     _libExt,
     ExecutableData,
     import_file,
+    to_legal_filename,
 )
 from pyomo.common.download import FileDownloader
 
@@ -497,3 +498,35 @@ class TestFileUtils(unittest.TestCase):
         Executable(f_in_path2).rehash()
         self.assertTrue(Executable(f_in_path2).available())
         self.assertEqual(Executable(f_in_path2).path(), f_loc)
+
+    def test_to_legal_filename(self):
+        self.assertEqual('abc', to_legal_filename('abc'))
+        self.assertEqual('', to_legal_filename(''))
+        if envvar.is_windows:
+            self.assertEqual('_abc', to_legal_filename(' abc'))
+            self.assertEqual('abc_', to_legal_filename('abc.'))
+            self.assertEqual('abc_', to_legal_filename('abc '))
+            self.assertEqual('abc_def', to_legal_filename('abc/def'))
+            self.assertEqual('abc_def', to_legal_filename('abc\\def'))
+            self.assertEqual(
+                'a_b_c', to_legal_filename(''.join(['a', chr(0), 'b', chr(7), 'c']))
+            )
+        else:
+            self.assertEqual(' abc', to_legal_filename(' abc'))
+            self.assertEqual('abc.', to_legal_filename('abc.'))
+            self.assertEqual('abc ', to_legal_filename('abc '))
+            self.assertEqual('abc_def', to_legal_filename('abc/def'))
+            self.assertEqual('abc\\def', to_legal_filename('abc\\def'))
+            self.assertEqual(
+                'a_b' + chr(7) + 'c',
+                to_legal_filename(''.join(['a', chr(0), 'b', chr(7), 'c'])),
+            )
+
+        self.assertEqual('_abc', to_legal_filename(' abc', True))
+        self.assertEqual('abc_', to_legal_filename('abc.', True))
+        self.assertEqual('abc_', to_legal_filename('abc ', True))
+        self.assertEqual('abc_def', to_legal_filename('abc/def', True))
+        self.assertEqual('abc_def', to_legal_filename('abc\\def', True))
+        self.assertEqual(
+            'a_b_c', to_legal_filename(''.join(['a', chr(0), 'b', chr(7), 'c']), True)
+        )

--- a/pyomo/contrib/solver/common/factory.py
+++ b/pyomo/contrib/solver/common/factory.py
@@ -16,9 +16,7 @@ from pyomo.contrib.solver.common.base import LegacySolverWrapper
 
 
 class SolverFactoryClass(Factory):
-    """ Factory class for generating instances of solver interfaces (API v2)
-
-    """
+    """Factory class for generating instances of solver interfaces (API v2)"""
 
     def register(self, name, legacy_name=None, doc=None):
         """Register a new solver with this solver factory
@@ -108,6 +106,7 @@ class SolverFactoryClass(Factory):
             return cls
 
         return decorator
+
 
 #: Global registry/factory for "v2" solver interfaces.
 SolverFactory: SolverFactoryClass = SolverFactoryClass()

--- a/pyomo/contrib/solver/common/factory.py
+++ b/pyomo/contrib/solver/common/factory.py
@@ -24,15 +24,19 @@ class SolverFactoryClass(Factory):
         if legacy_name is None:
             legacy_name = name
 
-        def decorator(cls):
+        def decorator(cls, legacy_cls=None):
             self._cls[name] = cls
             self._doc[name] = doc
 
-            class LegacySolver(LegacySolverWrapper, cls):
-                pass
+            if legacy_cls is None:
+
+                class LegacySolver(LegacySolverWrapper, cls):
+                    pass
+
+                legacy_cls = LegacySolver
 
             LegacySolverFactory.register(legacy_name, doc + " (new interface)")(
-                LegacySolver
+                legacy_cls
             )
 
             # Preserve the preferred name, as registered in the Factory

--- a/pyomo/contrib/solver/common/factory.py
+++ b/pyomo/contrib/solver/common/factory.py
@@ -97,9 +97,9 @@ class SolverFactoryClass(Factory):
 
                 legacy_cls = LegacySolver
 
-            LegacySolverFactory.register(legacy_name, doc + " (new interface)")(
-                legacy_cls
-            )
+            LegacySolverFactory.register(
+                legacy_name, doc + " (new interface)" if doc else doc
+            )(legacy_cls)
 
             # Preserve the preferred name, as registered in the Factory
             cls.name = name

--- a/pyomo/contrib/solver/common/factory.py
+++ b/pyomo/contrib/solver/common/factory.py
@@ -16,11 +16,75 @@ from pyomo.contrib.solver.common.base import LegacySolverWrapper
 
 
 class SolverFactoryClass(Factory):
-    """
-    Registers new interfaces in the legacy SolverFactory
+    """ Factory class for generating instances of solver interfaces (API v2)
+
     """
 
     def register(self, name, legacy_name=None, doc=None):
+        """Register a new solver with this solver factory
+
+        This will register the solver both with this
+        :attr:`SolverFactory` and with the original (legacy)
+        :attr:`~pyomo.opt.base.solvers.LegacySolverFactory`
+
+        Examples
+        --------
+
+        .. testcode::
+           :hide:
+
+           SolverFactory = SolverFactoryClass()
+
+        This method can either be called as a decorator on a solver
+        interface class definition, e.g.:
+
+        .. testcode::
+
+           from pyomo.contrib.solver.common.base import SolverBase
+
+           @SolverFactory.register("test_solver_1")
+           class TestSolver1(SolverBase):
+               pass
+
+        Or explicitly:
+
+        .. testcode::
+
+           class TestSolver2(SolverBase):
+               pass
+
+           SolverFactory.register("test_solver_2")(TestSolver2)
+
+        When called explicitly, you can pass a custom
+        LegacySolverInterface class:
+
+        .. testcode::
+
+           from pyomo.contrib.solver.common.base import LegacySolverWrapper
+
+           class LegacyTestSolver2(LegacySolverWrapper, TestSolver2):
+               pass
+
+           SolverFactory.register("test_solver_2a")(TestSolver2, LegacyTestSolver2)
+
+
+        Parameters
+        ----------
+        name : str
+
+            The name used to register this solver interface class
+
+        legacy_name : str
+
+            The name to use to register the legacy interface wrapper to
+            this solver interface in the LegacySolverInterface.  If
+            ``None``, then ``name`` will be used.
+
+        doc : str
+
+            Extended description of this solver interface.
+
+        """
         if legacy_name is None:
             legacy_name = name
 
@@ -45,5 +109,5 @@ class SolverFactoryClass(Factory):
 
         return decorator
 
-
-SolverFactory = SolverFactoryClass()
+#: Global registry/factory for "v2" solver interfaces.
+SolverFactory: SolverFactoryClass = SolverFactoryClass()

--- a/pyomo/contrib/solver/common/factory.py
+++ b/pyomo/contrib/solver/common/factory.py
@@ -53,8 +53,8 @@ class SolverFactoryClass(Factory):
 
            SolverFactory.register("test_solver_2")(TestSolver2)
 
-        When called explicitly, you can pass a custom
-        LegacySolverInterface class:
+        When called explicitly, you can pass a custom class to register
+        with the :attr:`LegacySolverFactory`:
 
         .. testcode::
 

--- a/pyomo/contrib/solver/common/util.py
+++ b/pyomo/contrib/solver/common/util.py
@@ -27,7 +27,7 @@ class NoFeasibleSolutionError(PyomoException):
 class NoOptimalSolutionError(PyomoException):
     default_message = (
         'Solver did not find the optimal solution. Set '
-        'opt.config.raise_exception_on_nonoptimal_result = False to bypass this error.'
+        'opt.config.raise_exception_on_nonoptimal_result=False to bypass this error.'
     )
 
 

--- a/pyomo/contrib/solver/plugins.py
+++ b/pyomo/contrib/solver/plugins.py
@@ -11,7 +11,7 @@
 
 
 from .common.factory import SolverFactory
-from .solvers.ipopt import Ipopt
+from .solvers.ipopt import Ipopt, LegacyIpoptSolver
 from .solvers.gurobi_persistent import GurobiPersistent
 from .solvers.gurobi_direct import GurobiDirect
 from .solvers.highs import Highs
@@ -20,7 +20,7 @@ from .solvers.highs import Highs
 def load():
     SolverFactory.register(
         name='ipopt', legacy_name='ipopt_v2', doc='The IPOPT NLP solver'
-    )(Ipopt)
+    )(Ipopt, LegacyIpoptSolver)
     SolverFactory.register(
         name='gurobi_persistent',
         legacy_name='gurobi_persistent_v2',

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -369,7 +369,14 @@ class Ipopt(SolverBase):
                 dname = config.working_dir
             if not os.path.exists(dname):
                 os.mkdir(dname)
-            basename = to_legal_filename(model.name)
+            # Because we are just "making up" a file name, it is better
+            # to always generate a consistent and legal name, rather
+            # than blindly follow what the user gave us.  We will use
+            # `universal=True` here to make sure that double quotes are
+            # translated, thereby guaranteeing that we should always
+            # generate a legal base name (unless, of course, the user
+            # put double quotes somewhere else in the path)
+            basename = to_legal_filename(model.name, universal=True)
             # Strip off quotes - the command line parser will re-add them
             if basename[0] in "'\"" and basename[0] == basename[-1]:
                 basename = basename[1:-1]

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -381,7 +381,9 @@ class Ipopt(SolverBase):
             # The base file name for this interface is "model_name + PID
             # + thread id", so that this is reasonably unique in both
             # parallel and threaded environments (even when working_dir
-            # is set to a persistent directory)
+            # is set to a persistent directory).  Note that the Pyomo
+            # solver interfaces are not formally thread-safe (yet), so
+            # this is a bit of future-proofing.
             basename = os.path.join(
                 dname, f"{basename}.{os.getpid()}.{threading.get_ident()}"
             )

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -295,11 +295,9 @@ class Ipopt(SolverBase):
         for key, msg in unallowed_ipopt_options.items():
             if key in config.solver_options:
                 raise ValueError(f"unallowed ipopt option '{key}': {msg}")
-        # Map standard Pyomo solver options to Ipopt options
-        if (
-            config.time_limit is not None
-            and 'max_cpu_time' not in config.solver_options
-        ):
+        # Map standard Pyomo solver options to Ipopt options: standard
+        # options override ipopt-specific options.
+        if config.time_limit is not None:
             config.solver_options['max_cpu_time'] = config.time_limit
 
     def _write_options_file(

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -31,6 +31,7 @@ from pyomo.common.errors import (
     DeveloperError,
     InfeasibleConstraintException,
 )
+from pyomo.common.fileutils import to_legal_filename
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.timing import HierarchicalTimer
 from pyomo.core.base.var import VarData
@@ -368,7 +369,7 @@ class Ipopt(SolverBase):
                 dname = config.working_dir
             if not os.path.exists(dname):
                 os.mkdir(dname)
-            basename = model.name
+            basename = to_legal_filename(model.name)
             # Strip off quotes - the command line parser will re-add them
             if basename[0] in "'\"" and basename[0] == basename[-1]:
                 basename = basename[1:-1]

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -178,7 +178,8 @@ class SolverFactoryClass(Factory):
         return opt
 
 
-LegacySolverFactory = SolverFactoryClass('solver type')
+#: Global registry/factory for "v1" solver interfaces.
+LegacySolverFactory: SolverFactoryClass = SolverFactoryClass('solver type')
 
 SolverFactory = SolverFactoryClass('solver type')
 SolverFactory._cls = LegacySolverFactory._cls


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
@eslickj pointed out two problems with the new `contrib.solver` Ipopt interface:
- naming your model anything with a space in it would cause ipopt to fail to parse any options from the option file
- The LegacySolver wrapper failed to process the `OF_` options that the original ipopt interface supported.  

This PR resolves both of those issues:
- Update how we generate the base file name to avoid the quotes that can be added when retrieving the model's local name.  In addition, we process the model name to ensure that it is a valid (allowable by the OS) file name.  Finally, we ensure that all string options passed to the solver on the command line are properly quoted.
- Create a custom Legacy wrapper for Ipopt that will correctly handle the old `OF_*` options
- Define a new utility for ensuring strings are valid file names
- Ensure that temporary filenames are more likely to be unique (by including the PID and thread id)
- Check to make sure the interface doesn't overwrite any existing files
- The standard Pyomo `time_limit` option overrides the ipopt-specific `max_cpu_time` option

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
