### PR TITLE
NFC: Fixing some docstrings in the core.lp_dual transformation

### DIFF
--- a/pyomo/core/plugins/transform/lp_dual.py
+++ b/pyomo/core/plugins/transform/lp_dual.py
@@ -237,9 +237,9 @@ class LinearProgrammingDual:
         Parameters
         ----------
         model: ConcreteModel
-            A primal model passed as an argument to the 'core.lp_dual' transformation
+            A dual model returned from the 'core.lp_dual' transformation
         primal_var: Var
-            A primal variable on 'model'
+            A primal variable on the model passed to the transformation
 
         """
         dual_constraint = model.private_data().dual_constraint
@@ -285,9 +285,9 @@ class LinearProgrammingDual:
         Parameters
         ----------
         model: ConcreteModel
-            A primal model passed as an argument to the 'core.lp_dual' transformation
+            A dual model returned from the 'core.lp_dual' transformation
         primal_constraint: Constraint
-            A constraint on 'model'
+            A constraint on the primal model passed to the transformation
 
         """
         dual_var = model.private_data().dual_var


### PR DESCRIPTION
## Fixes #3839

## Summary/Motivation:

The docstrings for the public API to map between primal and dual components from the `core.lp_dual` transformation were wrong. This fixes them. All the mappings actually take the *dual* model as the first argument, not the primal.

## Changes proposed in this PR:
- NFC: fixing docstrings.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
