### PR TITLE
Parmest: Correct two very old test skips

### DIFF
--- a/pyomo/contrib/parmest/tests/test_graphics.py
+++ b/pyomo/contrib/parmest/tests/test_graphics.py
@@ -20,10 +20,6 @@ from pyomo.common.dependencies import (
     matplotlib_available,
 )
 
-import platform
-
-is_osx = platform.mac_ver()[0] != ''
-
 import pyomo.common.unittest as unittest
 import sys
 import os
@@ -42,10 +38,6 @@ testdir = os.path.dirname(os.path.abspath(__file__))
 )
 @unittest.skipIf(
     not graphics.imports_available, "parmest.graphics imports are unavailable"
-)
-@unittest.skipIf(
-    is_osx,
-    "Disabling graphics tests on OSX due to issue in Matplotlib, see Pyomo PR #1337",
 )
 class TestGraphics(unittest.TestCase):
     def setUp(self):

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -215,7 +215,7 @@ class TestRooneyBiegler(unittest.TestCase):
 
         self.pest.diagnostic_mode = False
 
-    @unittest.skip("Presently having trouble with mpiexec on appveyor")
+    @unittest.pytest.mark.mpi
     def test_parallel_parmest(self):
         """use mpiexec and mpi4py"""
         p = str(parmestbase.__path__)
@@ -229,7 +229,7 @@ class TestRooneyBiegler(unittest.TestCase):
             + os.sep
             + "rooney_biegler"
             + os.sep
-            + "rooney_biegler_parmest.py"
+            + "rooney_biegler.py"
         )
         rbpath = os.path.abspath(rbpath)  # paranoia strikes deep...
         rlist = ["mpiexec", "--allow-run-as-root", "-n", "2", sys.executable, rbpath]
@@ -1279,7 +1279,7 @@ class TestRooneyBieglerDeprecated(unittest.TestCase):
 
         self.pest.diagnostic_mode = False
 
-    @unittest.skip("Presently having trouble with mpiexec on appveyor")
+    @unittest.pytest.mark.mpi
     def test_parallel_parmest(self):
         """use mpiexec and mpi4py"""
         p = str(parmestbase.__path__)
@@ -1293,7 +1293,7 @@ class TestRooneyBieglerDeprecated(unittest.TestCase):
             + os.sep
             + "rooney_biegler"
             + os.sep
-            + "rooney_biegler_parmest.py"
+            + "rooney_biegler.py"
         )
         rbpath = os.path.abspath(rbpath)  # paranoia strikes deep...
         rlist = ["mpiexec", "--allow-run-as-root", "-n", "2", sys.executable, rbpath]


### PR DESCRIPTION

## Fixes N/A

## Summary/Motivation:
I stumbled across a couple of tests that were being skipped in parmest for very old reasons. I checked them locally, and they are actually fine, so this PR fixes those skips.

## Changes proposed in this PR:
- OSX + matplotlib can work together nicely now
- We haven't tested on AppVeyor in years
- A path changed

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
