### PR TITLE
[KNITRO] Add tests to verify extra info is correctly populated

### DIFF
--- a/pyomo/contrib/solver/solvers/knitro/base.py
+++ b/pyomo/contrib/solver/solvers/knitro/base.py
@@ -146,7 +146,7 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
             results.extra_info.mip_rel_gap = self._engine.get_mip_rel_gap()
             results.extra_info.mip_number_solves = self._engine.get_mip_number_solves()
         else:
-            results.extra_info.num_iters = self._engine.get_number_iters()
+            results.extra_info.number_iters = self._engine.get_number_iters()
         results.timing_info.solve_time = self._engine.get_solve_time()
         results.timing_info.timer = timer
 

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -43,6 +43,7 @@ class TestKnitroDirectSolverConfig(unittest.TestCase):
         self.assertEqual(config._description, "A description")
         self.assertIsNone(config.time_limit)
 
+
 @unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
     def test_results_extra_info_mip(self):
@@ -67,7 +68,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertIsInstance(results.extra_info.mip_number_nodes, int)
         self.assertIsInstance(results.extra_info.mip_abs_gap, float)
         self.assertIsInstance(results.extra_info.mip_rel_gap, float)
-        self.assertIsInstance(results.extra_info.mip_number_solves,int)
+        self.assertIsInstance(results.extra_info.mip_number_solves, int)
 
         # Check that non-MIP field does not exist
         self.assertFalse(hasattr(results.extra_info, 'number_iters'))
@@ -79,7 +80,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
         m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
         m.obj = pyo.Objective(
-            expr=(1.0 - m.x) ** 2 + 100.0 * (m.y - m.x ** 2) ** 2, sense=pyo.minimize
+            expr=(1.0 - m.x) ** 2 + 100.0 * (m.y - m.x**2) ** 2, sense=pyo.minimize
         )
 
         results = opt.solve(m)
@@ -94,6 +95,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertFalse(hasattr(results.extra_info, 'mip_abs_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
+
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroDirectSolverInterface(unittest.TestCase):

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -43,6 +43,57 @@ class TestKnitroDirectSolverConfig(unittest.TestCase):
         self.assertEqual(config._description, "A description")
         self.assertIsNone(config.time_limit)
 
+@unittest.skipIf(not avail, "KNITRO solver is not available")
+class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
+    def test_results_extra_info_mip(self):
+        """Test that MIP-specific extra info is populated for MIP problems."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.Integers, bounds=(0, 10))
+        m.y = pyo.Var(domain=pyo.Integers, bounds=(0, 10))
+        m.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
+        m.c1 = pyo.Constraint(expr=2 * m.x + m.y <= 15)
+        m.c2 = pyo.Constraint(expr=m.x + 2 * m.y <= 15)
+
+        results = opt.solve(m)
+
+        # Check that MIP-specific fields are populated
+        self.assertIsNotNone(results.extra_info.mip_number_nodes)
+        self.assertIsNotNone(results.extra_info.mip_abs_gap)
+        self.assertIsNotNone(results.extra_info.mip_rel_gap)
+        self.assertIsNotNone(results.extra_info.mip_number_solves)
+
+        # Check that MIP-specific fields are of correct type
+        self.assertIsInstance(results.extra_info.mip_number_nodes, int)
+        self.assertIsInstance(results.extra_info.mip_abs_gap, float)
+        self.assertIsInstance(results.extra_info.mip_rel_gap, float)
+        self.assertIsInstance(results.extra_info.mip_number_solves,int)
+
+        # Check that non-MIP field does not exist
+        self.assertFalse(hasattr(results.extra_info, 'number_iters'))
+
+    def test_results_extra_info_no_mip(self):
+        """Test that iteration info is populated for non-MIP problems."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.obj = pyo.Objective(
+            expr=(1.0 - m.x) ** 2 + 100.0 * (m.y - m.x ** 2) ** 2, sense=pyo.minimize
+        )
+
+        results = opt.solve(m)
+
+        # Check that num_iters is populated for non-MIP
+        self.assertIsNotNone(results.extra_info.number_iters)
+        self.assertIsInstance(results.extra_info.number_iters, int)
+        self.assertGreater(results.extra_info.number_iters, 0)
+
+        # Check that MIP-specific fields do not exist
+        self.assertFalse(hasattr(results.extra_info, 'mip_number_nodes'))
+        self.assertFalse(hasattr(results.extra_info, 'mip_abs_gap'))
+        self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
+        self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroDirectSolverInterface(unittest.TestCase):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

This PR add two tests to verify if the extra_info attribute of the results has been correctly populated with the expected info.


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
