### PR TITLE
Fix two issues with ipopt output parsing

### DIFF
--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 # Acceptable chars for the end of the alpha_pr column
 # in ipopt's output, per https://coin-or.github.io/Ipopt/OUTPUT.html
-_ALPHA_PR_CHARS = set("fFhHkKnNRwstTr")
+_ALPHA_PR_CHARS = set("fFhHkKnNRwsStTr")
 
 
 class IpoptConfig(SolverConfig):
@@ -613,6 +613,16 @@ class Ipopt(SolverBase):
 
             for line in iter_table:
                 tokens = line.strip().split()
+
+                # The ipopt output squishes the first and second columns
+                # if the first has a restoration flag and the second has a minus sign,
+                # like this: 2631r-2.9874883e+03. Catch and avoid it.
+                first = tokens[0]
+                if 'r-' in first:
+                    it, obj = first.split('r', 1)
+                    tokens.insert(0, it + 'r')
+                    tokens[1] = obj
+
                 if len(tokens) != len(columns):
                     continue
                 iter_data = dict(zip(columns, tokens))


### PR DESCRIPTION


<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
Minor changes to IPOPT output table parsing.

## Summary/Motivation:
The IPOPT output table can look like:
```
2121r-3.0297310e+03 2.70e-01 1.00e+03  -0.6 0.00e+00    -  0.00e+00 2.77e-07R  6
2122r-3.0144871e+03 9.46e-02 1.00e+03  -0.6 6.80e+03    -  4.34e-03 2.24e-03f  1
2123 -3.0145760e+03 9.46e-02 2.28e+02  -1.7 4.56e+02    -  6.14e-03 1.95e-04f  1
2124 -3.0145339e+03 9.46e-02 9.09e+04  -1.7 9.98e+02    -  5.13e-02 4.23e-05h  1
```
Notice there is not space between the first two columns. This PR notices and parses this correctly.

Also, according to https://coin-or.github.io/Ipopt/OUTPUT.html, capital 'S' is a valid alpha_pr tag, so this PR adds it as such.

## Changes proposed in this PR:
- Handled when first two columns get squished
- Added 'S' to _ALPHA_PR_CHARS

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
