### PR TITLE
Restore Xpress workflow

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -375,22 +375,10 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
-            # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
-            # release on that platform.
-            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                # We would like to just use something like:
-                #  - "!=9.5.1" (conda errors)
-                #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
-                #  - "<=9.5.0|>9.5.1" (conda seg faults)
-                XPRESS='xpress>=9.5.2'
-            else
-                XPRESS='xpress'
-            fi
             TIMEOUT_MSG="TIMEOUT: killing conda install process"
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -441,22 +441,10 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
-            # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
-            # release on that platform.
-            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
-                # We would like to just use something like:
-                #  - "!=9.5.1" (conda errors)
-                #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)
-                #  - "<=9.5.0|>9.5.1" (conda seg faults)
-                XPRESS='xpress>=9.5.2'
-            else
-                XPRESS='xpress'
-            fi
             TIMEOUT_MSG="TIMEOUT: killing conda install process"
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""


### PR DESCRIPTION
Hi!

I looked into the `xpress.init()` hanging issue, and it seems to have been resolved with newer versions of Xpress. 

This PR simply removes the specialized code that was added to avoid the hanging scenario.

Feel free to let me know if you still see issues with the workflow!

Thanks,
Francesco
