### PR TITLE
Expanded LegacySolverWrapper fixes

### DIFF
--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -405,7 +405,7 @@ class LegacySolverWrapper:
         def __contains__(self, name):
             return True
 
-    class UpdatableConfigDict(ConfigDict):
+    class _UpdatableConfigDict(ConfigDict):
         # The legacy solver interface used Option objects.  we will make
         # the ConfigDict *look* like an Option by supporting update()
         __slots__ = ()
@@ -434,7 +434,7 @@ class LegacySolverWrapper:
         # config.solver_options; change its class so it behaves more
         # like an old Bunch/Options object.
         self.options = self.config.solver_options
-        self.options.__class__ = LegacySolverWrapper.UpdatableConfigDict
+        self.options.__class__ = LegacySolverWrapper._UpdatableConfigDict
         # We will assume the solver interface supports all capabilities
         # (unless a derived class actually set something
         if not hasattr(self, '_capabilities'):

--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -612,7 +612,7 @@ class LegacySolverWrapper:
         legacy_results.solution.insert(legacy_soln)
         # Timing info was not originally on the legacy results, but we
         # want to make it accessible to folks who are utilizing the
-        # backwards compatible version.  Note that embetting the
+        # backwards compatible version.  Note that embedding the
         # ConfigDict broke pickling the legacy_results, so we will only
         # return raw nested dicts
         legacy_results.timing_info = results.timing_info.value()

--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -605,7 +605,7 @@ class LegacySolverWrapper:
         # Timing info was not originally on the legacy results, but we want
         # to make it accessible to folks who are utilizing the backwards
         # compatible version.
-        legacy_results.timing_info = results.timing_info
+        legacy_results.timing_info = results.timing_info.value()
         if delete_legacy_soln:
             legacy_results.solution.delete(0)
         return legacy_results

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -349,7 +349,7 @@ class Ipopt(SolverBase):
                 dname = config.working_dir
             if not os.path.exists(dname):
                 os.mkdir(dname)
-            basename = os.path.join(dname, model.name)
+            basename = os.path.join(dname, model.name or 'unknown')
             if os.path.exists(basename + '.nl'):
                 raise RuntimeError(
                     f"NL file with the same name {basename + '.nl'} already exists!"

--- a/pyomo/contrib/solver/tests/unit/test_base.py
+++ b/pyomo/contrib/solver/tests/unit/test_base.py
@@ -24,7 +24,7 @@ class TestSolverBase(unittest.TestCase):
     def test_class_method_list(self):
         expected_list = ['CONFIG', 'available', 'is_persistent', 'solve', 'version']
         method_list = [
-            method for method in dir(base.SolverBase) if method.startswith('_') is False
+            method for method in dir(base.SolverBase) if not method.startswith('_')
         ]
         self.assertEqual(sorted(expected_list), sorted(method_list))
 
@@ -83,7 +83,7 @@ class TestPersistentSolverBase(unittest.TestCase):
         method_list = [
             method
             for method in dir(base.PersistentSolverBase)
-            if (method.startswith('__') or method.startswith('_abc')) is False
+            if not (method.startswith('__') or method.startswith('_abc'))
         ]
         self.assertEqual(sorted(expected_list), sorted(method_list))
 
@@ -138,7 +138,7 @@ class TestLegacySolverWrapper(unittest.TestCase):
         method_list = [
             method
             for method in dir(base.LegacySolverWrapper)
-            if method.startswith('_') is False
+            if not method.startswith('_')
         ]
         self.assertEqual(sorted(expected_list), sorted(method_list))
 

--- a/pyomo/contrib/solver/tests/unit/test_base.py
+++ b/pyomo/contrib/solver/tests/unit/test_base.py
@@ -131,9 +131,11 @@ class TestLegacySolverWrapper(unittest.TestCase):
         expected_list = [
             'available',
             'config_block',
+            'default_variable_value',
             'license_is_valid',
             'set_options',
             'solve',
+            'warm_start_capable',
         ]
         method_list = [
             method

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -53,7 +53,7 @@ _SUFFIX_API = (
 
 def suffix_generator(a_block, datatype=NOTSET, direction=NOTSET, active=None):
     _iter = (
-        (s.name, s)
+        (s.local_name, s)
         for s in a_block.component_data_objects(
             Suffix, active=active, descend_into=False
         )

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -52,7 +52,12 @@ _SUFFIX_API = (
 
 
 def suffix_generator(a_block, datatype=NOTSET, direction=NOTSET, active=None):
-    _iter = a_block.component_map(Suffix, active=active).items()
+    _iter = (
+        (s.name, s)
+        for s in a_block.component_data_objects(
+            Suffix, active=active, descend_into=False
+        )
+    )
     if direction is not NOTSET:
         direction = _SuffixDirectionDomain(direction)
         if not direction:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
While working with @AnhTran01, we realized that the `LegacySolverWrapper` in `pyomo.contrib.solver` was not compatible with the old solver regression tests in `pyomo.solvers`.  This PR expands the functionality so that new solvers wrapped in the `LegacySolverWrapper` can be run through that test suite.

## Changes proposed in this PR:
- Make `suffix_generator` compatible with kernel models
- Include `_capabilities`, `warm_start_capable`, and `default_variable_value` in the Legacy API
- Expose an `options` ConfigDict that is compatible with the `Bunch`/`Options` API
- Modify `timing_info` output so that it doesn't preclude pickling the legacy results object

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
