### PR TITLE
Disallow pytest 9.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,15 @@ setup_kwargs = dict(
         # There are certain tests that also require pytest-qt, but because those
         # tests are so environment/machine specific, we are leaving these out of
         # the dependencies.
-        'tests': ['coverage', 'parameterized', 'pybind11', 'pytest', 'pytest-parallel'],
+        'tests': [
+            'coverage',
+            'parameterized',
+            'pybind11',
+            # 9.0.0 breaks skipping individual tests; see
+            # https://github.com/pytest-dev/pytest/issues/13895
+            'pytest!=9.0.0',
+            'pytest-parallel',
+        ],
         'docs': [
             'Sphinx>4,!=8.2.0',
             'sphinx-copybutton',


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
pytest 9.0.0 broke support for skipping a test by raising `unittest.SkipTest` (which also breaks the `unittest.skip`, `unittest.skipIf`, and `unittest.skipUnless` decorators).  See upstream: https://github.com/pytest-dev/pytest/issues/13895

## Changes proposed in this PR:
- Disallow installing pytest 9.0.0

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
