### PR TITLE
Update to pypy3.11 and ignore pint

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,7 +22,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree pint
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
   CACHE_VER: v250827.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -30,7 +30,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree pint
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
   CACHE_VER: v250827.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,8 @@ setup_kwargs = dict(
             'openpyxl',  # dataportals
             'packaging',  # for checking other dependency versions
             #'pathos',   # requested for #963, but PR currently closed
-            'pint',  # units
+            # pint causes a segfault on pypy
+            'pint; implementation_name!="pypy"',  # units
             'plotly',  # incidence_analysis
             'python-louvain',  # community_detection
             'pyyaml',  # core


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
A new version of `pillow` was released, and it broke pypy-3.10. Update but also ignore pint.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
