### PR TITLE
Pyomo.DoE: Bugfix for GreyBox

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -359,8 +359,7 @@ class DesignOfExperiments:
                         )
             # Set objective value
             if self.objective_option == ObjectiveLib.trace:
-                # Do safe inverse here?
-                trace_val = 1 / np.trace(np.array(self.get_FIM()))
+                trace_val = np.trace(np.linalg.pinv(self.get_FIM()))
                 model.obj_cons.egb_fim_block.outputs["A-opt"].set_value(trace_val)
             elif self.objective_option == ObjectiveLib.determinant:
                 det_val = np.linalg.det(np.array(self.get_FIM()))

--- a/pyomo/contrib/doe/grey_box_utilities.py
+++ b/pyomo/contrib/doe/grey_box_utilities.py
@@ -420,7 +420,9 @@ class FIMExternalGreyBox(
                 # there is an additional element. A more detailed
                 # explanation is included in the documentation.
                 multiplier = ((i != j) + (k != l)) + ((i != j) and (k != l)) * (i != k)
-                hess_vals[-1] += multiplier * (Minv[i, l] * Minv_sq[k, j]) + (Minv_sq[i, l] * Minv[k, j])
+                hess_vals[-1] += multiplier * (Minv[i, l] * Minv_sq[k, j]) + (
+                    Minv_sq[i, l] * Minv[k, j]
+                )
 
         elif self.objective_option == ObjectiveLib.determinant:
             # Grab inverse

--- a/pyomo/contrib/doe/grey_box_utilities.py
+++ b/pyomo/contrib/doe/grey_box_utilities.py
@@ -420,9 +420,9 @@ class FIMExternalGreyBox(
                 # there is an additional element. A more detailed
                 # explanation is included in the documentation.
                 multiplier = ((i != j) + (k != l)) + ((i != j) and (k != l)) * (i != k)
-                hess_vals[-1] += multiplier * ((Minv[i, l] * Minv_sq[k, j]) + (
-                    Minv_sq[i, l] * Minv[k, j]
-                ))
+                hess_vals[-1] += multiplier * (
+                    (Minv[i, l] * Minv_sq[k, j]) + (Minv_sq[i, l] * Minv[k, j])
+                )
 
         elif self.objective_option == ObjectiveLib.determinant:
             # Grab inverse

--- a/pyomo/contrib/doe/grey_box_utilities.py
+++ b/pyomo/contrib/doe/grey_box_utilities.py
@@ -420,9 +420,9 @@ class FIMExternalGreyBox(
                 # there is an additional element. A more detailed
                 # explanation is included in the documentation.
                 multiplier = ((i != j) + (k != l)) + ((i != j) and (k != l)) * (i != k)
-                hess_vals[-1] += multiplier * (Minv[i, l] * Minv_sq[k, j]) + (
+                hess_vals[-1] += multiplier * ((Minv[i, l] * Minv_sq[k, j]) + (
                     Minv_sq[i, l] * Minv[k, j]
-                )
+                ))
 
         elif self.objective_option == ObjectiveLib.determinant:
             # Grab inverse

--- a/pyomo/contrib/doe/tests/test_greybox.py
+++ b/pyomo/contrib/doe/tests/test_greybox.py
@@ -532,9 +532,6 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Get numerical derivative matrix
         jac_FD = get_numerical_derivative(grey_box_object)
 
-        print(jac_FD)
-        print(jac)
-
         # assert that each component is close
         self.assertTrue(np.all(np.isclose(jac, jac_FD, rtol=1e-4, atol=1e-4)))
 
@@ -629,8 +626,6 @@ class TestFIMExternalGreyBox(unittest.TestCase):
 
         # Get numerical derivative matrix
         hess_FD = get_numerical_second_derivative(grey_box_object)
-        print("hess_FD", hess_FD)
-        print("hess_gb", hess_gb)
 
         # assert that each component is close
         self.assertTrue(np.all(np.isclose(hess_gb, hess_FD, rtol=1e-4, atol=1e-4)))
@@ -1015,12 +1010,6 @@ class TestFIMExternalGreyBox(unittest.TestCase):
 
         # Solve the model
         doe_object.run_doe()
-
-        print("Termination Message")
-        print(doe_object.results["Termination Message"])
-        print(cyipopt_call_working)
-        print(bad_message in doe_object.results["Termination Message"])
-        print("End Message")
 
         optimal_time_val = doe_object.results["Experiment Design"][0]
         optimal_obj_val = np.log10(np.exp(pyo.value(doe_object.model.objective)))

--- a/pyomo/contrib/doe/tests/test_greybox.py
+++ b/pyomo/contrib/doe/tests/test_greybox.py
@@ -215,9 +215,11 @@ def get_numerical_second_derivative(grey_box_object=None, return_reduced=True):
         for i in ordered_quads:
             row = ordered_pairs_list.index(i[0])
             col = ordered_pairs_list.index(i[1])
-            numerical_derivative_reduced[row, col] = numerical_derivative[
-                i[0][0], i[0][1], i[1][0], i[1][1]
-            ]
+            i, j, k, l = i[0][0], i[0][1], i[1][0], i[1][1]
+            multiplier = 1 + ((i != j) + (k != l)) + ((i != j) and (k != l)) * (i != k)
+            numerical_derivative_reduced[row, col] = (
+                multiplier * numerical_derivative[i, j, k, l]
+            )
 
         numerical_derivative_reduced += (
             numerical_derivative_reduced.transpose()
@@ -524,10 +526,14 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Recover the Jacobian in Matrix Form
         jac = np.zeros_like(grey_box_object._get_FIM())
         jac[np.triu_indices_from(jac)] = utri_vals_jac
-        jac += jac.transpose() - np.diag(np.diag(jac))
+        jac += jac.transpose()
+        jac = jac / 2
 
         # Get numerical derivative matrix
         jac_FD = get_numerical_derivative(grey_box_object)
+
+        print(jac_FD)
+        print(jac)
 
         # assert that each component is close
         self.assertTrue(np.all(np.isclose(jac, jac_FD, rtol=1e-4, atol=1e-4)))
@@ -547,7 +553,8 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Recover the Jacobian in Matrix Form
         jac = np.zeros_like(grey_box_object._get_FIM())
         jac[np.triu_indices_from(jac)] = utri_vals_jac
-        jac += jac.transpose() - np.diag(np.diag(jac))
+        jac += jac.transpose()
+        jac = jac / 2
 
         # Get numerical derivative matrix
         jac_FD = get_numerical_derivative(grey_box_object)
@@ -570,7 +577,8 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Recover the Jacobian in Matrix Form
         jac = np.zeros_like(grey_box_object._get_FIM())
         jac[np.triu_indices_from(jac)] = utri_vals_jac
-        jac += jac.transpose() - np.diag(np.diag(jac))
+        jac += jac.transpose()
+        jac = jac / 2
 
         # Get numerical derivative matrix
         jac_FD = get_numerical_derivative(grey_box_object)
@@ -593,7 +601,8 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Recover the Jacobian in Matrix Form
         jac = np.zeros_like(grey_box_object._get_FIM())
         jac[np.triu_indices_from(jac)] = utri_vals_jac
-        jac += jac.transpose() - np.diag(np.diag(jac))
+        jac += jac.transpose()
+        jac = jac / 2
 
         # Get numerical derivative matrix
         jac_FD = get_numerical_derivative(grey_box_object)
@@ -620,6 +629,8 @@ class TestFIMExternalGreyBox(unittest.TestCase):
 
         # Get numerical derivative matrix
         hess_FD = get_numerical_second_derivative(grey_box_object)
+        print("hess_FD", hess_FD)
+        print("hess_gb", hess_gb)
 
         # assert that each component is close
         self.assertTrue(np.all(np.isclose(hess_gb, hess_FD, rtol=1e-4, atol=1e-4)))
@@ -990,7 +1001,10 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # (time, optimal objective value)
         # Here, the objective value is
         # log-10(determinant) of the FIM
-        optimal_experimental_designs = [np.array([2.24, 4.33]), np.array([10.00, 4.35])]
+        optimal_experimental_designs = [
+            np.array([1.782, 4.34]),
+            np.array([10.00, 4.35]),
+        ]
         objective_option = "determinant"
         doe_object, grey_box_object = make_greybox_and_doe_objects_rooney_biegler(
             objective_option=objective_option
@@ -1035,7 +1049,7 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Here, the objective value is
         # trace(inverse(FIM))
         optimal_experimental_designs = [
-            np.array([1.94, 0.0295]),
+            np.array([1.33, 0.0277]),
             np.array([9.9, 0.0366]),
         ]
         objective_option = "trace"
@@ -1076,7 +1090,7 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Here, the objective value is
         # minimum eigenvalue of the FIM
         optimal_experimental_designs = [
-            np.array([1.92, 36.018]),
+            np.array([1.30, 38.70]),
             np.array([10.00, 28.349]),
         ]
         objective_option = "minimum_eigenvalue"
@@ -1117,7 +1131,7 @@ class TestFIMExternalGreyBox(unittest.TestCase):
         # Here, the objective value is
         # condition number of the FIM
         optimal_experimental_designs = [
-            np.array([1.59, 15.22]),
+            np.array([0.943, 13.524]),
             np.array([10.00, 27.675]),
         ]
         objective_option = "condition_number"


### PR DESCRIPTION
## Fixes # .
GreyBox derivatives now match expected values between cyIPOPT and IPOPT.

## Summary/Motivation:
GreyBox would converge to points very slightly away from a fixed point. The issue stemmed from using a triangular version of the FIM. In this manner, the excluded elements from triangularization would not have impact on the GreyBox output, causing the gradient (and hessian) to be incorrect for off-diagonal elements of the FIM.


## Changes proposed in this PR:
- Corrected math in the grey box utilities file for Pyomo.DoE
- Corrected the tests to now check the symmetric-space derivatives instead of the full-space derivatives

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
