### PR TITLE
DIsable unreliable DoE test

### DIFF
--- a/pyomo/contrib/doe/tests/test_doe_solve.py
+++ b/pyomo/contrib/doe/tests/test_doe_solve.py
@@ -251,7 +251,9 @@ class TestReactorExampleSolving(unittest.TestCase):
         # Make sure FIM and Q.T @ sigma_inv @ Q are close (alternate definition of FIM)
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q)))
 
-    def test_reactor_obj_cholesky_solve_bad_prior(self):
+    def DISABLE_test_reactor_obj_cholesky_solve_bad_prior(self):
+        # [10/2025] This test has been disabled because it frequently
+        # (and randomly) returns "infeasible" when run on Windows.
         from pyomo.contrib.doe.doe import _SMALL_TOLERANCE_DEFINITENESS
 
         fd_method = "central"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This disables a test that has become unreliable (it frequently returns `infeasible` when run on GHA/Windows/conda).  We discussed the test at a previous dev call, and @djlaky was not convinced that this test was even providing meaningful information after the DoE refactor.  

This is only disabling the test (and not removing it completely) to leave breadcrumbs for @djlaky / the DoE developers for future test refinements.

## Changes proposed in this PR:
- Disable unreliable DoE test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
