### PR TITLE
Pin windows python to 3.13.5

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -352,10 +352,6 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == 3.13* ]]; then
-            # As of Nov 7, 2024, qtconsole is not compatible with python 3.13 on win
-            EXCLUDE="qtconsole $EXCLUDE"
-        fi
         EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -97,6 +97,11 @@ jobs:
         other: [""]
         category: [""]
 
+        # HACK: Avoid 3.13.7 on Windows. We exclude this originally...
+        exclude:
+        - os: windows-latest
+          python: 3.13
+
         include:
         - os: ubuntu-latest
           test_docs: 1
@@ -109,6 +114,15 @@ jobs:
           PYENV: pip
 
         - os: windows-latest
+          test_docs: 1
+          TARGET: win
+          PYENV: conda
+          PACKAGES: glpk pytest-qt filelock
+
+        # Now manually add 3.13.5 back in. Ergo, all other OS' will
+        # run 3.13.7, but windows, the problem child, will not
+        - os: windows-latest
+          python: '3.13.5'
           test_docs: 1
           TARGET: win
           PYENV: conda
@@ -403,10 +417,6 @@ jobs:
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
-        fi
-        if [[ "${{matrix.TARGET}}" == win && "${{matrix.python}}" == 3.13* ]]; then
-            # As of Nov 7, 2024, qtconsole is not compatible with python 3.13 on win
-            EXCLUDE="qtconsole $EXCLUDE"
         fi
         EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
Python 3.13.7 has strange behavior in how conda + pip interact on Windows. Pinning to one supported version prior (3.13.5) resolves the issues.

I have reported the problem in this issue: https://github.com/python/cpython/issues/138691

## Changes proposed in this PR:
- Pin windows to 3.13.5 (allow other OS' to use 3.13.7)
- `qtconsole` is now supported for 3.13, so get rid of that logic

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
