### PR TITLE
Work around environments where `IntEnum.__doc__` is None

### DIFF
--- a/pyomo/common/enums.py
+++ b/pyomo/common/enums.py
@@ -42,6 +42,8 @@ if sys.version_info[:2] < (3, 11):
 else:
     _EnumType = enum.EnumType
 if sys.version_info[:2] < (3, 13):
+    import inspect
+
     # prior to 3.13 the int.{to,from}_bytes docstrings had LaTeX-like
     # "`..'" quotations, which Sphinx can't parse correctly.
     def _fix_doc(ref):
@@ -53,7 +55,8 @@ if sys.version_info[:2] < (3, 13):
 
     class IntEnum(enum.IntEnum):
         __doc__ = (
-            """A compatibility wrapper around :class:`enum.IntEnum`
+            inspect.cleandoc(
+                """A compatibility wrapper around :class:`enum.IntEnum`
 
         This wrapper class updates the :meth:`to_bytes` and
         :meth:`from_bytes` docstrings in Python <= 3.12 to suppress
@@ -62,7 +65,9 @@ if sys.version_info[:2] < (3, 13):
         .. rubric:: IntEnum
 
         """
-            + enum.IntEnum.__doc__
+            )
+            + "\n\n"
+            + inspect.cleandoc(getattr(enum.IntEnum, "__doc__", "") or "")
         )
 
         @_fix_doc(enum.IntEnum.to_bytes)

--- a/pyomo/common/enums.py
+++ b/pyomo/common/enums.py
@@ -67,6 +67,7 @@ if sys.version_info[:2] < (3, 13):
         """
             )
             + "\n\n"
+            # There are environments where IntEnum.__doc__ is None (see #3710)
             + inspect.cleandoc(getattr(enum.IntEnum, "__doc__", "") or "")
         )
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3710 .

## Summary/Motivation:
There are apparently environments where `enum.IntEnum.__doc__` is None.  This works around those situations, plus does a little extra work to ensure that the docstring is rendered cleanly by Sphinx

## Changes proposed in this PR:
- Catch situation where `enum.IntEnum.__doc__` is None.  
- Make more effort to ensure combined docstring is formatted (indented) correctly.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
