### PR TITLE
Change how `available` and `license` work in new solver interfaces

### DIFF
--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -64,7 +64,7 @@ class Availability(IntEnum):
 
     LicenseError = -2
     """The solver was found but no usable license is available. This could
-    indicate either that no license was found, an expired or misformed
+    indicate either that no license was found, an expired or malformed
     license was found, or the license is incorrect for the problem type."""
 
     def __bool__(self):

--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -55,6 +55,7 @@ class Availability(IntEnum):
     LimitedLicense = 1
     """The solver was found and a limited license (e.g., demo license) is
     accessible to use."""
+
     NotFound = 0
     """The solver was not found, either because the executable was not
     on the path or the solver package is not importable."""

--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -53,7 +53,7 @@ class Availability(IntEnum):
     """The solver was found and a full license is accessible to use."""
 
     LimitedLicense = 1
-    """The solver was found and a limited license (e.g., demo license is
+    """The solver was found and a limited license (e.g., demo license) is
     accessible to use."""
     NotFound = 0
     """The solver was not found, either because the executable was not

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -326,7 +326,7 @@ class GurobiSolverMixin:
                 pass
 
     def version(self, recheck: bool = False) -> Optional[Tuple[int, int, int]]:
-        if not recheck and self._version is not None:
+        if not recheck and self._version_cache is not None:
             return self._version_cache
 
         if not self._gurobipy_available:

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -271,7 +271,7 @@ class GurobiSolverMixin:
         # allows different derived interfaces to have different
         # availability (e.g., persistent has a minimum version
         # requirement that the direct interface doesn't)
-        if not self._is_gp_available():
+        if not self._is_gp_available:
             self.__class__._available_cache = Availability.NotFound
         else:
             with capture_output(capture_fd=True):
@@ -333,7 +333,7 @@ class GurobiSolverMixin:
         if not recheck and self._version_cache is not None:
             return self._version_cache
 
-        if not self._is_gp_available():
+        if not self._is_gp_available:
             return None
 
         self.__class__._version_cache = (

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -292,13 +292,10 @@ class GurobiSolverMixin:
         Build a tiny model (>2000 vars) to test demo/community limits and
         classify license level.
         """
-        env = type(self)._gurobipy_env
-        if env is None:
-            # license handle couldn’t acquire an env (e.g., timeout)
-            return Availability.LicenseError
-
+        env = None
         m = None
         try:
+            env = gurobipy.Env()
             env.setParam("OutputFlag", 0)
             m = gurobipy.Model(env=env)
             m.Params.OutputFlag = 0
@@ -326,6 +323,11 @@ class GurobiSolverMixin:
             try:
                 if m is not None:
                     m.dispose()
+            except Exception:
+                pass
+            try:
+                if env is not None:
+                    env.close()
             except Exception:
                 pass
 

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -326,10 +326,12 @@ class GurobiSolverMixin:
                 pass
 
     def version(self, recheck: bool = False) -> Optional[Tuple[int, int, int]]:
+        if not recheck and self._version is not None:
+            return self._version_cache
+
         if not self._gurobipy_available:
             return None
-
-        if recheck or self._version_cache is None:
+        else:
             self.__class__._version_cache = (
                 gurobipy.GRB.VERSION_MAJOR,
                 gurobipy.GRB.VERSION_MINOR,

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -271,7 +271,7 @@ class GurobiSolverMixin:
         # allows different derived interfaces to have different
         # availability (e.g., persistent has a minimum version
         # requirement that the direct interface doesn't)
-        if not self._is_gp_available:
+        if not self._is_gp_available():
             self.__class__._available_cache = Availability.NotFound
         else:
             with capture_output(capture_fd=True):
@@ -333,7 +333,7 @@ class GurobiSolverMixin:
         if not recheck and self._version_cache is not None:
             return self._version_cache
 
-        if not self._is_gp_available:
+        if not self._is_gp_available():
             return None
 
         self.__class__._version_cache = (

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
@@ -106,16 +106,14 @@ class TestGurobiMixin(unittest.TestCase):
 
     def test_available_notfound(self):
         mixin = GurobiSolverMixin()
-        with unittest.mock.patch.object(
-            GurobiSolverMixin, "_gurobipy_available", False
-        ):
+        with unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", False):
             self.assertEqual(mixin.available(), Availability.NotFound)
 
     def test_available_full_license(self):
         opt = GurobiDirect()
         mock_gp = self.mocked_gurobipy("ok")
         with (
-            unittest.mock.patch.object(type(opt), "_gurobipy_available", True),
+            unittest.mock.patch.object(type(opt), "_is_gp_available", True),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -125,7 +123,7 @@ class TestGurobiMixin(unittest.TestCase):
         opt = GurobiDirect()
         mock_gp = self.mocked_gurobipy("too_large")
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -138,7 +136,7 @@ class TestGurobiMixin(unittest.TestCase):
         env_error = self.GurobiError("no gurobi license", errno=10009)
         mock_gp = self.mocked_gurobipy(license_status="ok", env_side_effect=env_error)
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -151,7 +149,7 @@ class TestGurobiMixin(unittest.TestCase):
         # FullLicense
         mock_full = self.mocked_gurobipy("ok")
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_full),
         ):
             self.assertEqual(opt.available(recheck=True), Availability.FullLicense)

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
@@ -1,0 +1,198 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2025
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.common.tee import capture_output
+from pyomo.common import unittest
+
+from pyomo.contrib.solver.solvers.gurobi_direct import (
+    gurobipy_available,
+    GurobiSolverMixin,
+    GurobiDirect,
+)
+
+from pyomo.contrib.solver.common.base import Availability
+
+
+class TestGurobiMixin(unittest.TestCase):
+
+    MODULE_PATH = "pyomo.contrib.solver.solvers.gurobi_direct"
+
+    def setUp(self):
+        # Reset shared state before each test
+        GurobiSolverMixin._gurobipy_env = None
+        GurobiSolverMixin._available_cache = None
+        GurobiSolverMixin._version_cache = None
+        GurobiSolverMixin._num_gurobipy_env_clients = 0
+
+    class GurobiError(Exception):
+        def __init__(self, msg="", errno=None):
+            super().__init__(msg)
+            self.errno = errno
+
+    class Env:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+
+        def setParam(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    class Model:
+        def __init__(self, env=None, license_status="ok"):
+            self.license_status = license_status
+            self.Params = type("P", (), {})()
+            self.Params.OutputFlag = 0
+            self._disposed = False
+
+        def addVars(self, rng):
+            return None
+
+        def optimize(self):
+            if self.license_status == "ok":
+                return
+            if self.license_status == "too_large":
+                raise TestGurobiMixin.GurobiError("Model too large", errno=10010)
+            if self.license_status == "timeout":
+                raise TestGurobiMixin.GurobiError("timeout waiting for license")
+            if self.license_status == "no_license":
+                raise TestGurobiMixin.GurobiError("no gurobi license", errno=10009)
+            if self.license_status == "bad":
+                raise TestGurobiMixin.GurobiError("other licensing problem")
+
+        def dispose(self):
+            self._disposed = True
+
+    @staticmethod
+    def mocked_gurobipy(license_status="ok", env_side_effect=None):
+        """
+        Build a fake gurobipy module.
+        - license_status controls Model.optimize() behavior
+        - env_side_effect (callable or Exception) controls Env() behavior
+          e.g. env_side_effect=TestGurobiMixin.GurobiError("no gurobi license", errno=10009)
+        """
+
+        # Arbitrarily picking a version
+        class GRB:
+            VERSION_MAJOR = 12
+            VERSION_MINOR = 0
+            VERSION_TECHNICAL = 1
+
+        mocker = unittest.mock.MagicMock()
+        if env_side_effect is None:
+            mocker.Env = unittest.mock.MagicMock(return_value=TestGurobiMixin.Env())
+        else:
+            if isinstance(env_side_effect, Exception):
+                mocker.Env = unittest.mock.MagicMock(side_effect=env_side_effect)
+            else:
+                mocker.Env = unittest.mock.MagicMock(side_effect=env_side_effect)
+        mocker.Model = unittest.mock.MagicMock(
+            side_effect=lambda *a, **kw: TestGurobiMixin.Model(
+                license_status=license_status
+            )
+        )
+        mocker.GRB = GRB
+        mocker.GurobiError = TestGurobiMixin.GurobiError
+        return mocker
+
+    def test_available_notfound(self):
+        mixin = GurobiSolverMixin()
+        with unittest.mock.patch.object(
+            GurobiSolverMixin, "_gurobipy_available", False
+        ):
+            self.assertEqual(mixin.available(), Availability.NotFound)
+
+    def test_available_full_license(self):
+        opt = GurobiDirect()
+        mock_gp = self.mocked_gurobipy("ok")
+        with (
+            unittest.mock.patch.object(type(opt), "_gurobipy_available", True),
+            unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
+        ):
+            with capture_output(capture_fd=True):
+                self.assertEqual(opt.available(recheck=True), Availability.FullLicense)
+
+    def test_available_limited_license(self):
+        opt = GurobiDirect()
+        mock_gp = self.mocked_gurobipy("too_large")
+        with (
+            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
+        ):
+            with capture_output(capture_fd=True):
+                self.assertEqual(
+                    opt.available(recheck=True), Availability.LimitedLicense
+                )
+
+    def test_available_license_error_no_license(self):
+        mixin = GurobiSolverMixin()
+        env_error = self.GurobiError("no gurobi license", errno=10009)
+        mock_gp = self.mocked_gurobipy(license_status="ok", env_side_effect=env_error)
+        with (
+            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
+        ):
+            with capture_output(capture_fd=True):
+                self.assertEqual(
+                    mixin.available(recheck=True), Availability.LicenseError
+                )
+
+    def test_available_cache_and_recheck(self):
+        opt = GurobiDirect()
+        # FullLicense
+        mock_full = self.mocked_gurobipy("ok")
+        with (
+            unittest.mock.patch.object(GurobiSolverMixin, "_gurobipy_available", True),
+            unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_full),
+        ):
+            self.assertEqual(opt.available(recheck=True), Availability.FullLicense)
+            # Change behavior to license error; without recheck should use cache
+            env_error = self.GurobiError("no gurobi license", errno=10009)
+            mock_err = self.mocked_gurobipy("ok", env_side_effect=env_error)
+            with unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_err):
+                self.assertEqual(opt.available(), Availability.FullLicense)
+                # Now recheck
+                self.assertEqual(opt.available(recheck=True), Availability.LicenseError)
+
+    def test_version_cache(self):
+        mixin = GurobiSolverMixin()
+        mock_gp = self.mocked_gurobipy()
+        with unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp):
+            self.assertEqual(mixin.version(), (12, 0, 1))
+            # Change the version, but we didn't ask for a recheck, so
+            # the cached version should stay the same
+            mock_gp.GRB.VERSION_MINOR = 99
+            self.assertEqual(mixin.version(), (12, 0, 1))
+
+    def test_license_acquire_release(self):
+        opt = GurobiDirect()
+        mock_gp = self.mocked_gurobipy()
+        with unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp):
+            # Explicit acquire/release should set and clear the shared Env
+            self.assertIsNone(GurobiDirect._gurobipy_env)
+            opt.license.acquire()
+            self.assertIsNotNone(GurobiDirect._gurobipy_env)
+            opt.license.release()
+            self.assertIsNone(GurobiDirect._gurobipy_env)
+
+
+@unittest.skipIf(not gurobipy_available, "The 'gurobipy' module is not available.")
+class TestGurobiDirectInterface(unittest.TestCase):
+    def test_available_cache(self):
+        opt = GurobiDirect()
+        opt.available()
+        self.assertIsNotNone(opt._available_cache)
+
+    def test_version_cache(self):
+        opt = GurobiDirect()
+        opt.version()
+        self.assertIsNotNone(opt._version_cache)

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
@@ -106,14 +106,18 @@ class TestGurobiMixin(unittest.TestCase):
 
     def test_available_notfound(self):
         mixin = GurobiSolverMixin()
-        with unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", False):
+        with unittest.mock.patch.object(
+            GurobiSolverMixin, "_is_gp_available", return_value=False
+        ):
             self.assertEqual(mixin.available(), Availability.NotFound)
 
     def test_available_full_license(self):
         opt = GurobiDirect()
         mock_gp = self.mocked_gurobipy("ok")
         with (
-            unittest.mock.patch.object(type(opt), "_is_gp_available", True),
+            unittest.mock.patch.object(
+                type(opt), "_is_gp_available", return_value=True
+            ),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -123,7 +127,9 @@ class TestGurobiMixin(unittest.TestCase):
         opt = GurobiDirect()
         mock_gp = self.mocked_gurobipy("too_large")
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
+            unittest.mock.patch.object(
+                GurobiSolverMixin, "_is_gp_available", return_value=True
+            ),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -136,7 +142,9 @@ class TestGurobiMixin(unittest.TestCase):
         env_error = self.GurobiError("no gurobi license", errno=10009)
         mock_gp = self.mocked_gurobipy(license_status="ok", env_side_effect=env_error)
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
+            unittest.mock.patch.object(
+                GurobiSolverMixin, "_is_gp_available", return_value=True
+            ),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_gp),
         ):
             with capture_output(capture_fd=True):
@@ -149,7 +157,9 @@ class TestGurobiMixin(unittest.TestCase):
         # FullLicense
         mock_full = self.mocked_gurobipy("ok")
         with (
-            unittest.mock.patch.object(GurobiSolverMixin, "_is_gp_available", True),
+            unittest.mock.patch.object(
+                GurobiSolverMixin, "_is_gp_available", return_value=True
+            ),
             unittest.mock.patch(f"{self.MODULE_PATH}.gurobipy", mock_full),
         ):
             self.assertEqual(opt.available(recheck=True), Availability.FullLicense)

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_direct.py
@@ -12,13 +12,13 @@
 from pyomo.common.tee import capture_output
 from pyomo.common import unittest
 
-from pyomo.contrib.solver.solvers.gurobi_direct import (
-    gurobipy_available,
-    GurobiSolverMixin,
-    GurobiDirect,
-)
+from pyomo.contrib.solver.solvers.gurobi_direct import GurobiSolverMixin, GurobiDirect
 
 from pyomo.contrib.solver.common.base import Availability
+
+opt = GurobiDirect()
+if not opt.available():
+    raise unittest.SkipTest("Gurobi is not available")
 
 
 class TestGurobiMixin(unittest.TestCase):
@@ -185,7 +185,6 @@ class TestGurobiMixin(unittest.TestCase):
             self.assertIsNone(GurobiDirect._gurobipy_env)
 
 
-@unittest.skipIf(not gurobipy_available, "The 'gurobipy' module is not available.")
 class TestGurobiDirectInterface(unittest.TestCase):
     def test_available_cache(self):
         opt = GurobiDirect()

--- a/pyomo/contrib/solver/tests/solvers/test_highs.py
+++ b/pyomo/contrib/solver/tests/solvers/test_highs.py
@@ -12,13 +12,97 @@
 import pyomo.common.unittest as unittest
 import pyomo.environ as pyo
 
-from pyomo.contrib.solver.solvers.highs import Highs
+import pyomo.contrib.solver.solvers.highs as highs
+from pyomo.contrib.solver.common.base import Availability
+from pyomo.contrib.solver.common.results import SolutionStatus
 
-opt = Highs()
-if not opt.available():
-    raise unittest.SkipTest
+highs_available = highs.Highs().available()
 
 
+@unittest.skipIf(not highs_available, "highspy is not available")
+class TestHighsInterface(unittest.TestCase):
+    def test_default_instantiation(self):
+        opt = highs.Highs()
+        self.assertTrue(opt.is_persistent())
+        self.assertEqual(opt.name, 'highs')
+        self.assertEqual(opt.CONFIG, opt.config)
+        self.assertTrue(opt.available())
+        self.assertIsNotNone(opt.version())
+
+    def test_available_cache_and_recheck(self):
+        opt = highs.Highs()
+
+        first = opt.available()
+        self.assertTrue(first)
+        self.assertIsNotNone(opt._available_cache)
+
+        # Make sure that recheck works by faking highspy_available
+        with unittest.mock.patch(
+            'pyomo.contrib.solver.solvers.highs.highspy_available', False
+        ):
+            self.assertEqual(opt.available(), first)
+            self.assertEqual(opt.available(recheck=True), Availability.NotFound)
+
+    def test_version_cache_and_recheck_with_attrs(self):
+        opt = highs.Highs()
+        version = opt.version()
+        self.assertIsNotNone(version)
+        self.assertIsNotNone(opt._version_cache)
+
+
+@unittest.skipIf(not highs_available, "highspy is not available")
+class TestHighs(unittest.TestCase):
+    def create_lp_model(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.NonNegativeReals)
+        m.y = pyo.Var(domain=pyo.NonNegativeReals)
+        m.con = pyo.Constraint(expr=m.x + m.y >= 1)
+        m.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.minimize)
+        return m
+
+    def create_mip_model(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.NonNegativeIntegers)
+        m.y = pyo.Var(domain=pyo.NonNegativeReals)
+        m.con1 = pyo.Constraint(expr=m.x + m.y >= 3)
+        m.con2 = pyo.Constraint(expr=m.y <= 2)
+        m.obj = pyo.Objective(expr=3 * m.x + m.y, sense=pyo.minimize)
+        return m
+
+    def test_lp_solve(self):
+        m = self.create_lp_model()
+        res = highs.Highs().solve(m)
+        self.assertEqual(res.solver_name, 'highs')
+        self.assertEqual(res.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(pyo.value(m.obj), 1.0, places=7)
+        self.assertGreaterEqual(m.x.value, 0.0)
+        self.assertGreaterEqual(m.y.value, 0.0)
+        self.assertGreaterEqual(m.x.value + m.y.value, 1.0 - 1e-7)
+
+    def test_mip_solve(self):
+        m = self.create_mip_model()
+        res = highs.Highs().solve(m)
+        self.assertEqual(res.solver_name, 'highs')
+        self.assertEqual(res.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(pyo.value(m.obj), 5.0, places=7)
+        self.assertAlmostEqual(m.x.value, 1.0, places=7)
+        self.assertAlmostEqual(m.y.value, 2.0, places=7)
+
+    def test_persistent_update_path(self):
+        m = self.create_lp_model()
+        opt = highs.Highs()
+        res1 = opt.solve(m)
+        self.assertEqual(res1.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(pyo.value(m.obj), 1.0, places=7)
+
+        # Tighten the constraint
+        m.con.set_value(m.x + m.y >= 1.5)
+        res2 = opt.solve(m)
+        self.assertEqual(res2.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(pyo.value(m.obj), 1.5, places=7)
+
+
+@unittest.skipIf(not highs_available, "highspy is not available")
 class TestBugs(unittest.TestCase):
     def test_mutable_params_with_remove_cons(self):
         m = pyo.ConcreteModel()
@@ -35,7 +119,7 @@ class TestBugs(unittest.TestCase):
         m.p1.value = 1
         m.p2.value = 1
 
-        opt = Highs()
+        opt = highs.Highs()
         res = opt.solve(m)
         self.assertAlmostEqual(res.objective_bound, 1)
 
@@ -62,7 +146,7 @@ class TestBugs(unittest.TestCase):
         m.p1.value = -10
         m.p2.value = 10
 
-        opt = Highs()
+        opt = highs.Highs()
         res = opt.solve(m)
         self.assertAlmostEqual(res.objective_bound, 1)
 
@@ -87,7 +171,7 @@ class TestBugs(unittest.TestCase):
 
         m.obj = pyo.Objective(expr=m.fx * 0.5 + m.fy * 0.4, sense=pyo.maximize)
 
-        opt = Highs()
+        opt = highs.Highs()
 
         # solution 1 has m.x == 1 and m.y == 0
         r = opt.solve(m)

--- a/pyomo/contrib/solver/tests/solvers/test_ipopt.py
+++ b/pyomo/contrib/solver/tests/solvers/test_ipopt.py
@@ -16,7 +16,7 @@ import pyomo.environ as pyo
 from pyomo.common.envvar import is_windows
 from pyomo.common.fileutils import ExecutableData
 from pyomo.common.config import ConfigDict, ADVANCED_OPTION
-from pyomo.common.errors import DeveloperError
+from pyomo.common.errors import DeveloperError, ApplicationError
 from pyomo.common.tee import capture_output
 import pyomo.contrib.solver.solvers.ipopt as ipopt
 from pyomo.contrib.solver.common.util import NoSolutionError
@@ -108,6 +108,7 @@ class TestIpoptInterface(unittest.TestCase):
             'available',
             'has_linear_solver',
             'is_persistent',
+            'license',
             'solve',
             'version',
             'name',
@@ -136,10 +137,9 @@ class TestIpoptInterface(unittest.TestCase):
         opt.available()
         self.assertTrue(opt._available_cache[1])
         self.assertIsNotNone(opt._available_cache[0])
-        # Now we will try with a custom config that has a fake path
-        config = ipopt.IpoptConfig()
-        config.executable = Executable('/a/bogus/path')
-        opt.available(config=config)
+        # Now we will change the executable to a fake path
+        opt.config.executable = Executable('/a/bogus/path')
+        opt.available(recheck=True)
         self.assertFalse(opt._available_cache[1])
         self.assertIsNone(opt._available_cache[0])
 
@@ -148,10 +148,9 @@ class TestIpoptInterface(unittest.TestCase):
         opt.version()
         self.assertIsNotNone(opt._version_cache[0])
         self.assertIsNotNone(opt._version_cache[1])
-        # Now we will try with a custom config that has a fake path
-        config = ipopt.IpoptConfig()
-        config.executable = Executable('/a/bogus/path')
-        opt.version(config=config)
+        # Now we will change the executable to a fake path
+        opt.config.executable = Executable('/a/bogus/path')
+        opt.version(recheck=True)
         self.assertIsNone(opt._version_cache[0])
         self.assertIsNone(opt._version_cache[1])
 
@@ -477,6 +476,13 @@ class TestIpopt(unittest.TestCase):
         ipopt.Ipopt().solve(model)
         self.assertAlmostEqual(model.x.value, 1)
         self.assertAlmostEqual(model.y.value, 1)
+
+    def test_ipopt_solve_not_available(self):
+        model = self.create_model()
+        opt = ipopt.Ipopt()
+        opt.config.executable = Executable('/a/bogus/path')
+        with self.assertRaises(ApplicationError):
+            opt.solve(model)
 
     def test_ipopt_results(self):
         model = self.create_model()

--- a/pyomo/contrib/solver/tests/unit/test_base.py
+++ b/pyomo/contrib/solver/tests/unit/test_base.py
@@ -42,6 +42,8 @@ class TestSolverBase(unittest.TestCase):
         self.assertEqual(instance.name, 'solverbase')
         self.assertEqual(instance.api_version().name, 'V2')
         self.assertEqual(instance.CONFIG, instance.config)
+        self.assertTrue(hasattr(instance, 'license'))
+        self.assertIsInstance(instance.license, base._LicenseManager)
         with self.assertRaises(NotImplementedError):
             self.assertEqual(instance.version(), None)
         with self.assertRaises(NotImplementedError):
@@ -62,6 +64,18 @@ class TestSolverBase(unittest.TestCase):
     def test_custom_solver_name(self):
         instance = base.SolverBase(name='my_unique_name')
         self.assertEqual(instance.name, 'my_unique_name')
+
+    def test_default_license_behavior(self):
+        instance = base.SolverBase()
+        # plain context manager
+        with instance.license:
+            pass
+        # context manager with timeout
+        with instance.license(timeout=0.1):
+            pass
+        # explicit calls also work
+        instance.license.acquire(timeout=0.1)
+        instance.license.release()
 
 
 class TestPersistentSolverBase(unittest.TestCase):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes None (but is part of #3688)

## Summary/Motivation:
As part of the solver redesign effort, we decided to change how `available` and licensing in general will work in the new solver interface paradigm. This implements the most recent comment in #3688 for all existing solvers.

## Changes proposed in this PR:
- Redefine what `available` basically means
- Add a `license` attribute to each solver (default is no operation)
- Custom license manager for gurobi

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
