### PR TITLE
Update solver tests for gurobiasl 13.0.0

### DIFF
--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -1414,7 +1414,7 @@ class TestSolvers(unittest.TestCase):
                 opt.config.writer_config.linear_presolve = False
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
-        m.y = pyo.Var()
+        m.y = pyo.Var(bounds=(-1.4, None))
         m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
         m.c1 = pyo.Constraint(expr=m.x == 2 / m.y)
         m.y.fix(1)
@@ -1422,6 +1422,8 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 2)
         m.y.unfix()
         res = opt.solve(m)
+        # The globaal minimum is +/-(2**.5, 2**.5) without bounds.
+        # Bounds force it to the positive side
         self.assertAlmostEqual(m.x.value, 2**0.5, delta=1e-3)
         self.assertAlmostEqual(m.y.value, 2**0.5, delta=1e-3)
 

--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -1422,7 +1422,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 2)
         m.y.unfix()
         res = opt.solve(m)
-        # The globaal minimum is +/-(2**.5, 2**.5) without bounds.
+        # The global minimum is +/-(2**.5, 2**.5) without bounds.
         # Bounds force it to the positive side
         self.assertAlmostEqual(m.x.value, 2**0.5, delta=1e-3)
         self.assertAlmostEqual(m.y.value, 2**0.5, delta=1e-3)

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -106,24 +106,24 @@ SkipTests['cplex', 'nl', 'QCP_simple'] = (
 
 # 12.0.3 (for AMPL only) returns all zeros for suffixes
 MissingSuffixFailures['gurobi', 'nl', 'LP_duals_maximize'] = (
-    lambda v: v[:3] == (12, 0, 3),
+    lambda v: v[:3] >= (12, 0, 3),
     {'dual': (False, {})},
-    "AMPL Gurobi 12.0.3 fails to report duals for problems solved in presolve",
+    "AMPL Gurobi>=12.0.3 fails to report duals for problems solved in presolve",
 )
 MissingSuffixFailures['gurobi', 'nl', 'LP_duals_minimize'] = (
-    lambda v: v[:3] == (12, 0, 3),
+    lambda v: v[:3] >= (12, 0, 3),
     {'dual': (False, {})},
-    "AMPL Gurobi 12.0.3 fails to report duals for problems solved in presolve",
+    "AMPL Gurobi>=12.0.3 fails to report duals for problems solved in presolve",
 )
 MissingSuffixFailures['gurobi', 'nl', 'LP_inactive_index'] = (
-    lambda v: v[:3] == (12, 0, 3),
+    lambda v: v[:3] >= (12, 0, 3),
     {'dual': (False, {})},
-    "AMPL Gurobi 12.0.3 fails to report duals for problems solved in presolve",
+    "AMPL Gurobi>=12.0.3 fails to report duals for problems solved in presolve",
 )
 MissingSuffixFailures['gurobi', 'nl', 'QP_simple'] = (
-    lambda v: v[:3] == (12, 0, 3),
+    lambda v: v[:3] >= (12, 0, 3),
     {'dual': (False, {})},
-    "AMPL Gurobi 12.0.3 fails to report duals for problems solved in presolve",
+    "AMPL Gurobi>=12.0.3 fails to report duals for problems solved in presolve",
 )
 
 #


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Updating some of the writer tests, as the behavior from 12.0.3 persists into 13.0.0.

## Changes proposed in this PR:
- Expect no dual variables from gurobiasl when the model is solved in presolve.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
