### PR TITLE
Get correct highs iteration count depending on method

### DIFF
--- a/pyomo/contrib/solver/solvers/highs.py
+++ b/pyomo/contrib/solver/solvers/highs.py
@@ -769,10 +769,9 @@ class Highs(PersistentSolverMixin, PersistentSolverUtils, PersistentSolverBase):
                     results.iteration_count = 0
                 else:
                     assert (
-                        len(positive_iters) == 1,
+                        len(positive_iters) == 1
                     ), "Only one iteration count should have a positive value"
                     results.iteration_count = positive_iters[0]
-                results.iteration_count = max(counts)
             else:
                 results.iteration_count = 0
 

--- a/pyomo/contrib/solver/tests/solvers/test_highs.py
+++ b/pyomo/contrib/solver/tests/solvers/test_highs.py
@@ -126,9 +126,10 @@ class TestHighsMiniDemos(unittest.TestCase):
             solver.config.solver_options["solver"] = (
                 method  # 'simplex' | 'ipm' | 'pdlp'
             )
+            solver.config.solver_options["presolve"] = "off"
             results = solver.solve(m)
             self.assertTrue(results.solution_status == SolutionStatus.optimal)
-            self.assertTrue(results.iteration_count >= 0)
+            self.assertTrue(results.iteration_count > 0)
 
     def test_mip_demo(self):
         # Build MIP
@@ -139,9 +140,21 @@ class TestHighsMiniDemos(unittest.TestCase):
         m.obj = pyo.Objective(expr=3 * m.a + 2 * m.b, sense=pyo.maximize)
 
         solver = Highs()
+        solver.config.solver_options["presolve"] = "off"
         results = solver.solve(m)
         self.assertTrue(results.solution_status == SolutionStatus.optimal)
-        self.assertTrue(results.iteration_count >= 0)
+        self.assertTrue(results.iteration_count > 0)
+
+    def test_mip_pmedian(self):
+        # Build MIP
+        from pyomo.core.tests.examples.pmedian_concrete import create_model
+
+        M = create_model()
+
+        solver = Highs()
+        results = solver.solve(M)
+        self.assertEqual(results.solution_status, SolutionStatus.optimal)
+        self.assertTrue(results.iteration_count > 0)
 
     def test_qp_demo(self):
         # Build convex QP
@@ -152,6 +165,7 @@ class TestHighsMiniDemos(unittest.TestCase):
         m.obj = pyo.Objective(expr=(m.x - 1) ** 2 + (m.y - 2) ** 2, sense=pyo.minimize)
 
         solver = Highs()
+        solver.config.solver_options["presolve"] = "off"
         results = solver.solve(m)
         self.assertTrue(results.solution_status == SolutionStatus.optimal)
-        self.assertTrue(results.iteration_count >= 0)
+        self.assertTrue(results.iteration_count > 0)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes and Summary/Motivation # .
In the highs solver interface, instead of always reporting the simplex iteration count, we should get the iteration count of the method that was used. See #3753.


## Changes proposed in this PR:
- Take the max of the available iteration counts, if the info is valid

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
