### PR TITLE
Extend url-check timeout to 30 seconds

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -64,6 +64,8 @@ jobs:
         verbose: true
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 30
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -75,6 +75,8 @@ jobs:
         verbose: true
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 30
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -26,6 +26,8 @@ jobs:
         verbose: true
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 30
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures

--- a/doc/OnlineDocs/explanation/modeling_utils/preprocessing.rst
+++ b/doc/OnlineDocs/explanation/modeling_utils/preprocessing.rst
@@ -7,7 +7,7 @@ programs (NLPs and MINLPs), as well as generalized disjunctive programs (GDPs).
 
 This contributed package is maintained by `Qi Chen
 <https://github.com/qtothec>`_ and `his colleagues from Carnegie Mellon
-University <http://capd.cheme.cmu.edu/>`_.
+University <https://capd.cheme.cmu.edu/>`_.
 
 The following preprocessing transformations are available. However, some may
 later be deprecated or combined, depending on their usefulness.


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This extends the timeout for the url checker in an attempt to better tolerate some less responsive websites.

## Changes proposed in this PR:
- extend urlchecker timeout from 5 to 30 seconds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
