### PR TITLE
Compute wall_time using the monotonic time.perf_counter()

### DIFF
--- a/pyomo/contrib/solver/common/persistent.py
+++ b/pyomo/contrib/solver/common/persistent.py
@@ -11,6 +11,7 @@
 
 import abc
 import datetime
+import time
 from typing import List
 
 from pyomo.core.base.constraint import ConstraintData, Constraint
@@ -508,6 +509,7 @@ class PersistentSolverMixin:
 
     def solve(self, model, **kwds) -> Results:
         start_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tick = time.perf_counter()
         self._active_config = config = self.config(value=kwds, preserve_implicit=True)
         StaleFlagManager.mark_all_as_stale()
 
@@ -529,9 +531,9 @@ class PersistentSolverMixin:
         res = self._solve()
         self._last_results_object = res
 
-        end_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tock = time.perf_counter()
         res.timing_info.start_timestamp = start_timestamp
-        res.timing_info.wall_time = (end_timestamp - start_timestamp).total_seconds()
+        res.timing_info.wall_time = tock - tick
         res.timing_info.timer = timer
         self._active_config = self.config
 

--- a/pyomo/contrib/solver/solvers/gurobi_direct.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import datetime
+import time
 import io
 import math
 import operator
@@ -276,6 +277,7 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
 
     def solve(self, model, **kwds) -> Results:
         start_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tick = time.perf_counter()
         config = self.config(value=kwds, preserve_implicit=True)
         if not self.available():
             c = self.__class__
@@ -392,9 +394,9 @@ class GurobiDirect(GurobiSolverMixin, SolverBase):
         res.solver_version = self.version()
         res.solver_log = ostreams[0].getvalue()
 
-        end_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tock = time.perf_counter()
         res.timing_info.start_timestamp = start_timestamp
-        res.timing_info.wall_time = (end_timestamp - start_timestamp).total_seconds()
+        res.timing_info.wall_time = tock - tick
         res.timing_info.timer = timer
         return res
 

--- a/pyomo/contrib/solver/solvers/gurobi_direct_minlp.py
+++ b/pyomo/contrib/solver/solvers/gurobi_direct_minlp.py
@@ -11,6 +11,7 @@
 
 
 import datetime
+import time
 import io
 from operator import attrgetter, itemgetter
 
@@ -592,6 +593,7 @@ class GurobiDirectMINLP(GurobiDirect):
             model (Block): a Pyomo model or Block to be solved
         """
         start_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tick = time.perf_counter()
         config = self.config(value=kwds, preserve_implicit=True)
         if not self.available():
             c = self.__class__
@@ -656,8 +658,8 @@ class GurobiDirectMINLP(GurobiDirect):
         res.solver_version = self.version()
         res.solver_log = ostreams[0].getvalue()
 
-        end_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tock = time.perf_counter()
         res.timing_info.start_timestamp = start_timestamp
-        res.timing_info.wall_time = (end_timestamp - start_timestamp).total_seconds()
+        res.timing_info.wall_time = tock - tick
         res.timing_info.timer = timer
         return res

--- a/pyomo/contrib/solver/solvers/ipopt.py
+++ b/pyomo/contrib/solver/solvers/ipopt.py
@@ -13,6 +13,7 @@ import logging
 import os
 import subprocess
 import datetime
+import time
 import io
 import re
 import sys
@@ -344,6 +345,7 @@ class Ipopt(SolverBase):
         "Solve a model using Ipopt"
         # Begin time tracking
         start_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tick = time.perf_counter()
         # Update configuration options, based on keywords passed to solve
         config: IpoptConfig = self.config(value=kwds, preserve_implicit=True)
         # Check if solver is available
@@ -570,11 +572,9 @@ class Ipopt(SolverBase):
             results.solver_log = ostreams[0].getvalue()
 
         # Capture/record end-time / wall-time
-        end_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tock = time.perf_counter()
         results.timing_info.start_timestamp = start_timestamp
-        results.timing_info.wall_time = (
-            end_timestamp - start_timestamp
-        ).total_seconds()
+        results.timing_info.wall_time = tock - tick
         results.timing_info.timer = timer
         return results
 

--- a/pyomo/contrib/solver/solvers/knitro/base.py
+++ b/pyomo/contrib/solver/solvers/knitro/base.py
@@ -11,7 +11,8 @@
 
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timezone
+import datetime
+import time
 from io import StringIO
 from typing import Optional
 
@@ -66,7 +67,8 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
         self._saved_var_values = {}
 
     def solve(self, model: BlockData, **kwds) -> Results:
-        tick = datetime.now(timezone.utc)
+        start_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        tick = time.perf_counter()
         self._check_available()
 
         config = self._build_config(**kwds)
@@ -89,10 +91,10 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
 
         results = self._postsolve(config, timer)
 
-        tock = datetime.now(timezone.utc)
+        tock = time.perf_counter()
 
-        results.timing_info.start_timestamp = tick
-        results.timing_info.wall_time = (tock - tick).total_seconds()
+        results.timing_info.start_timestamp = start_timestamp
+        results.timing_info.wall_time = tock - tick
         return results
 
     def _build_config(self, **kwds) -> KnitroConfig:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3808

## Summary/Motivation:
This PR is intended to solve the fact  that the measured wall_time is sometimes negative due to the usage of datetime.datetime.now(). It resolves #3808 

## Changes proposed in this PR:
- Instead of relying on datetime.datetime.now() we now use time.perf_counter as proposed in #3808 
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.