### PR TITLE
Update PyROS tests for Python 3.14

### DIFF
--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -1260,7 +1260,7 @@ class RegressionTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             expected_exception=ValueError,
-            expected_regex="math domain error",
+            expected_regex="(math domain error)|(expected a positive input)",
             msg="Exception arising from math domain error not raised",
         ):
             # should raise math domain error:
@@ -1285,7 +1285,7 @@ class RegressionTest(unittest.TestCase):
         m.x2.setub(1 / m.q)
         with self.assertRaisesRegex(
             expected_exception=ZeroDivisionError,
-            expected_regex="float division by zero",
+            expected_regex="division by zero",
             msg="Exception arising from math domain error not raised",
         ):
             pyros_solver.solve(


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This updates a PyROS test that started failing under Python 3.14 (due to changes in Python exception messages).

## Changes proposed in this PR:
- Update expected exception messages to be compatible with Python 3.14

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
