### PR TITLE
Pytest 9.0.1 workaround

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -192,23 +192,24 @@ class TestPyomoUnittest(unittest.TestCase):
         time.sleep(1)
         self.assertEqual(0, 0)
 
-    @unittest.timeout(10)
-    def test_timeout_skip(self):
-        if TestPyomoUnittest.test_timeout_skip.skip:
+    def timeout_skip(self, skip):
+        if skip:
             self.skipTest("Skipping this test")
         self.assertEqual(0, 1)
 
-    test_timeout_skip.skip = True
+    @unittest.timeout(10)
+    def test_timeout_skip(self):
+        self.timeout_skip(True)
 
-    def test_timeout_skip_fails(self):
-        try:
-            with self.assertRaisesRegex(unittest.SkipTest, r"Skipping this test"):
-                self.test_timeout_skip()
-            TestPyomoUnittest.test_timeout_skip.skip = False
-            with self.assertRaisesRegex(AssertionError, r"0 != 1"):
-                self.test_timeout_skip()
-        finally:
-            TestPyomoUnittest.test_timeout_skip.skip = True
+    @unittest.timeout(10)
+    def test_timeout_skip_pass(self):
+        with self.assertRaisesRegex(AssertionError, r"0 != 1"):
+            self.timeout_skip(False)
+
+    @unittest.expectedFailure
+    @unittest.timeout(10)
+    def test_timeout_skip_fail(self):
+        self.timeout_skip(False)
 
     @unittest.timeout(10)
     def bound_function(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Pytest 9.0.1 changed how expected failures worked with subTests, which broke Pyomo's `unittest.timeout()` decorator.  This reworks how we handle unittest tests when running timeout() using the spawn (or forkserver) interface.

## Changes proposed in this PR:
- catch "one more" exception that can be raised for unpicklable objects
- rework the unittest / spawn (or forkserver) implementation for `unittest.timeout()` to be compatible with pytest 9.0.1

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
