### PR TITLE
handle numeric constant in observer component collector

### DIFF
--- a/pyomo/contrib/observer/component_collector.py
+++ b/pyomo/contrib/observer/component_collector.py
@@ -24,6 +24,7 @@ from pyomo.core.expr.numeric_expr import (
     UnaryFunctionExpression,
     AbsExpression,
 )
+from pyomo.core.expr.numvalue import NumericConstant
 from pyomo.core.expr.relational_expr import (
     RangedExpression,
     InequalityExpression,
@@ -82,6 +83,7 @@ collector_handlers[InequalityExpression] = handle_skip
 collector_handlers[EqualityExpression] = handle_skip
 collector_handlers[int] = handle_skip
 collector_handlers[float] = handle_skip
+collector_handlers[NumericConstant] = handle_skip
 
 
 class _ComponentFromExprCollector(StreamBasedExpressionVisitor):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->


## Changes proposed in this PR:
- Add handling for `NumericConstant` in the walker that collects variables, parameters, named expressions, and external functions for the observer.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
