### PR TITLE
New TPL cache version on GHA workflows

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -147,7 +147,6 @@ jobs:
         else
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
-        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
             EXTRAS="$EXTRAS,docs,optional"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -199,7 +199,6 @@ jobs:
         else
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
-        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
             EXTRAS="$EXTRAS,docs,optional"


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
We realized from the GAMS V2 PR that the old GAMS version is still being used (29.1.0). After a bit of poking, the issue is that the older version is being downloaded in the TPL cache, and it shows up first on the path, so the new version is being completely ignored.

## Changes proposed in this PR:
- Update cache version number to refresh it

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
