### PR TITLE
Relax piecewise test tolerances due to upstream changes

### DIFF
--- a/pyomo/contrib/piecewise/tests/test_nonlinear_to_pwl.py
+++ b/pyomo/contrib/piecewise/tests/test_nonlinear_to_pwl.py
@@ -602,7 +602,7 @@ class TestLinearTreeDomainPartitioning(unittest.TestCase):
             # pretty close to m.x, but we're a bit off because we don't have 0
             # as a breakpoint.
             0.9833360108369479 * m.x + 0.16663989163052034,
-            places=7,
+            places=6,
         )
 
     def test_linear_model_tree_random(self):
@@ -657,7 +657,7 @@ class TestLinearTreeDomainPartitioning(unittest.TestCase):
             pwlf._simplices,
             [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8)],
         )
-        self.assertEqual(
+        self.assertStructuredAlmostEqual(
             pwlf._points,
             [
                 (-10,),
@@ -670,6 +670,7 @@ class TestLinearTreeDomainPartitioning(unittest.TestCase):
                 (2.15597,),
                 (10,),
             ],
+            places=4,
         )
         self.assertEqual(len(pwlf._linear_functions), 8)
         for i in range(3):
@@ -680,7 +681,7 @@ class TestLinearTreeDomainPartitioning(unittest.TestCase):
             # pretty close to - m.x, but we're a bit off because we don't have 0
             # as a breakpoint.
             -0.9851979299618323 * m.x + 0.12006477080409184,
-            places=7,
+            places=6,
         )
         for i in range(4, 8):
             assertExpressionsEqual(self, pwlf._linear_functions[i](m.x), m.x)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Tests have started failing due to minor changes upstream.  This PR relaxes some test tolerances so things pass again.

## Changes proposed in this PR:
- relax test tolerances in nonlinear transform.
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
