### PR TITLE
[KNITRO] Add objective bound retrieval for MIP

### DIFF
--- a/pyomo/contrib/solver/solvers/knitro/base.py
+++ b/pyomo/contrib/solver/solvers/knitro/base.py
@@ -140,6 +140,10 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
         results.solution_status = self._get_solution_status(status)
         results.termination_condition = self._get_termination_condition(status)
         results.incumbent_objective = self._engine.get_obj_value()
+
+        if self._is_mip():
+            results.objective_bound = self._engine.get_obj_bound()
+
         if self._is_mip():
             results.extra_info.mip_number_nodes = self._engine.get_mip_number_nodes()
             results.extra_info.mip_abs_gap = self._engine.get_mip_abs_gap()

--- a/pyomo/contrib/solver/solvers/knitro/engine.py
+++ b/pyomo/contrib/solver/solvers/knitro/engine.py
@@ -303,6 +303,11 @@ class Engine:
             return None
         return self.execute(knitro.KN_get_obj_value)
 
+    def get_obj_bound(self) -> Optional[float]:
+        if not self.has_objective:
+            return None
+        return self.execute(knitro.KN_get_mip_relaxation_bnd)
+
     def get_idxs(
         self, item_type: type[ItemType], items: Iterable[ItemType]
     ) -> list[int]:

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -96,6 +96,41 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
 
+class TestKnitroSolverObjectiveBound(unittest.TestCase):
+    def test_objective_bound_mip(self):
+        """Test that objective bound is retrieved for MIP problems."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(domain=pyo.Integers, bounds=(0, 10))
+        m.y = pyo.Var(domain=pyo.Integers, bounds=(0, 10))
+        m.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
+        m.c1 = pyo.Constraint(expr=2 * m.x + m.y <= 15)
+        m.c2 = pyo.Constraint(expr=m.x + 2 * m.y <= 15)
+
+        results = opt.solve(m)
+
+        # Check that objective_bound is populated
+        self.assertIsNotNone(results.objective_bound)
+        self.assertIsInstance(results.objective_bound, float)
+
+        # For maximization, bound should be >= incumbent objective
+        self.assertGreaterEqual(results.objective_bound, results.incumbent_objective)
+
+    def test_objective_bound_no_mip(self):
+        """Test that objective bound is not set for non-MIP problems."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.obj = pyo.Objective(
+            expr=(1.0 - m.x) ** 2 + 100.0 * (m.y - m.x**2) ** 2, sense=pyo.minimize
+        )
+
+        results = opt.solve(m)
+
+        # Check that objective_bound is None for non-MIP
+        self.assertIsNone(results.objective_bound)
+
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroDirectSolverInterface(unittest.TestCase):

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -96,6 +96,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
 
+
 class TestKnitroSolverObjectiveBound(unittest.TestCase):
     def test_objective_bound_mip(self):
         """Test that objective bound is retrieved for MIP problems."""

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -96,6 +96,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
 
+
 @unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroSolverObjectiveBound(unittest.TestCase):
     def test_objective_bound_mip(self):

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -96,7 +96,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
         self.assertFalse(hasattr(results.extra_info, 'mip_rel_gap'))
         self.assertFalse(hasattr(results.extra_info, 'mip_number_solves'))
 
-
+@unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroSolverObjectiveBound(unittest.TestCase):
     def test_objective_bound_mip(self):
         """Test that objective bound is retrieved for MIP problems."""


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

This PR add the objective bound retreival for MIP when KNITRO is used as solver.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
