### PR TITLE
Add flexibility into error message checking on `gurobi_minlp`

### DIFF
--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_walker.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_walker.py
@@ -565,7 +565,8 @@ class TestGurobiMINLPWalker(CommonTest):
         with self.assertRaisesRegex(
             InvalidValueError,
             r"Invalid number encountered evaluating constant unary expression "
-            r"sqrt\(- p\): math domain error",
+            r"sqrt\(\s*-\s*p\s*\): "
+            r"(?:math domain error|expected a nonnegative input, got -?\d+(?:\.\d+)?)",
         ):
             _, expr = visitor.walk_expression(m.c.body)
 
@@ -578,6 +579,7 @@ class TestGurobiMINLPWalker(CommonTest):
         with self.assertRaisesRegex(
             InvalidValueError,
             r"Invalid number encountered evaluating constant unary expression "
-            r"log\(p\): math domain error",
+            r"log\(\s*p\s*\): "
+            r"(?:math domain error|expected a positive input)",
         ):
             _, expr = visitor.walk_expression(m.c.body)


### PR DESCRIPTION

## Fixes NA

## Summary/Motivation:
Gurobi released a version that actually works on 3.14 today, hooray! However, two of our gurobi_minlp tests are too strict about the expected phrasing of the error. So this loosens that / allows support for multiple Python versions.

## Changes proposed in this PR:
- Change error message regex on gurobi_minlp tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
