### PR TITLE
Clean pyomo collections module

### DIFF
--- a/doc/OnlineDocs/_templates/recursive-module.rst
+++ b/doc/OnlineDocs/_templates/recursive-module.rst
@@ -94,7 +94,7 @@ Library Reference
    :toctree:
    :template: recursive-module.rst
    :recursive:
-{% for item in modules %}
+{% for item in all_modules %}
 {# Need item != tests for Sphinx >= 8.0; !endswith(.tests) for < 8.0 #}
 {% if item != 'tests' and not item.endswith('.tests')
    and item != 'examples' and not item.endswith('.examples') %}

--- a/pyomo/_archive/__init__.py
+++ b/pyomo/_archive/__init__.py
@@ -13,6 +13,6 @@ __doc__ = """This package contains archived modules that are no longer part of t
 official Pyomo API.
 
 These modules are still importable through their old names via
-:func:`pyomo.common.moved_module()`
+:func:`pyomo.common.deprecation.moved_module()`
 
 """

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -10,10 +10,10 @@
 #  ___________________________________________________________________________
 
 
-from collections.abc import MutableMapping, MutableSet, Mapping, Set, Sequence
-from collections import UserDict
+from collections import OrderedDict, UserDict
+from collections.abc import Mapping, MutableMapping, MutableSet, Sequence, Set
 
-from .orderedset import OrderedDict, OrderedSet
+from .bunch import Bunch
 from .component_map import ComponentMap, DefaultComponentMap
 from .component_set import ComponentSet
-from .bunch import Bunch
+from .orderedset import OrderedSet

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -12,7 +12,18 @@
 from collections import defaultdict
 
 
-class _Hasher(defaultdict):
+class Hasher(defaultdict):
+    """
+    Hasher is a dictionary-like class that provides a consistent hashing for Python objects.
+
+    This class allows registration of custom hashing functions for specific types. When an object is passed to the Hasher, it determines the appropriate hashing strategy based on the object's type:
+    - If a custom hashing function is registered for the type, it is used.
+    - If the object is natively hashable, the default hash is used.
+    - If the object is unhashable, the object's `id()` is used as a fallback.
+
+    The Hasher also includes a special handling for tuples by recursively applying the appropriate hashing strategy to each element within the tuple.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(lambda: self._missing_impl, *args, **kwargs)
         self[tuple] = self._tuple
@@ -49,4 +60,7 @@ class _Hasher(defaultdict):
         self[cls] = self._hashable if hashable else self._unhashable
 
 
-hasher = _Hasher()
+# The global 'hasher' instance manages
+# registered hashing functions for different
+# types.
+hasher = Hasher()

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -63,7 +63,9 @@ class Hasher(defaultdict):
 
 
 #: The global 'hasher' instance for managing "universal" hashing
-#:
-#: This instance of the :class:`Hasher` is used by :class:`ComponentMap` and
-#: :class:`ComponentSet` for generating hashes for all Python and Pyomo types.
+#
+#: This instance of the :class:`Hasher` is used by
+#: :class:`~pyomo.common.collections.cmponent_map.ComponentMap` and
+#: :class:`~pyomo.common.collections.cmponent_map.ComponentSet` for
+#: generating hashes for all Python and Pyomo types.
 hasher = Hasher()

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -12,17 +12,18 @@
 from collections import defaultdict
 
 
-class Hasher(defaultdict):
+class HashDispatcher(defaultdict):
     """Dispatch table for generating "universal" hashing of all Python objects.
 
     This class manages a dispatch table for providing hash functions for all Python
     types.  When an object is passed to the Hasher, it determines the appropriate
     hashing strategy based on the object's type:
-    - If a custom hashing function is registered for the type, it is used.
-    - If the object is natively hashable, the default hash is used.
-    - If the object is unhashable, the object's `id()` is used as a fallback.
 
-    The Hasher also includes a special handling for tuples by recursively applying the
+      - If a custom hashing function is registered for the type, it is used.
+      - If the object is natively hashable, the default hash is used.
+      - If the object is unhashable, the object's :func:`id()` is used as a fallback.
+
+    The Hasher also includes special handling for tuples by recursively applying the
     appropriate hashing strategy to each element within the tuple.
     """
 
@@ -62,10 +63,10 @@ class Hasher(defaultdict):
         self[cls] = self._hashable if hashable else self._unhashable
 
 
-#: The global 'hasher' instance for managing "universal" hashing
-#
-#: This instance of the :class:`Hasher` is used by
-#: :class:`~pyomo.common.collections.cmponent_map.ComponentMap` and
-#: :class:`~pyomo.common.collections.cmponent_map.ComponentSet` for
+#: The global 'hasher' instance for managing "universal" hashing.
+#:
+#: This instance of the :class:`HashDispatcher` is used by
+#: :class:`~pyomo.common.collections.component_map.ComponentMap` and
+#: :class:`~pyomo.common.collections.component_set.ComponentSet` for
 #: generating hashes for all Python and Pyomo types.
-hasher = Hasher()
+hasher = HashDispatcher()

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -13,15 +13,17 @@ from collections import defaultdict
 
 
 class Hasher(defaultdict):
-    """
-    Hasher is a dictionary-like class that provides a consistent hashing for Python objects.
+    """Dispatch table for generating "universal" hashing of all Python objects.
 
-    This class allows registration of custom hashing functions for specific types. When an object is passed to the Hasher, it determines the appropriate hashing strategy based on the object's type:
+    This class manages a dispatch table for providing hash functions for all Python 
+    types.  When an object is passed to the Hasher, it determines the appropriate
+    hashing strategy based on the object's type:
     - If a custom hashing function is registered for the type, it is used.
     - If the object is natively hashable, the default hash is used.
     - If the object is unhashable, the object's `id()` is used as a fallback.
 
-    The Hasher also includes a special handling for tuples by recursively applying the appropriate hashing strategy to each element within the tuple.
+    The Hasher also includes a special handling for tuples by recursively applying the
+    appropriate hashing strategy to each element within the tuple.
     """
 
     def __init__(self, *args, **kwargs):

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 class Hasher(defaultdict):
     """Dispatch table for generating "universal" hashing of all Python objects.
 
-    This class manages a dispatch table for providing hash functions for all Python 
+    This class manages a dispatch table for providing hash functions for all Python
     types.  When an object is passed to the Hasher, it determines the appropriate
     hashing strategy based on the object's type:
     - If a custom hashing function is registered for the type, it is used.

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -1,0 +1,52 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2025
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from collections import defaultdict
+
+
+class _Hasher(defaultdict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(lambda: self._missing_impl, *args, **kwargs)
+        self[tuple] = self._tuple
+
+    def _missing_impl(self, val):
+        try:
+            hash(val)
+            self[val.__class__] = self._hashable
+        except:
+            self[val.__class__] = self._unhashable
+        return self[val.__class__](val)
+
+    @staticmethod
+    def _hashable(val):
+        return val
+
+    @staticmethod
+    def _unhashable(val):
+        return id(val)
+
+    def _tuple(self, val):
+        return tuple(self[i.__class__](i) for i in val)
+
+    def hashable(self, obj, hashable=None):
+        if isinstance(obj, type):
+            cls = obj
+        else:
+            cls = type(obj)
+        if hashable is None:
+            fcn = self.get(cls, None)
+            if fcn is None:
+                raise KeyError(obj)
+            return fcn is self._hashable
+        self[cls] = self._hashable if hashable else self._unhashable
+
+
+hasher = _Hasher()

--- a/pyomo/common/collections/_hasher.py
+++ b/pyomo/common/collections/_hasher.py
@@ -60,7 +60,8 @@ class Hasher(defaultdict):
         self[cls] = self._hashable if hashable else self._unhashable
 
 
-# The global 'hasher' instance manages
-# registered hashing functions for different
-# types.
+#: The global 'hasher' instance for managing "universal" hashing
+#:
+#: This instance of the :class:`Hasher` is used by :class:`ComponentMap` and
+#: :class:`ComponentSet` for generating hashes for all Python and Pyomo types.
 hasher = Hasher()

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -9,13 +9,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from collections import OrderedDict
 from collections.abc import MutableSet
+
 from pyomo.common.autoslots import AutoSlots
 
 
 class OrderedSet(AutoSlots.Mixin, MutableSet):
-    __slots__ = ('_dict',)
+    __slots__ = ("_dict",)
 
     def __init__(self, iterable=None):
         # Starting in Python 3.7, dict is ordered (and is faster than
@@ -26,7 +26,7 @@ class OrderedSet(AutoSlots.Mixin, MutableSet):
 
     def __str__(self):
         """String representation of the mapping."""
-        return "OrderedSet(%s)" % (', '.join(repr(x) for x in self))
+        return "OrderedSet(%s)" % (", ".join(repr(x) for x in self))
 
     def update(self, iterable):
         if isinstance(iterable, OrderedSet):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes NA

## Summary/Motivation:

This PR introduce some refactoring of the pyomo collections module.

## Changes proposed in this PR:
- Create a separate file for the hasher.
- Remove `OrderDict` import from `orderset`.
- Sort imports.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
