### PR TITLE
[KNITRO] Enhance status mapping

### DIFF
--- a/pyomo/contrib/solver/solvers/knitro/base.py
+++ b/pyomo/contrib/solver/solvers/knitro/base.py
@@ -78,10 +78,10 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
         self._presolve(model, config, timer)
         self._validate_problem()
 
-        self._stream = StringIO()
         if config.restore_variable_values_after_solve:
             self._save_var_values()
 
+        self._stream = StringIO()
         with capture_output(TeeStream(self._stream, *config.tee), capture_fd=True):
             self._solve(config, timer)
 
@@ -132,14 +132,13 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
         raise NotImplementedError
 
     def _postsolve(self, config: KnitroConfig, timer: HierarchicalTimer) -> Results:
-        status = self._engine.get_status()
         results = Results()
         results.solver_name = self.name
         results.solver_version = self.version()
         results.solver_log = self._stream.getvalue()
         results.solver_config = config
-        results.solution_status = self._get_solution_status(status)
-        results.termination_condition = self._get_termination_condition(status)
+        results.solution_status = self._engine.get_solution_status()
+        results.termination_condition = self._engine.get_termination_condition()
         results.incumbent_objective = self._engine.get_obj_value()
 
         if self._is_mip():
@@ -211,48 +210,6 @@ class KnitroSolverBase(SolutionProvider, PackageChecker, SolverBase):
             ConstraintData: self._model_data.cons,
         }
         return maps[item_type]
-
-    @staticmethod
-    def _get_solution_status(status: int) -> SolutionStatus:
-        """
-        Map KNITRO status codes to Pyomo SolutionStatus values.
-
-        See https://www.artelys.com/app/docs/knitro/3_referenceManual/returnCodes.html
-        """
-        if status in {0, -100}:
-            return SolutionStatus.optimal
-        elif -101 >= status >= -199 or -400 >= status >= -409:
-            return SolutionStatus.feasible
-        elif status in {-200, -204, -205, -206}:
-            return SolutionStatus.infeasible
-        else:
-            return SolutionStatus.noSolution
-
-    @staticmethod
-    def _get_termination_condition(status: int) -> TerminationCondition:
-        """
-        Map KNITRO status codes to Pyomo TerminationCondition values.
-
-        See https://www.artelys.com/app/docs/knitro/3_referenceManual/returnCodes.html
-        """
-        if status in {0, -100}:
-            return TerminationCondition.convergenceCriteriaSatisfied
-        elif status == -202:
-            return TerminationCondition.locallyInfeasible
-        elif status in {-200, -204, -205}:
-            return TerminationCondition.provenInfeasible
-        elif status in {-300, -301}:
-            return TerminationCondition.infeasibleOrUnbounded
-        elif status in {-400, -410}:
-            return TerminationCondition.iterationLimit
-        elif status in {-401, -411}:
-            return TerminationCondition.maxTimeLimit
-        elif status == -500:
-            return TerminationCondition.interrupted
-        elif -500 > status >= -599:
-            return TerminationCondition.error
-        else:
-            return TerminationCondition.unknown
 
     @staticmethod
     def _get_error_type(

--- a/pyomo/contrib/solver/solvers/knitro/engine.py
+++ b/pyomo/contrib/solver/solvers/knitro/engine.py
@@ -16,6 +16,8 @@ from typing import Any, TypeVar
 from pyomo.common.enums import ObjectiveSense
 from pyomo.common.errors import DeveloperError
 from pyomo.common.numeric_types import value
+from pyomo.contrib.solver.common.results import SolutionStatus, TerminationCondition
+
 from pyomo.contrib.solver.solvers.knitro.api import knitro
 from pyomo.contrib.solver.solvers.knitro.callback import build_callback_handler
 from pyomo.contrib.solver.solvers.knitro.package import Package
@@ -292,16 +294,12 @@ class Engine:
     def get_obj_value(self) -> float | None:
         if not self.has_objective:
             return None
-        if self._status not in {
-            knitro.KN_RC_OPTIMAL,
-            knitro.KN_RC_OPTIMAL_OR_SATISFACTORY,
-            knitro.KN_RC_NEAR_OPT,
-            knitro.KN_RC_ITER_LIMIT_FEAS,
-            knitro.KN_RC_FEAS_NO_IMPROVE,
-            knitro.KN_RC_TIME_LIMIT_FEAS,
+        if self.get_solution_status() in {
+            SolutionStatus.optimal,
+            SolutionStatus.feasible,
         }:
-            return None
-        return self.execute(knitro.KN_get_obj_value)
+            return self.execute(knitro.KN_get_obj_value)
+        return None
 
     def get_obj_bound(self) -> float | None:
         if not self.has_objective:
@@ -443,3 +441,97 @@ class Engine:
     def register_callback(self, i: int | None, expr: NonlinearExpressionData) -> None:
         callback = build_callback_handler(expr, idx=i).expand()
         self.add_callback(i, expr, callback)
+
+    def get_solution_status(self) -> SolutionStatus:
+        """
+        Map KNITRO status codes to Pyomo SolutionStatus values.
+
+        See https://www.artelys.com/app/docs/knitro/3_referenceManual/returnCodes.html
+        """
+        if self._status is None:
+            msg = "Solver has not been run. No solution status is available!"
+            raise RuntimeError(msg)
+        elif self._status in {
+            knitro.KN_RC_OPTIMAL,
+            knitro.KN_RC_OPTIMAL_OR_SATISFACTORY,
+            knitro.KN_RC_NEAR_OPT,
+        }:
+            return SolutionStatus.optimal
+        elif self._status in {
+            knitro.KN_RC_FEAS_XTOL,
+            knitro.KN_RC_FEAS_NO_IMPROVE,
+            knitro.KN_RC_FEAS_FTOL,
+            -103,  # KN_RC_FEAS_BEST
+            -104,  # KN_RC_FEAS_MULTISTART
+            knitro.KN_RC_ITER_LIMIT_FEAS,
+            knitro.KN_RC_TIME_LIMIT_FEAS,
+            knitro.KN_RC_FEVAL_LIMIT_FEAS,
+            knitro.KN_RC_MIP_EXH_FEAS,
+            knitro.KN_RC_MIP_TERM_FEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_FEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_FEAS,
+        }:
+            return SolutionStatus.feasible
+        elif self._status in {
+            knitro.KN_RC_INFEASIBLE,
+            knitro.KN_RC_INFEAS_CON_BOUNDS,
+            knitro.KN_RC_INFEAS_VAR_BOUNDS,
+            knitro.KN_RC_INFEAS_MULTISTART,
+        }:
+            return SolutionStatus.infeasible
+        else:
+            return SolutionStatus.noSolution
+
+    def get_termination_condition(self) -> TerminationCondition:
+        """
+        Map KNITRO status codes to Pyomo TerminationCondition values.
+
+        See https://www.artelys.com/app/docs/knitro/3_referenceManual/returnCodes.html
+        """
+        if self._status is None:
+            msg = "Solver has not been run. No termination condition is available!"
+            raise RuntimeError(msg)
+        elif self._status in {
+            knitro.KN_RC_OPTIMAL,
+            knitro.KN_RC_OPTIMAL_OR_SATISFACTORY,
+            knitro.KN_RC_NEAR_OPT,
+        }:
+            return TerminationCondition.convergenceCriteriaSatisfied
+        elif self._status in {
+            knitro.KN_RC_INFEAS_NO_IMPROVE,
+            knitro.KN_RC_INFEAS_MULTISTART,
+        }:
+            return TerminationCondition.locallyInfeasible
+        elif self._status in {
+            knitro.KN_RC_INFEASIBLE,
+            knitro.KN_RC_INFEAS_CON_BOUNDS,
+            knitro.KN_RC_INFEAS_VAR_BOUNDS,
+        }:
+            return TerminationCondition.provenInfeasible
+        elif self._status in {knitro.KN_RC_UNBOUNDED, knitro.KN_RC_UNBOUNDED_OR_INFEAS}:
+            return TerminationCondition.infeasibleOrUnbounded
+        elif self._status in {
+            knitro.KN_RC_ITER_LIMIT_FEAS,
+            knitro.KN_RC_FEVAL_LIMIT_FEAS,
+            knitro.KN_RC_MIP_EXH_FEAS,
+            knitro.KN_RC_MIP_TERM_FEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_FEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_FEAS,
+            knitro.KN_RC_ITER_LIMIT_INFEAS,
+            knitro.KN_RC_FEVAL_LIMIT_INFEAS,
+            knitro.KN_RC_MIP_EXH_INFEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_INFEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_INFEAS,
+        }:
+            return TerminationCondition.iterationLimit
+        elif self._status in {
+            knitro.KN_RC_TIME_LIMIT_FEAS,
+            knitro.KN_RC_TIME_LIMIT_INFEAS,
+        }:
+            return TerminationCondition.maxTimeLimit
+        elif self._status == knitro.KN_RC_USER_TERMINATION:
+            return TerminationCondition.interrupted
+        elif -500 >= self._status >= -600:
+            return TerminationCondition.error
+        else:
+            return TerminationCondition.unknown

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -16,8 +16,10 @@ import pyomo.common.unittest as unittest
 import pyomo.environ as pyo
 
 from pyomo.contrib.solver.common.results import SolutionStatus, TerminationCondition
+from pyomo.contrib.solver.solvers.knitro.api import knitro
 from pyomo.contrib.solver.solvers.knitro.config import KnitroConfig
 from pyomo.contrib.solver.solvers.knitro.direct import KnitroDirectSolver
+from pyomo.contrib.solver.solvers.knitro.engine import Engine
 
 avail = KnitroDirectSolver().available()
 
@@ -135,6 +137,198 @@ class TestKnitroSolverObjectiveBound(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+class TestKnitroSolverIncumbentObjective(unittest.TestCase):
+    def test_none_without_objective(self):
+        """Test that incumbent objective is None when no objective is present."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.c1 = pyo.Constraint(expr=m.x + m.y >= 1)
+
+        results = opt.solve(m)
+        self.assertIsNone(results.incumbent_objective)
+
+    def test_none_when_infeasible(self):
+        """Test that incumbent objective is None when problem is infeasible."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=m.x + m.y)
+        m.c1 = pyo.Constraint(expr=m.x + m.y <= -20)
+
+        opt.config.raise_exception_on_nonoptimal_result = False
+        opt.config.load_solutions = False
+        results = opt.solve(m)
+        print(results.solution_status)
+        print(results.termination_condition)
+        self.assertIsNone(results.incumbent_objective)
+
+    def test_none_when_unbounded(self):
+        """Test that incumbent objective is None when problem is unbounded."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, None))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, None))
+        m.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
+        m.c1 = pyo.Constraint(expr=m.x + m.y >= -10)
+
+        opt.config.raise_exception_on_nonoptimal_result = False
+        opt.config.load_solutions = False
+        results = opt.solve(m)
+        self.assertIsNone(results.incumbent_objective)
+
+    def test_value_when_optimal(self):
+        """Test that incumbent objective is correct for optimal solution."""
+        opt = KnitroDirectSolver()
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.y = pyo.Var(initialize=1.5, bounds=(-5, 5))
+        m.obj = pyo.Objective(expr=m.x + m.y, sense=pyo.maximize)
+        m.c1 = pyo.Constraint(expr=m.x + m.y <= 3)
+
+        results = opt.solve(m)
+        self.assertIsNotNone(results.incumbent_objective)
+        self.assertAlmostEqual(results.incumbent_objective, 3.0)
+
+
+@unittest.skipIf(not avail, "KNITRO solver is not available")
+class TestKnitroSolverSolutionStatus(unittest.TestCase):
+    def test_solution_status_mapping(self):
+        """Test that solution status is correctly mapped from KNITRO status."""
+        engine = Engine()
+
+        # Test optimal statuses
+        for code in [
+            knitro.KN_RC_OPTIMAL,
+            knitro.KN_RC_OPTIMAL_OR_SATISFACTORY,
+            knitro.KN_RC_NEAR_OPT,
+        ]:
+            engine._status = code
+            self.assertEqual(engine.get_solution_status(), SolutionStatus.optimal)
+
+        # Test feasible statuses
+        for code in [
+            knitro.KN_RC_FEAS_XTOL,
+            knitro.KN_RC_FEAS_NO_IMPROVE,
+            knitro.KN_RC_FEAS_FTOL,
+            -103,  # KN_RC_FEAS_BEST
+            -104,  # KN_RC_FEAS_MULTISTART
+            knitro.KN_RC_ITER_LIMIT_FEAS,
+            knitro.KN_RC_TIME_LIMIT_FEAS,
+            knitro.KN_RC_FEVAL_LIMIT_FEAS,
+            knitro.KN_RC_MIP_EXH_FEAS,
+            knitro.KN_RC_MIP_TERM_FEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_FEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_FEAS,
+        ]:
+            engine._status = code
+            self.assertEqual(engine.get_solution_status(), SolutionStatus.feasible)
+
+        # Test infeasible statuses
+        for code in [
+            knitro.KN_RC_INFEASIBLE,
+            knitro.KN_RC_INFEAS_CON_BOUNDS,
+            knitro.KN_RC_INFEAS_VAR_BOUNDS,
+            knitro.KN_RC_INFEAS_MULTISTART,
+        ]:
+            engine._status = code
+            self.assertEqual(engine.get_solution_status(), SolutionStatus.infeasible)
+
+        # Test noSolution statuses (anything else)
+        for code in [-501, -600, -99999, -1]:
+            engine._status = code
+            self.assertEqual(engine.get_solution_status(), SolutionStatus.noSolution)
+
+
+@unittest.skipIf(not avail, "KNITRO solver is not available")
+class TestKnitroSolverTerminationCondition(unittest.TestCase):
+    def test_termination_condition_mapping(self):
+        """Test that termination condition is correctly mapped from KNITRO status."""
+        engine = Engine()
+
+        # Test convergenceCriteriaSatisfied
+        for code in [
+            knitro.KN_RC_OPTIMAL,
+            knitro.KN_RC_OPTIMAL_OR_SATISFACTORY,
+            knitro.KN_RC_NEAR_OPT,
+        ]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(),
+                TerminationCondition.convergenceCriteriaSatisfied,
+            )
+
+        # Test locallyInfeasible
+        for code in [knitro.KN_RC_INFEAS_NO_IMPROVE, knitro.KN_RC_INFEAS_MULTISTART]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(),
+                TerminationCondition.locallyInfeasible,
+            )
+
+        # Test provenInfeasible
+        for code in [
+            knitro.KN_RC_INFEASIBLE,
+            knitro.KN_RC_INFEAS_CON_BOUNDS,
+            knitro.KN_RC_INFEAS_VAR_BOUNDS,
+        ]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(),
+                TerminationCondition.provenInfeasible,
+            )
+
+        # Test infeasibleOrUnbounded
+        for code in [knitro.KN_RC_UNBOUNDED, knitro.KN_RC_UNBOUNDED_OR_INFEAS]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(),
+                TerminationCondition.infeasibleOrUnbounded,
+            )
+
+        # Test iterationLimit
+        for code in [
+            knitro.KN_RC_ITER_LIMIT_FEAS,
+            knitro.KN_RC_FEVAL_LIMIT_FEAS,
+            knitro.KN_RC_MIP_EXH_FEAS,
+            knitro.KN_RC_MIP_TERM_FEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_FEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_FEAS,
+            knitro.KN_RC_ITER_LIMIT_INFEAS,
+            knitro.KN_RC_FEVAL_LIMIT_INFEAS,
+            knitro.KN_RC_MIP_EXH_INFEAS,
+            knitro.KN_RC_MIP_SOLVE_LIMIT_INFEAS,
+            knitro.KN_RC_MIP_NODE_LIMIT_INFEAS,
+        ]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(), TerminationCondition.iterationLimit
+            )
+
+        # Test interrupted
+        engine._status = knitro.KN_RC_USER_TERMINATION
+        self.assertEqual(
+            engine.get_termination_condition(), TerminationCondition.interrupted
+        )
+
+        # Test error (-500 > status >= -600)
+        for code in [-501, -550, -600]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(), TerminationCondition.error
+            )
+
+        # Test unknown (anything else outside the defined ranges)
+        for code in [-601, -99999, -1]:
+            engine._status = code
+            self.assertEqual(
+                engine.get_termination_condition(), TerminationCondition.unknown
+            )
+
+
+@unittest.skipIf(not avail, "KNITRO solver is not available")
 class TestKnitroDirectSolverInterface(unittest.TestCase):
     def test_class_member_list(self):
         opt = KnitroDirectSolver()
@@ -174,54 +368,6 @@ class TestKnitroDirectSolverInterface(unittest.TestCase):
         opt.available()
         self.assertTrue(opt._available_cache)
         self.assertIsNotNone(opt._available_cache)
-
-    def test_solution_status_mapping(self):
-        opt = KnitroDirectSolver()
-        for opt_status in [0, -100]:
-            status = opt._get_solution_status(opt_status)
-            self.assertEqual(status, SolutionStatus.optimal)
-
-        for opt_status in [*range(-101, -103, -1), *range(-400, -406, -1)]:
-            status = opt._get_solution_status(opt_status)
-            self.assertEqual(status, SolutionStatus.feasible)
-
-        for opt_status in [-200, -204, -205, -206]:
-            status = opt._get_solution_status(opt_status)
-            self.assertEqual(status, SolutionStatus.infeasible)
-
-        for opt_status in [-501, -99999, -1]:
-            status = opt._get_solution_status(opt_status)
-            self.assertEqual(status, SolutionStatus.noSolution)
-
-    def test_termination_condition_mapping(self):
-        opt = KnitroDirectSolver()
-        for opt_status in [0, -100]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(
-                term_cond, TerminationCondition.convergenceCriteriaSatisfied
-            )
-        term_cond = opt._get_termination_condition(-202)
-        self.assertEqual(term_cond, TerminationCondition.locallyInfeasible)
-        for opt_status in [-200, -204, -205]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.provenInfeasible)
-        for opt_status in [-300, -301]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.infeasibleOrUnbounded)
-        for opt_status in [-400, -410]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.iterationLimit)
-        for opt_status in [-401, -411]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.maxTimeLimit)
-        term_cond = opt._get_termination_condition(-500)
-        self.assertEqual(term_cond, TerminationCondition.interrupted)
-        for opt_status in [-501, -550, -599]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.error)
-        for opt_status in [-600, -99999, -1]:
-            term_cond = opt._get_termination_condition(opt_status)
-            self.assertEqual(term_cond, TerminationCondition.unknown)
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -199,6 +199,11 @@ class TestKnitroSolverSolutionStatus(unittest.TestCase):
         """Test that solution status is correctly mapped from KNITRO status."""
         engine = Engine()
 
+        # Test that RuntimeError is raised for None status
+        engine._status = None
+        with self.assertRaises(RuntimeError):
+            engine.get_solution_status()
+
         # Test optimal statuses
         for code in [
             knitro.KN_RC_OPTIMAL,
@@ -247,6 +252,11 @@ class TestKnitroSolverTerminationCondition(unittest.TestCase):
     def test_termination_condition_mapping(self):
         """Test that termination condition is correctly mapped from KNITRO status."""
         engine = Engine()
+
+        # Test that RuntimeError is raised for None status
+        engine._status = None
+        with self.assertRaises(RuntimeError):
+            engine.get_termination_condition()
 
         # Test convergenceCriteriaSatisfied
         for code in [


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

This PR improves how return codes are mapped to `SolutionStatus` and `TerminationCondition`, ensuring more accurate and complete status reporting.

## Changes proposed in this PR:
- Added several missing return codes to the mapping.
- Fixed `get_obj_value` so it is called whenever the problem is feasible, not only when it is optimal.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
