### PR TITLE
Standardize 'multiprocessing' deferred import

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -1082,6 +1082,7 @@ with declare_modules_as_importable(globals()):
     ctypes, _ = attempt_import(
         'ctypes', deferred_submodules=['util'], callback=_finalize_ctypes
     )
+    multiprocessing, _ = attempt_import('multiprocessing')
     random, _ = attempt_import('random')
 
     # Necessary for minimum version checking for other optional dependencies

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -11,7 +11,7 @@
 
 import os
 
-from .dependencies import ctypes
+from .dependencies import ctypes, multiprocessing
 
 
 def _as_bytes(val):
@@ -65,8 +65,6 @@ def _load_dll(name, timeout=10):
     """
     if not ctypes.util.find_library(name):
         return False, None
-
-    import multiprocessing
 
     if _load_dll.pool is None:
         try:

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -67,6 +67,11 @@ def _load_dll(name, timeout=10):
         return False, None
 
     if _load_dll.pool is None:
+        # Resolving the deferred multiprocessing import could change the
+        # local "multiprocessing" variable (replacing it with the
+        # imported module).  This can result in an UnboundLocalError.
+        # By explicitly declaring it "global" we can avoid the error.
+        global multiprocessing
         try:
             _load_dll.pool = multiprocessing.Pool(1)
         except AssertionError:

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -34,7 +34,7 @@ from unittest import *
 import unittest as _unittest
 
 from pyomo.common.collections import Mapping, Sequence
-from pyomo.common.dependencies import attempt_import, check_min_version
+from pyomo.common.dependencies import attempt_import, check_min_version, multiprocessing
 from pyomo.common.errors import InvalidValueError
 from pyomo.common.fileutils import import_file
 from pyomo.common.log import LoggingIntercept, pyomo_formatter
@@ -410,7 +410,6 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
 
     """
     import functools
-    import multiprocessing
     import queue
 
     def timeout_decorator(fcn):

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -12,7 +12,6 @@
 import itertools
 import logging
 import math
-import multiprocessing
 import os
 import threading
 import enum
@@ -27,7 +26,7 @@ from pyomo.common.config import (
 )
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.modeling import unique_component_name
-from pyomo.common.dependencies import dill, dill_available
+from pyomo.common.dependencies import dill, dill_available, multiprocessing
 
 from pyomo.core import (
     Block,


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Pyomo generally has deferred the import of the `multiprocessing` module to speed up import of `pyomo.environ`.  Recent changes in GDP (#3641) changed that and caused `multiprocessing` to be unconditionally imported.  This restores the previous behavior (and centralizes the deferred import into `pyomo.common.dependencies`.

## Changes proposed in this PR:
- Add `multiprocessing` to the list of deferred imports in `pyomo.common.dependencies`
- Standardize import of `multiprocessing` to use deferred import

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
