### PR TITLE
Remove `iteration_count` as a default Results object value

### DIFF
--- a/pyomo/contrib/solver/common/results.py
+++ b/pyomo/contrib/solver/common/results.py
@@ -197,14 +197,6 @@ class Results(ConfigDict):
                 description="A tuple representing the version of the solver in use.",
             ),
         )
-        self.iteration_count: Optional[int] = self.declare(
-            'iteration_count',
-            ConfigValue(
-                domain=NonNegativeInt,
-                default=None,
-                description="The total number of iterations.",
-            ),
-        )
         self.timing_info: ConfigDict = self.declare(
             'timing_info', ConfigDict(implicit=True)
         )

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -442,7 +442,7 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
             results.incumbent_objective = None
             results.objective_bound = None
 
-        results.iteration_count = grb_model.getAttr('IterCount')
+        results.extra_info.iteration_count = grb_model.getAttr('IterCount')
 
         timer.start('load solution')
         if config.load_solutions:

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -14,6 +14,7 @@ import io
 import math
 import operator
 import os
+import logging
 
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.common.config import ConfigValue
@@ -43,6 +44,7 @@ from pyomo.contrib.solver.common.results import (
 )
 from pyomo.contrib.solver.common.solution_loader import SolutionLoaderBase
 
+logger = logging.getLogger(__name__)
 
 gurobipy, gurobipy_available = attempt_import('gurobipy')
 
@@ -442,7 +444,9 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
             results.incumbent_objective = None
             results.objective_bound = None
 
-        results.extra_info.iteration_count = grb_model.getAttr('IterCount')
+        results.extra_info.IterCount = grb_model.getAttr('IterCount')
+        results.extra_info.BarIterCount = grb_model.getAttr('BarIterCount')
+        results.extra_info.NodeCount = grb_model.getAttr('NodeCount')
 
         timer.start('load solution')
         if config.load_solutions:

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -857,7 +857,9 @@ class GurobiPersistent(
             ):
                 results.incumbent_objective = None
 
-        results.extra_info.iteration_count = gprob.getAttr('IterCount')
+        results.extra_info.IterCount = gprob.getAttr('IterCount')
+        results.extra_info.BarIterCount = gprob.getAttr('BarIterCount')
+        results.extra_info.NodeCount = gprob.getAttr('NodeCount')
 
         timer.start('load solution')
         if config.load_solutions:

--- a/pyomo/contrib/solver/solvers/gurobi_persistent.py
+++ b/pyomo/contrib/solver/solvers/gurobi_persistent.py
@@ -857,7 +857,7 @@ class GurobiPersistent(
             ):
                 results.incumbent_objective = None
 
-        results.iteration_count = gprob.getAttr('IterCount')
+        results.extra_info.iteration_count = gprob.getAttr('IterCount')
 
         timer.start('load solution')
         if config.load_solutions:

--- a/pyomo/contrib/solver/solvers/highs.py
+++ b/pyomo/contrib/solver/solvers/highs.py
@@ -750,7 +750,15 @@ class Highs(PersistentSolverMixin, PersistentSolverUtils, PersistentSolverBase):
                     results.objective_bound = None
             else:
                 results.objective_bound = info.mip_dual_bound
-            results.iteration_count = info.simplex_iteration_count
+
+            if info.valid:
+                results.extra_info.iteration_counts = {
+                    'simplex_iteration_count': info.simplex_iteration_count,
+                    'ipm_iteration_count': info.ipm_iteration_count,
+                    'mip_node_count': info.mip_node_count,
+                    'pdlp_iteration_count': info.pdlp_iteration_count,
+                    'qp_iteration_count': info.qp_iteration_count,
+                }
 
         if config.load_solutions:
             if has_feasible_solution:

--- a/pyomo/contrib/solver/solvers/highs.py
+++ b/pyomo/contrib/solver/solvers/highs.py
@@ -752,13 +752,13 @@ class Highs(PersistentSolverMixin, PersistentSolverUtils, PersistentSolverBase):
                 results.objective_bound = info.mip_dual_bound
 
             if info.valid:
-                results.extra_info.iteration_counts = {
-                    'simplex_iteration_count': info.simplex_iteration_count,
-                    'ipm_iteration_count': info.ipm_iteration_count,
-                    'mip_node_count': info.mip_node_count,
-                    'pdlp_iteration_count': info.pdlp_iteration_count,
-                    'qp_iteration_count': info.qp_iteration_count,
-                }
+                results.extra_info.simplex_iteration_count = (
+                    info.simplex_iteration_count
+                )
+                results.extra_info.ipm_iteration_count = info.ipm_iteration_count
+                results.extra_info.mip_node_count = info.mip_node_count
+                results.extra_info.pdlp_iteration_count = info.pdlp_iteration_count
+                results.extra_info.qp_iteration_count = info.qp_iteration_count
 
         if config.load_solutions:
             if has_feasible_solution:

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -473,7 +473,7 @@ class Ipopt(SolverBase):
                 results = Results()
                 results.termination_condition = TerminationCondition.provenInfeasible
                 results.solution_loader = SolSolutionLoader(None, None)
-                results.iteration_count = 0
+                results.extra_info.iteration_count = 0
                 results.timing_info.total_seconds = 0
             elif len(nl_info.variables) == 0:
                 if len(nl_info.eliminated_vars) == 0:
@@ -487,7 +487,7 @@ class Ipopt(SolverBase):
                     )
                     results.solution_status = SolutionStatus.optimal
                     results.solution_loader = SolSolutionLoader(None, nl_info=nl_info)
-                    results.iteration_count = 0
+                    results.extra_info.iteration_count = 0
                     results.timing_info.total_seconds = 0
             else:
                 if os.path.isfile(basename + '.sol'):
@@ -503,7 +503,9 @@ class Ipopt(SolverBase):
                     results.solution_loader = SolSolutionLoader(None, None)
                 else:
                     try:
-                        results.iteration_count = parsed_output_data.pop('iters')
+                        results.extra_info.iteration_count = parsed_output_data.pop(
+                            'iters'
+                        )
                         cpu_seconds = parsed_output_data.pop('cpu_seconds')
                         for k, v in cpu_seconds.items():
                             results.timing_info[k] = v

--- a/pyomo/contrib/solver/solvers/knitro/base.py
+++ b/pyomo/contrib/solver/solvers/knitro/base.py
@@ -141,7 +141,7 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
         results.solution_status = self._get_solution_status(status)
         results.termination_condition = self._get_termination_condition(status)
         results.incumbent_objective = self._engine.get_obj_value()
-        results.iteration_count = self._engine.get_num_iters()
+        results.extra_info.iteration_count = self._engine.get_num_iters()
         results.timing_info.solve_time = self._engine.get_solve_time()
         results.timing_info.timer = timer
 

--- a/pyomo/contrib/solver/tests/solvers/test_ipopt.py
+++ b/pyomo/contrib/solver/tests/solvers/test_ipopt.py
@@ -594,13 +594,13 @@ class TestIpopt(unittest.TestCase):
         result = ipopt.Ipopt().solve(model, solver_options={'print_level': 0})
         # IPOPT doesn't tell us anything about the iters if the print level
         # is set to 0
-        self.assertIsNone(result.iteration_count)
+        self.assertFalse(hasattr(result.extra_info, 'iteration_count'))
         self.assertFalse(hasattr(result.extra_info, 'iteration_log'))
         model = self.create_model()
         result = ipopt.Ipopt().solve(model, solver_options={'print_level': 3})
         # At a slightly higher level, we get some of the info, like
         # iteration count, but NOT iteration_log
-        self.assertEqual(result.iteration_count, 11)
+        self.assertEqual(result.extra_info.iteration_count, 11)
         self.assertFalse(hasattr(result.extra_info, 'iteration_log'))
 
     def test_ipopt_loud_print_level(self):
@@ -609,13 +609,13 @@ class TestIpopt(unittest.TestCase):
             result = ipopt.Ipopt().solve(model, solver_options={'print_level': 8})
             # Nothing unexpected should be in the results object at this point,
             # except that the solver_log is significantly longer
-            self.assertEqual(result.iteration_count, 11)
+            self.assertEqual(result.extra_info.iteration_count, 11)
             self.assertEqual(result.incumbent_objective, 7.013645951336496e-25)
             self.assertIn('Optimal Solution Found', result.extra_info.solver_message)
             self.assertTrue(hasattr(result.extra_info, 'iteration_log'))
             model = self.create_model()
             result = ipopt.Ipopt().solve(model, solver_options={'print_level': 12})
-            self.assertEqual(result.iteration_count, 11)
+            self.assertEqual(result.extra_info.iteration_count, 11)
             self.assertEqual(result.incumbent_objective, 7.013645951336496e-25)
             self.assertIn('Optimal Solution Found', result.extra_info.solver_message)
             self.assertTrue(hasattr(result.extra_info, 'iteration_log'))
@@ -624,7 +624,7 @@ class TestIpopt(unittest.TestCase):
         model = self.create_model()
         results = ipopt.Ipopt().solve(model)
         self.assertEqual(results.solver_name, 'ipopt')
-        self.assertEqual(results.iteration_count, 11)
+        self.assertEqual(results.extra_info.iteration_count, 11)
         self.assertEqual(results.incumbent_objective, 7.013645951336496e-25)
         self.assertIn('Optimal Solution Found', results.extra_info.solver_message)
 

--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -604,9 +604,6 @@ class TestSolvers(unittest.TestCase):
         for v in res.solver_version:
             self.assertIsInstance(v, int)
 
-        # iteration_count is nonnegative
-        self.assertGreaterEqual(res.iteration_count, 0)
-
         # timing_info should exist
         self.assertIsNotNone(res.timing_info)
 

--- a/pyomo/contrib/solver/tests/unit/test_results.py
+++ b/pyomo/contrib/solver/tests/unit/test_results.py
@@ -157,7 +157,6 @@ class TestResults(unittest.TestCase):
         expected_declared = {
             'extra_info',
             'incumbent_objective',
-            'iteration_count',
             'objective_bound',
             'solution_loader',
             'solution_status',
@@ -182,7 +181,6 @@ class TestResults(unittest.TestCase):
         self.assertEqual(res.solution_status, results.SolutionStatus.noSolution)
         self.assertIsNone(res.solver_name)
         self.assertIsNone(res.solver_version)
-        self.assertIsNone(res.iteration_count)
         self.assertIsInstance(res.timing_info, ConfigDict)
         self.assertIsInstance(res.extra_info, ConfigDict)
         self.assertIsNone(res.timing_info.start_timestamp)
@@ -198,7 +196,6 @@ incumbent_objective: None
 objective_bound: None
 solver_name: None
 solver_version: None
-iteration_count: None
 timing_info:
   start_timestamp: None
   wall_time: None


### PR DESCRIPTION


## Fixes #3753 

## Summary/Motivation:
As part of #3753 and #3754, we decided that `iteration_count` should be removed as a default piece of information on the Results object (particularly because it's not well defined for certain solvers, e.g., MIP solvers). This instead downgrades iteration count to being an `extra_info` declaration, if desired, and is specific to each solver.

## Changes proposed in this PR:
- Remove `iteration_count` from defaults `Results` object
- Adjust each individual solver to move `iteration_count` into the `extra_info` ConfigDict
- Report ALL iteration counts from highs rather than whatever subset, with appropriate key-value pairs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
