### PR TITLE
Fix boolean conversion in DeferredImportIndicator class

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -346,7 +346,7 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
 
     def __bool__(self):
         self.resolve()
-        return self._available
+        return bool(self._available)
 
     def resolve(self):
         # Only attempt the import once, then cache some form of result


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # NA

## Summary/Motivation:

Some linters, such as Pyright, raise warnings when an object of class `DeferredImportIndicator` is used in an if statement, since its `__bool__` method may return `None`.
This PR explicitly casts the result of that method to `bool` to ensure a proper boolean value is returned.

## Changes proposed in this PR:
- Cast the result of `__bool__` method of `DeferredImportIndicator` to be a `bool`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
