### PR TITLE
pytest: rework `conftest.py` to support solver/writer marker expressions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -44,7 +44,7 @@ def pytest_itemcollected(item):
 
     We have historically supported "category markers"::
 
-        @pytest.mark.solve("highs")
+        @pytest.mark.solver("highs")
 
     Unfortunately, pytest doesn't allow for building marker
     expressions (e.g., for "-m") based on the marker.args.  We will

--- a/conftest.py
+++ b/conftest.py
@@ -32,7 +32,7 @@ def pytest_configure(config):
 
 
 def pytest_itemcollected(item):
-    """Standardize all pyomo test markers.
+    """Standardize all Pyomo test markers.
 
     This callback ensures that all unmarked tests, along with all tests
     that are only marked by category markers (e.g., "solver" or
@@ -50,7 +50,7 @@ def pytest_itemcollected(item):
     expressions (e.g., for "-m") based on the marker.args.  We will
     map the positional argument (for pytest.mark.solver and
     pytest.mark.writer) to the keyword argument "id".  This will allow
-    querying againse specific solver interfaces in marker expressions
+    querying against specific solver interfaces in marker expressions
     with::
 
         solver(id='highs')

--- a/conftest.py
+++ b/conftest.py
@@ -50,7 +50,7 @@ def pytest_itemcollected(item):
     expressions (e.g., for "-m") based on the marker.args.  We will
     map the positional argument (for pytest.mark.solver and
     pytest.mark.writer) to the keyword argument "id".  This will allow
-    querrying againse specific solver interfaces in marker expressions
+    querying againse specific solver interfaces in marker expressions
     with::
 
         solver(id='highs')

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ _implicit_markers = {'default'}
 _category_markers = {'solver', 'writer'}
 _extended_implicit_markers = _implicit_markers.union(_category_markers)
 
+
 def pytest_configure(config):
     # If the user specified "--solver" or "--writer", then add that
     # logic to the marker expression
@@ -53,7 +54,7 @@ def pytest_itemcollected(item):
         if mark.name not in _category_markers:
             continue
         if mark.args:
-            _id, = mark.args
+            (_id,) = mark.args
             mark.kwargs['id'] = _id
         if 'vendor' not in mark.kwargs:
             mark.kwargs['vendor'] = mark.kwargs['id'].split("_")[0]

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -99,10 +99,11 @@ Markers are declared in ``pyproject.toml``. Some commonly used markers are:
 - ``expensive``: tests that take a long time to run
 - ``mpi``: tests that require MPI
 - ``solver(id='name')``: tests for a specific solver,
-  e.g., ``@pytest.mark.solver("gurobi_direct")``
-- ``solver(vendor='name')``: tests for a set of solvers up to the first underscore,
-  e.g., ``solver(vendor="gurobi")`` will run all ``gurobi``, ``gurobi_direct``,
-  and ``gurobi_persistent`` tests
+  e.g., ``@pytest.mark.solver("name")``
+- ``solver(vendor='name')``: tests for a set of solvers (matching up to the
+  first underscore), e.g., ``solver(vendor="gurobi")`` will run tests marked
+  with ``solver("gurobi")``, ``solver("gurobi_direct")``, and
+  ``solver("gurobi_persistent")``
 
 More details about Pyomo-defined default test behavior can be found in
 the `conftest.py file <https://github.com/Pyomo/pyomo/blob/main/conftest.py>`_.

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -98,8 +98,11 @@ Markers are declared in ``pyproject.toml``. Some commonly used markers are:
 
 - ``expensive``: tests that take a long time to run
 - ``mpi``: tests that require MPI
-- ``solver(vendor='name')``: tests for a specific solver,
-  e.g., ``@pytest.mark.solver("gurobi")``
+- ``solver(id='name')``: tests for a specific solver,
+  e.g., ``@pytest.mark.solver("gurobi_direct")``
+- ``solver(vendor='name')``: tests for a set of solvers up to the first underscore,
+  e.g., ``solver(vendor="gurobi")`` will run all ``gurobi``, ``gurobi_direct``,
+  and ``gurobi_persistent`` tests
 
 More details about Pyomo-defined default test behavior can be found in
 the `conftest.py file <https://github.com/Pyomo/pyomo/blob/main/conftest.py>`_.

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -98,7 +98,7 @@ Markers are declared in ``pyproject.toml``. Some commonly used markers are:
 
 - ``expensive``: tests that take a long time to run
 - ``mpi``: tests that require MPI
-- ``solver(name)``: dynamic marker to label a test for a specific solver,
+- ``solver(vendor='name')``: tests for a specific solver,
   e.g., ``@pytest.mark.solver("gurobi")``
 
 More details about Pyomo-defined default test behavior can be found in

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp.py
@@ -39,6 +39,7 @@ gurobi_direct = SolverFactory('gurobi_direct_minlp')
 
 
 @unittest.skipUnless(gurobi_direct.available(), "needs Gurobi Direct MINLP interface")
+@unittest.pytest.mark.solver("gurobi_direct_minlp")
 class TestGurobiMINLP(unittest.TestCase):
     def test_gurobi_minlp_sincosexp(self):
         m = ConcreteModel(name="test")

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_walker.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_walker.py
@@ -64,6 +64,7 @@ class CommonTest(unittest.TestCase):
 
 
 @unittest.skipUnless(gurobipy_available, "gurobipy is not available")
+@unittest.pytest.mark.solver("gurobi_direct_minlp")
 class TestGurobiMINLPWalker(CommonTest):
     def _get_nl_expr_tree(self, visitor, expr):
         # This is a bit hacky, but the only way that I know to get the expression tree

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_writer.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_minlp_writer.py
@@ -74,6 +74,7 @@ def make_model():
 
 
 @unittest.skipUnless(gurobipy_available, "Gurobipy 12 is not available")
+@unittest.pytest.mark.solver("gurobi_direct_minlp")
 class TestGurobiMINLPWriter(CommonTest):
     def test_small_model(self):
         grb_model = gurobipy.Model()

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_persistent.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_persistent.py
@@ -122,6 +122,7 @@ def create_pmedian_model():
     return model
 
 
+@unittest.pytest.mark.solver("gurobi_persistent")
 class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
     def setUp(self):
         self.m = pyo.ConcreteModel()
@@ -183,6 +184,7 @@ class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
         self.assertAlmostEqual(y, self.m.y.value)
 
 
+@unittest.pytest.mark.solver("gurobi_persistent")
 class TestGurobiPersistent(unittest.TestCase):
     def test_nonconvex_qcp_objective_bound_1(self):
         # the goal of this test is to ensure we can get an objective bound
@@ -493,6 +495,7 @@ class TestGurobiPersistent(unittest.TestCase):
             self.assertIsNone(res.incumbent_objective)
 
 
+@unittest.pytest.mark.solver("gurobi_persistent")
 class TestManualMode(unittest.TestCase):
     def setUp(self):
         opt = GurobiPersistent()

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_warm_start.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_warm_start.py
@@ -67,6 +67,7 @@ class TestGurobiWarmStart(unittest.TestCase):
             self.assertEqual(value(m.x[i]), x[i])
 
     @unittest.skipUnless(gurobi_direct.available(), "needs Gurobi Direct interface")
+    @unittest.ptest.mark.solver("gurobi_direct")
     def test_gurobi_direct_warm_start(self):
         m = self.make_model()
 
@@ -82,6 +83,7 @@ class TestGurobiWarmStart(unittest.TestCase):
     @unittest.skipUnless(
         gurobi_direct_minlp.available(), "needs Gurobi Direct MINLP interface"
     )
+    @unittest.ptest.mark.solver("gurobi_direct_minlp")
     def test_gurobi_minlp_warmstart(self):
         m = self.make_model()
 
@@ -97,6 +99,7 @@ class TestGurobiWarmStart(unittest.TestCase):
     @unittest.skipUnless(
         gurobi_persistent.available(), "needs Gurobi persistent interface"
     )
+    @unittest.ptest.mark.solver("gurobi_persistent")
     def test_gurobi_persistent_warmstart(self):
         m = self.make_model()
 

--- a/pyomo/contrib/solver/tests/solvers/test_gurobi_warm_start.py
+++ b/pyomo/contrib/solver/tests/solvers/test_gurobi_warm_start.py
@@ -67,7 +67,7 @@ class TestGurobiWarmStart(unittest.TestCase):
             self.assertEqual(value(m.x[i]), x[i])
 
     @unittest.skipUnless(gurobi_direct.available(), "needs Gurobi Direct interface")
-    @unittest.ptest.mark.solver("gurobi_direct")
+    @unittest.pytest.mark.solver("gurobi_direct")
     def test_gurobi_direct_warm_start(self):
         m = self.make_model()
 
@@ -83,7 +83,7 @@ class TestGurobiWarmStart(unittest.TestCase):
     @unittest.skipUnless(
         gurobi_direct_minlp.available(), "needs Gurobi Direct MINLP interface"
     )
-    @unittest.ptest.mark.solver("gurobi_direct_minlp")
+    @unittest.pytest.mark.solver("gurobi_direct_minlp")
     def test_gurobi_minlp_warmstart(self):
         m = self.make_model()
 
@@ -99,7 +99,7 @@ class TestGurobiWarmStart(unittest.TestCase):
     @unittest.skipUnless(
         gurobi_persistent.available(), "needs Gurobi persistent interface"
     )
-    @unittest.ptest.mark.solver("gurobi_persistent")
+    @unittest.pytest.mark.solver("gurobi_persistent")
     def test_gurobi_persistent_warmstart(self):
         m = self.make_model()
 

--- a/pyomo/contrib/solver/tests/solvers/test_highs.py
+++ b/pyomo/contrib/solver/tests/solvers/test_highs.py
@@ -17,6 +17,7 @@ if not opt.available():
     raise unittest.SkipTest
 
 
+@unittest.pytest.mark.solver("highs")
 class TestBugs(unittest.TestCase):
     def test_mutable_params_with_remove_cons(self):
         m = pyo.ConcreteModel()

--- a/pyomo/contrib/solver/tests/solvers/test_ipopt.py
+++ b/pyomo/contrib/solver/tests/solvers/test_ipopt.py
@@ -53,6 +53,7 @@ def windows_tee_buffer(size=1 << 20):
         tee._pipe_buffersize = old
 
 
+@unittest.pytest.mark.solver("ipopt")
 class TestIpoptSolverConfig(unittest.TestCase):
     def test_default_instantiation(self):
         config = ipopt.IpoptConfig()
@@ -87,6 +88,7 @@ class TestIpoptSolverConfig(unittest.TestCase):
         self.assertFalse(config.executable.available())
 
 
+@unittest.pytest.mark.solver("ipopt")
 class TestIpoptSolutionLoader(unittest.TestCase):
     def test_get_reduced_costs_error(self):
         loader = ipopt.IpoptSolutionLoader(
@@ -105,6 +107,7 @@ class TestIpoptSolutionLoader(unittest.TestCase):
             loader.get_duals()
 
 
+@unittest.pytest.mark.solver("ipopt")
 class TestIpoptInterface(unittest.TestCase):
     @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
     def test_command_line_options(self):
@@ -1877,6 +1880,7 @@ else:
 
 
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
+@unittest.pytest.mark.solver("ipopt")
 class TestIpopt(unittest.TestCase):
     def create_model(self):
         model = pyo.ConcreteModel()
@@ -2091,6 +2095,7 @@ class TestIpopt(unittest.TestCase):
 
 
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
+@unittest.pytest.mark.solver("ipopt")
 class TestLegacyIpopt(unittest.TestCase):
     def create_model(self):
         model = pyo.ConcreteModel()

--- a/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_knitro_direct.py
@@ -23,6 +23,7 @@ avail = KnitroDirectSolver().available()
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroDirectSolverConfig(unittest.TestCase):
     def test_default_instantiation(self):
         config = KnitroConfig()
@@ -45,6 +46,7 @@ class TestKnitroDirectSolverConfig(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
     def test_results_extra_info_mip(self):
         """Test that MIP-specific extra info is populated for MIP problems."""
@@ -98,6 +100,7 @@ class TestKnitroSolverResultsExtraInfo(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroSolverObjectiveBound(unittest.TestCase):
     def test_objective_bound_mip(self):
         """Test that objective bound is retrieved for MIP problems."""
@@ -135,6 +138,7 @@ class TestKnitroSolverObjectiveBound(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroSolverIncumbentObjective(unittest.TestCase):
     def test_none_without_objective(self):
         """Test that incumbent objective is None when no objective is present."""
@@ -192,6 +196,7 @@ class TestKnitroSolverIncumbentObjective(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroSolverSolutionStatus(unittest.TestCase):
     def test_solution_status_mapping(self):
         """Test that solution status is correctly mapped from KNITRO status."""
@@ -246,6 +251,7 @@ class TestKnitroSolverSolutionStatus(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroSolverTerminationCondition(unittest.TestCase):
     def test_termination_condition_mapping(self):
         """Test that termination condition is correctly mapped from KNITRO status."""
@@ -337,6 +343,7 @@ class TestKnitroSolverTerminationCondition(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroDirectSolverInterface(unittest.TestCase):
     def test_class_member_list(self):
         opt = KnitroDirectSolver()
@@ -379,6 +386,7 @@ class TestKnitroDirectSolverInterface(unittest.TestCase):
 
 
 @unittest.skipIf(not avail, "KNITRO solver is not available")
+@unittest.pytest.mark.solver("knitro_direct")
 class TestKnitroDirectSolver(unittest.TestCase):
     def setUp(self):
         self.opt = KnitroDirectSolver()

--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -48,9 +48,23 @@ np, numpy_available = attempt_import('numpy')
 parameterized, param_available = attempt_import('parameterized')
 parameterized = parameterized.parameterized
 
-
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
+
+
+class mark_parameterized(parameterized):
+    """Custom :class:`parameterized` that marks the generated tests
+
+    This class will mark all generated tests as a 'solver' test, using
+    the first positional argument as the solver name.
+
+    """
+
+    @classmethod
+    def param_as_standalone_func(cls, p, func, name):
+        newfunc = parameterized.param_as_standalone_func(p, func, name)
+        return unittest.pytest.mark.solver(p.args[0])(newfunc)
+
 
 all_solvers = [
     ('gurobi_persistent', GurobiPersistent),
@@ -112,7 +126,7 @@ def test_all_solvers_list():
 
 
 class TestDualSignConvention(unittest.TestCase):
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_equality(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -164,7 +178,7 @@ class TestDualSignConvention(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], 0)
         self.assertAlmostEqual(duals[m.c2], -1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_inequality(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -226,7 +240,7 @@ class TestDualSignConvention(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], 0.5)
         self.assertAlmostEqual(duals[m.c2], 0.5)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_bounds(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -281,7 +295,7 @@ class TestDualSignConvention(unittest.TestCase):
         rc = res.solution_loader.get_reduced_costs()
         self.assertAlmostEqual(rc[m.x], -1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_range(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -333,7 +347,7 @@ class TestDualSignConvention(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], -0.5)
         self.assertAlmostEqual(duals[m.c2], -0.5)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_equality_max(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -387,7 +401,7 @@ class TestDualSignConvention(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], 0)
         self.assertAlmostEqual(duals[m.c2], 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_inequality_max(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -449,7 +463,7 @@ class TestDualSignConvention(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], -0.5)
         self.assertAlmostEqual(duals[m.c2], -0.5)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_bounds_max(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -506,7 +520,7 @@ class TestDualSignConvention(unittest.TestCase):
         rc = res.solution_loader.get_reduced_costs()
         self.assertAlmostEqual(rc[m.x], 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_range_max(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -563,11 +577,11 @@ class TestDualSignConvention(unittest.TestCase):
 
 @unittest.skipUnless(numpy_available, 'numpy is not available')
 class TestSolvers(unittest.TestCase):
-    @parameterized.expand(input=all_solvers)
+    @mark_parameterized.expand(input=all_solvers)
     def test_config_overwrite(self, name: str, opt_class: Type[SolverBase]):
         self.assertIsNot(SolverBase.CONFIG, opt_class.CONFIG)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_results_object_populated(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -631,7 +645,7 @@ class TestSolvers(unittest.TestCase):
         self.assertIsNotNone(res.solver_log)
         self.assertIsInstance(res.solver_log, str)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_remove_variable_and_objective(
         self, name: str, opt_class: Type[SolverBase], use_presolve
     ):
@@ -659,7 +673,7 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(m.x.value, 2)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_stale_vars(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -707,7 +721,7 @@ class TestSolvers(unittest.TestCase):
         res.solution_loader.load_vars([m.y])
         self.assertFalse(m.y.stale)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_range_constraint(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -735,7 +749,7 @@ class TestSolvers(unittest.TestCase):
         duals = res.solution_loader.get_duals()
         self.assertAlmostEqual(duals[m.c], 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_reduced_costs(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -764,7 +778,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(rc[m.x], -3)
         self.assertAlmostEqual(rc[m.y], -4)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_reduced_costs2(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -791,7 +805,7 @@ class TestSolvers(unittest.TestCase):
         rc = res.solution_loader.get_reduced_costs()
         self.assertAlmostEqual(rc[m.x], 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_param_changes(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -834,7 +848,7 @@ class TestSolvers(unittest.TestCase):
             self.assertAlmostEqual(duals[m.c1], (1 + a1 / (a2 - a1)))
             self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_immutable_param(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -881,7 +895,7 @@ class TestSolvers(unittest.TestCase):
             self.assertAlmostEqual(duals[m.c1], (1 + a1 / (a2 - a1)))
             self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_equality(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -925,7 +939,7 @@ class TestSolvers(unittest.TestCase):
                 self.assertAlmostEqual(duals[m.c1], (1 + a1 / (a2 - a1)))
                 self.assertAlmostEqual(duals[m.c2], -a1 / (a2 - a1))
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_linear_expression(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -970,7 +984,7 @@ class TestSolvers(unittest.TestCase):
                 bound = res.objective_bound
             self.assertTrue(bound <= m.y.value)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_no_objective(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1011,7 +1025,7 @@ class TestSolvers(unittest.TestCase):
                 self.assertAlmostEqual(duals[m.c1], 0)
                 self.assertAlmostEqual(duals[m.c2], 0)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_add_remove_cons(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1072,7 +1086,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], -(1 + a1 / (a2 - a1)))
         self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_results_infeasible(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1128,7 +1142,7 @@ class TestSolvers(unittest.TestCase):
             ):
                 res.solution_loader.get_reduced_costs()
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_duals(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -1156,7 +1170,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(duals[m.c1], 0.5)
         self.assertNotIn(m.c2, duals)
 
-    @parameterized.expand(input=_load_tests(qcp_solvers))
+    @mark_parameterized.expand(input=_load_tests(qcp_solvers))
     def test_mutable_quadratic_coefficient(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1185,7 +1199,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0.10256137418973625, 4)
         self.assertAlmostEqual(m.y.value, 0.0869525991355825, 4)
 
-    @parameterized.expand(input=_load_tests(qcp_solvers))
+    @mark_parameterized.expand(input=_load_tests(qcp_solvers))
     def test_mutable_quadratic_objective_qcp(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1217,7 +1231,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0.6962249634573562, 4)
         self.assertAlmostEqual(m.y.value, 0.09227926676152151, 4)
 
-    @parameterized.expand(input=_load_tests(qp_solvers))
+    @mark_parameterized.expand(input=_load_tests(qp_solvers))
     def test_mutable_quadratic_objective_qp(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1292,7 +1306,7 @@ class TestSolvers(unittest.TestCase):
         if opt_class is Highs:
             self.assertIn(opt._pyomo_var_to_solver_var_map[id(m.x3)], {0, 1})
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_fixed_vars(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1335,7 +1349,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 2)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_fixed_vars_2(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1378,7 +1392,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 2)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_fixed_vars_3(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1400,7 +1414,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(res.incumbent_objective, 3)
         self.assertAlmostEqual(m.x.value, 2)
 
-    @parameterized.expand(input=_load_tests(nlp_solvers))
+    @mark_parameterized.expand(input=_load_tests(nlp_solvers))
     def test_fixed_vars_4(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1425,7 +1439,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 2**0.5, delta=1e-3)
         self.assertAlmostEqual(m.y.value, 2**0.5, delta=1e-3)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_mutable_param_with_range(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1522,7 +1536,7 @@ class TestSolvers(unittest.TestCase):
                 self.assertAlmostEqual(duals[m.con1], (1 + a1 / (a2 - a1)), 6)
                 self.assertAlmostEqual(duals[m.con2], -a1 / (a2 - a1), 6)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_add_and_remove_vars(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1573,7 +1587,7 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(m.x.value, None)
         self.assertAlmostEqual(m.y.value, -1)
 
-    @parameterized.expand(input=_load_tests(nlp_solvers))
+    @mark_parameterized.expand(input=_load_tests(nlp_solvers))
     def test_exp(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt = opt_class()
         if not opt.available():
@@ -1592,7 +1606,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, -0.42630274815985264, delta=1e-3)
         self.assertAlmostEqual(m.y.value, 0.6529186341994245, delta=1e-3)
 
-    @parameterized.expand(input=_load_tests(nlp_solvers))
+    @mark_parameterized.expand(input=_load_tests(nlp_solvers))
     def test_log(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt = opt_class()
         if not opt.available():
@@ -1611,7 +1625,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0.6529186341994245)
         self.assertAlmostEqual(m.y.value, -0.42630274815985264)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_with_numpy(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1642,7 +1656,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
         self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_bounds_with_params(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1681,7 +1695,7 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(m.y.value, 3)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_solution_loader(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1738,7 +1752,7 @@ class TestSolvers(unittest.TestCase):
         self.assertIn(m.c1, duals)
         self.assertAlmostEqual(duals[m.c1], 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_time_limit(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1801,7 +1815,7 @@ class TestSolvers(unittest.TestCase):
             {TerminationCondition.maxTimeLimit, TerminationCondition.iterationLimit},
         )
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_objective_changes(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1876,7 +1890,7 @@ class TestSolvers(unittest.TestCase):
             res = opt.solve(m)
             self.assertAlmostEqual(res.incumbent_objective, 4)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_domain(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -1905,7 +1919,7 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 0)
 
-    @parameterized.expand(input=_load_tests(mip_solvers))
+    @mark_parameterized.expand(input=_load_tests(mip_solvers))
     def test_domain_with_integers(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1936,7 +1950,7 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_fixed_binaries(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -1968,7 +1982,7 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, 1)
 
-    @parameterized.expand(input=_load_tests(mip_solvers))
+    @mark_parameterized.expand(input=_load_tests(mip_solvers))
     def test_with_gdp(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -2004,7 +2018,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 1)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_variables_elsewhere(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -2038,7 +2052,7 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 2)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_variables_elsewhere2(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -2080,7 +2094,7 @@ class TestSolvers(unittest.TestCase):
         self.assertIn(m.y, sol)
         self.assertNotIn(m.z, sol)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_bug_1(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -2108,7 +2122,7 @@ class TestSolvers(unittest.TestCase):
         self.assertEqual(res.solution_status, SolutionStatus.optimal)
         self.assertAlmostEqual(res.incumbent_objective, 3)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_bug_2(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         """
         This test is for a bug where an objective containing a fixed variable does
@@ -2139,7 +2153,7 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.incumbent_objective, -18, 5)
 
-    @parameterized.expand(input=_load_tests(nl_solvers))
+    @mark_parameterized.expand(input=_load_tests(nl_solvers))
     def test_presolve_with_zero_coef(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -2204,7 +2218,7 @@ class TestSolvers(unittest.TestCase):
         )
         self.assertEqual(res.termination_condition, exp)
 
-    @parameterized.expand(input=_load_tests(all_solvers))
+    @mark_parameterized.expand(input=_load_tests(all_solvers))
     def test_scaling(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()
         if not opt.available():
@@ -2261,7 +2275,7 @@ class TestSolvers(unittest.TestCase):
             self.assertAlmostEqual(rc[m.x], 1)
             self.assertAlmostEqual(rc[m.y], 0)
 
-    @parameterized.expand(input=_load_tests([("highs", Highs)]))
+    @mark_parameterized.expand(input=_load_tests([("highs", Highs)]))
     def test_node_limit(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -2279,7 +2293,7 @@ class TestSolvers(unittest.TestCase):
         )
         assert res.termination_condition == TerminationCondition.iterationLimit
 
-    @parameterized.expand(input=_load_tests(nl_solvers))
+    @mark_parameterized.expand(input=_load_tests(nl_solvers))
     def test_external_function(
         self, name: str, opt_class: Type[SolverBase], use_presolve: bool
     ):
@@ -2298,7 +2312,7 @@ class TestSolvers(unittest.TestCase):
 
 
 class TestLegacySolverInterface(unittest.TestCase):
-    @parameterized.expand(input=all_solvers)
+    @mark_parameterized.expand(input=all_solvers)
     def test_param_updates(self, name: str, opt_class: Type[SolverBase]):
         opt = pyo.SolverFactory(name + '_v2')
         if not opt.available(exception_flag=False):
@@ -2328,7 +2342,7 @@ class TestLegacySolverInterface(unittest.TestCase):
             self.assertAlmostEqual(m.dual[m.c1], (1 + a1 / (a2 - a1)))
             self.assertAlmostEqual(m.dual[m.c2], a1 / (a2 - a1))
 
-    @parameterized.expand(input=all_solvers)
+    @mark_parameterized.expand(input=all_solvers)
     def test_load_solutions(self, name: str, opt_class: Type[SolverBase]):
         opt = pyo.SolverFactory(name + '_v2')
         if not opt.available(exception_flag=False):

--- a/pyomo/solvers/tests/checks/test_BARON.py
+++ b/pyomo/solvers/tests/checks/test_BARON.py
@@ -24,6 +24,7 @@ baron_available = _test_solver_cases('baron', 'bar').available
 
 
 @unittest.skipIf(not baron_available, "The 'BARON' solver is not available")
+@unittest.pytest.mark.solver("baron")
 class BaronTest(unittest.TestCase):
     """Test the BARON interface."""
 

--- a/pyomo/solvers/tests/checks/test_CBCplugin.py
+++ b/pyomo/solvers/tests/checks/test_CBCplugin.py
@@ -35,6 +35,8 @@ cbc_available = SolverFactory('cbc', solver_io='lp').available(exception_flag=Fa
 data_dir = '{}/data'.format(dirname(abspath(__file__)))
 
 
+@unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
+@unittest.pytest.mark.solver("cbc")
 class TestCBC(unittest.TestCase):
     """
     These tests are here to test the general functionality of the cbc solver when using the lp solverio, which will
@@ -51,7 +53,6 @@ class TestCBC(unittest.TestCase):
     def tearDown(self):
         sys.stderr = self.stderr
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_infeasible_lp(self):
         self.model.X = Var(within=Reals)
         self.model.C1 = Constraint(expr=self.model.X <= 1)
@@ -69,7 +70,6 @@ class TestCBC(unittest.TestCase):
         )
         self.assertEqual(SolverStatus.warning, results.solver.status)
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_unbounded_lp(self):
         self.model.Idx = RangeSet(2)
         self.model.X = Var(self.model.Idx, within=Reals)
@@ -88,7 +88,6 @@ class TestCBC(unittest.TestCase):
         )
         self.assertEqual(SolverStatus.warning, results.solver.status)
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_optimal_lp(self):
         self.model.X = Var(within=NonNegativeReals)
         self.model.Obj = Objective(expr=self.model.X, sense=minimize)
@@ -107,7 +106,6 @@ class TestCBC(unittest.TestCase):
         )
         self.assertEqual(SolverStatus.ok, results.solver.status)
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_infeasible_mip(self):
         self.model.X = Var(within=NonNegativeIntegers)
         self.model.C1 = Constraint(expr=self.model.X <= 1)
@@ -125,7 +123,6 @@ class TestCBC(unittest.TestCase):
         )
         self.assertEqual(SolverStatus.warning, results.solver.status)
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_unbounded_mip(self):
         self.model.X = Var(within=Integers)
         self.model.Obj = Objective(expr=self.model.X, sense=minimize)
@@ -141,7 +138,6 @@ class TestCBC(unittest.TestCase):
         )
         self.assertEqual(SolverStatus.warning, results.solver.status)
 
-    @unittest.skipIf(not cbc_available, "The 'cbc' solver is not available")
     def test_optimal_mip(self):
         self.model.Idx = RangeSet(2)
         self.model.X = Var(self.model.Idx, within=NonNegativeIntegers)

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -43,6 +43,8 @@ except ImportError:
 diff_tol = 1e-4
 
 
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+@unittest.pytest.mark.solver("cplex_direct")
 class CPLEXDirectTests(unittest.TestCase):
     def setUp(self):
         self.stderr = sys.stderr
@@ -51,9 +53,6 @@ class CPLEXDirectTests(unittest.TestCase):
     def tearDown(self):
         sys.stderr = self.stderr
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_infeasible_lp(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -68,9 +67,6 @@ class CPLEXDirectTests(unittest.TestCase):
                 results.solver.termination_condition, TerminationCondition.infeasible
             )
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_unbounded_lp(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -87,9 +83,6 @@ class CPLEXDirectTests(unittest.TestCase):
                 ),
             )
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_optimal_lp(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -100,9 +93,6 @@ class CPLEXDirectTests(unittest.TestCase):
 
             self.assertEqual(results.solution.status, SolutionStatus.optimal)
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_get_duals_lp(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -122,9 +112,6 @@ class CPLEXDirectTests(unittest.TestCase):
             self.assertAlmostEqual(model.dual[model.C1], 0.4)
             self.assertAlmostEqual(model.dual[model.C2], 0.2)
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_infeasible_mip(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -139,9 +126,6 @@ class CPLEXDirectTests(unittest.TestCase):
                 results.solver.termination_condition, TerminationCondition.infeasible
             )
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_unbounded_mip(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = AbstractModel()
@@ -159,9 +143,6 @@ class CPLEXDirectTests(unittest.TestCase):
                 ),
             )
 
-    @unittest.skipIf(
-        not cplexpy_available, "The 'cplex' python bindings are not available"
-    )
     def test_optimal_mip(self):
         with SolverFactory("cplex", solver_io="python") as opt:
             model = ConcreteModel()
@@ -174,6 +155,7 @@ class CPLEXDirectTests(unittest.TestCase):
 
 
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+@unittest.pytest.mark.solver("cplex_persistent")
 class TestIsFixedCallCount(unittest.TestCase):
     """Tests for PR#1402 (669e7b2b)"""
 
@@ -430,6 +412,7 @@ class TestAddVar(unittest.TestCase):
 
 
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+@unittest.pytest.mark.solver("cplex_direct")
 class TestAddCon(unittest.TestCase):
     def test_add_single_constraint(self):
         model = ConcreteModel()
@@ -536,6 +519,7 @@ class TestAddCon(unittest.TestCase):
 
 
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+@unittest.pytest.mark.solver("cplex_direct")
 class TestLoadVars(unittest.TestCase):
     def setUp(self):
         opt = SolverFactory("cplex", solver_io="python")

--- a/pyomo/solvers/tests/checks/test_CPLEXPersistent.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXPersistent.py
@@ -22,6 +22,7 @@ except ImportError:
 
 
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+@unittest.pytest.mark.solver("cplex_persistent")
 class TestQuadraticObjective(unittest.TestCase):
     def test_quadratic_objective_is_set(self):
         model = ConcreteModel()

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -38,6 +38,7 @@ opt_gms = SolverFactory('gams', solver_io='gms')
 gamsgms_available = opt_gms.available(exception_flag=False)
 
 
+@unittest.pytest.mark.solver("gams")
 class GAMSTests(unittest.TestCase):
     @unittest.skipIf(
         not gamspy_available, "The 'gams' python bindings are not available"
@@ -387,6 +388,7 @@ class GAMSLogfileTestBase(unittest.TestCase):
 
 
 @unittest.skipIf(not gamsgms_available, "The 'gams' executable is not available")
+@unittest.pytest.mark.solver("gams")
 class GAMSLogfileGmsTests(GAMSLogfileTestBase):
     """Test class for testing permultations of tee and logfile options.
 
@@ -450,6 +452,7 @@ class GAMSLogfileGmsTests(GAMSLogfileTestBase):
 
 
 @unittest.skipIf(not gamspy_available, "The 'gams' python bindings are not available")
+@unittest.pytest.mark.solver("gams")
 class GAMSLogfilePyTests(GAMSLogfileTestBase):
     """Test class for testing permultations of tee and logfile options.
 

--- a/pyomo/solvers/tests/checks/test_KNITROAMPL.py
+++ b/pyomo/solvers/tests/checks/test_KNITROAMPL.py
@@ -23,10 +23,9 @@ from pyomo.opt import SolverFactory, TerminationCondition
 knitroampl_available = SolverFactory('knitroampl').available(False)
 
 
+@unittest.skipIf(not knitroampl_available, "The 'knitroampl' command is not available")
+@unittest.pytest.mark.solver("knitroampl")
 class TestKNITROAMPLInterface(unittest.TestCase):
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_infeasible_lp(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()
@@ -41,9 +40,6 @@ class TestKNITROAMPLInterface(unittest.TestCase):
                 results.solver.termination_condition, TerminationCondition.infeasible
             )
 
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_unbounded_lp(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()
@@ -60,9 +56,6 @@ class TestKNITROAMPLInterface(unittest.TestCase):
                 ),
             )
 
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_optimal_lp(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()
@@ -77,9 +70,6 @@ class TestKNITROAMPLInterface(unittest.TestCase):
             )
             self.assertAlmostEqual(value(model.X), 2.5)
 
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_get_duals_lp(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()
@@ -99,9 +89,6 @@ class TestKNITROAMPLInterface(unittest.TestCase):
             self.assertAlmostEqual(model.dual[model.C1], 0.4)
             self.assertAlmostEqual(model.dual[model.C2], 0.2)
 
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_infeasible_mip(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()
@@ -116,9 +103,6 @@ class TestKNITROAMPLInterface(unittest.TestCase):
                 results.solver.termination_condition, TerminationCondition.infeasible
             )
 
-    @unittest.skipIf(
-        not knitroampl_available, "The 'knitroampl' command is not available"
-    )
     def test_optimal_mip(self):
         with SolverFactory('knitroampl') as opt:
             model = ConcreteModel()

--- a/pyomo/solvers/tests/checks/test_MOSEKDirect.py
+++ b/pyomo/solvers/tests/checks/test_MOSEKDirect.py
@@ -20,6 +20,7 @@ mosek_available = check_available_solvers('mosek_direct')
 
 
 @unittest.skipIf(not mosek_available, "MOSEK's python bindings are not available")
+@unittest.pytest.mark.solver("mosek_direct")
 class MOSEKDirectTests(unittest.TestCase):
     def setUp(self):
         self.stderr = sys.stderr

--- a/pyomo/solvers/tests/checks/test_MOSEKPersistent.py
+++ b/pyomo/solvers/tests/checks/test_MOSEKPersistent.py
@@ -28,6 +28,7 @@ if mosek_available:
 
 
 @unittest.skipIf(not mosek_available, "MOSEK's python bindings are missing.")
+@unittest.pytest.mark.solver("mosek_persistent")
 class MOSEKPersistentTests(unittest.TestCase):
     def setUp(self):
         self.stderr = sys.stderr

--- a/pyomo/solvers/tests/checks/test_SAS.py
+++ b/pyomo/solvers/tests/checks/test_SAS.py
@@ -294,6 +294,7 @@ class SASTestLP(SASTestAbc):
 
 
 @unittest.skipIf(not sas94_available, "The SAS94 solver interface is not available")
+@unittest.pytest.mark.solver("sas")
 class SASTestLP94(SASTestLP, unittest.TestCase):
     @mock.patch(
         "pyomo.solvers.plugins.solvers.SAS.SAS94.sas_version",
@@ -328,6 +329,7 @@ class SASTestLP94(SASTestLP, unittest.TestCase):
 
 # @unittest.skipIf(not sascas_available, "The SAS solver is not available")
 @unittest.skip("Tests not yet configured for SAS Viya interface.")
+@unittest.pytest.mark.solver("sas")
 class SASTestLPCAS(SASTestLP, unittest.TestCase):
     solver_io = "_sascas"
     session_options = CAS_OPTIONS
@@ -339,6 +341,7 @@ class SASTestLPCAS(SASTestLP, unittest.TestCase):
         self.checkSolution()
 
 
+@unittest.pytest.mark.solver("sas")
 class SASTestMILP(SASTestAbc):
     def setX(self):
         self.instance.X = Var([1, 2, 3], within=NonNegativeIntegers)
@@ -529,12 +532,14 @@ class SASTestMILP(SASTestAbc):
 
 # @unittest.skipIf(not sas94_available, "The SAS solver is not available")
 @unittest.skip("MILP94 tests disabled.")
+@unittest.pytest.mark.solver("sas")
 class SASTestMILP94(SASTestMILP, unittest.TestCase):
     pass
 
 
 # @unittest.skipIf(not sascas_available, "The SAS solver is not available")
 @unittest.skip("Tests not yet configured for SAS Viya interface.")
+@unittest.pytest.mark.solver("sas")
 class SASTestMILPCAS(SASTestMILP, unittest.TestCase):
     solver_io = "_sascas"
     session_options = CAS_OPTIONS

--- a/pyomo/solvers/tests/checks/test_cbc.py
+++ b/pyomo/solvers/tests/checks/test_cbc.py
@@ -27,6 +27,7 @@ opt_cbc = SolverFactory('cbc')
 cbc_available = opt_cbc.available(exception_flag=False)
 
 
+@unittest.pytest.mark.solver("cbc")
 class CBCTests(unittest.TestCase):
     @unittest.skipIf(not cbc_available, "The CBC solver is not available")
     def test_warm_start(self):

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -32,6 +32,7 @@ import pyomo.common.unittest as unittest
 from pyomo.solvers.plugins.solvers.cuopt_direct import cuopt_available
 
 
+@unittest.pytest.mark.solver("cuopt")
 class CUOPTTests(unittest.TestCase):
     @unittest.skipIf(not cuopt_available, "The CuOpt solver is not available")
     def test_values_and_rc(self):

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -23,6 +23,7 @@ except:
 
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
+@unittest.pytest.mark.solver("gurobi")
 class GurobiTest(unittest.TestCase):
     @unittest.skipIf(not has_worklimit, "gurobi < 9.5")
     @patch("pyomo.solvers.plugins.solvers.GUROBI_RUN.read")

--- a/pyomo/solvers/tests/checks/test_gurobi_direct.py
+++ b/pyomo/solvers/tests/checks/test_gurobi_direct.py
@@ -79,6 +79,7 @@ class GurobiBase(unittest.TestCase):
 
 
 @unittest.skipIf(gurobipy_available, "gurobipy is installed, skip import test")
+@unittest.pytest.mark.solver("gurobi_direct")
 class GurobiImportFailedTests(unittest.TestCase):
     def test_gurobipy_not_installed(self):
         # ApplicationError should be thrown if gurobipy is not available
@@ -90,6 +91,7 @@ class GurobiImportFailedTests(unittest.TestCase):
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
 @unittest.skipIf(not gurobi_available, "gurobi license is not valid")
+@unittest.pytest.mark.solver("gurobi_direct")
 class GurobiParameterTests(GurobiBase):
     # Test parameter handling at the model and environment level
 
@@ -170,6 +172,7 @@ class GurobiParameterTests(GurobiBase):
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
 @unittest.skipIf(not gurobi_available, "gurobi license is not valid")
+@unittest.pytest.mark.solver("gurobi_direct")
 class GurobiEnvironmentTests(GurobiBase):
     # Test handling of gurobi environments
 
@@ -337,6 +340,7 @@ class GurobiEnvironmentTests(GurobiBase):
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
 @unittest.skipIf(not gurobi_available, "gurobi license is not valid")
 @unittest.skipIf(not single_use_license(), reason="test needs a single use license")
+@unittest.pytest.mark.solver("gurobi_direct")
 class GurobiSingleUseTests(GurobiBase):
     # Integration tests for Gurobi single-use licenses (useful for checking all Gurobi
     # environments were correctly freed). These tests are not run in pyomo's CI. Each

--- a/pyomo/solvers/tests/checks/test_gurobi_persistent.py
+++ b/pyomo/solvers/tests/checks/test_gurobi_persistent.py
@@ -22,8 +22,9 @@ except:
     gurobipy_available = False
 
 
+@unittest.skipIf(not gurobipy_available, "gurobipy is not available")
+@unittest.pytest.mark.solver("gurobi_persistent")
 class TestGurobiPersistent(unittest.TestCase):
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_basics(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(bounds=(-10, 10))
@@ -107,7 +108,6 @@ class TestGurobiPersistent(unittest.TestCase):
         del m.z
         self.assertEqual(opt.get_model_attr('NumVars'), 2)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update1(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -129,7 +129,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update2(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -151,7 +150,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update3(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -171,7 +169,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update4(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -191,7 +188,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update5(self):
         m = pyo.ConcreteModel()
         m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
@@ -213,7 +209,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update6(self):
         m = pyo.ConcreteModel()
         m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
@@ -233,7 +228,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_update7(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -259,7 +253,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.update()
         self.assertEqual(opt._solver_model.getAttr('NumVars'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_linear_constraint_attr(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -271,7 +264,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.set_linear_constraint_attr(m.c, 'Lazy', 1)
         self.assertEqual(opt.get_linear_constraint_attr(m.c, 'Lazy'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_quadratic_constraint_attr(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -282,7 +274,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.set_instance(m)
         self.assertEqual(opt.get_quadratic_constraint_attr(m.c, 'QCRHS'), 0)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_var_attr(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(within=pyo.Binary)
@@ -292,7 +283,6 @@ class TestGurobiPersistent(unittest.TestCase):
         opt.set_var_attr(m.x, 'Start', 1)
         self.assertEqual(opt.get_var_attr(m.x, 'Start'), 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_callback(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(bounds=(0, 4))
@@ -323,7 +313,6 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 1)
         self.assertAlmostEqual(m.y.value, 1)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_add_column(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(within=pyo.NonNegativeReals)
@@ -343,7 +332,6 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 0.5)
 
-    @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
     def test_add_column_exceptions(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()

--- a/pyomo/solvers/tests/checks/test_ipopt.py
+++ b/pyomo/solvers/tests/checks/test_ipopt.py
@@ -15,6 +15,7 @@ ipopt_available = IPOPT.IPOPT().available()
 
 
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
+@unittest.pytest.mark.solver("ipopt")
 class TestIpoptInterface(unittest.TestCase):
     def test_has_linear_solver(self):
         opt = IPOPT.IPOPT()

--- a/pyomo/solvers/tests/checks/test_no_solution_behavior.py
+++ b/pyomo/solvers/tests/checks/test_no_solution_behavior.py
@@ -89,7 +89,7 @@ def create_method(model, solver, io, test_case):
         def return_test(self):
             return failed_solve_test(self)
 
-    unittest.pytest.mark.solver(solver)(return_test)
+    unittest.pytest.mark.solver(solver)(unittest.pytest.mark.writer(io)(return_test))
     return return_test
 
 

--- a/pyomo/solvers/tests/checks/test_pickle.py
+++ b/pyomo/solvers/tests/checks/test_pickle.py
@@ -138,7 +138,7 @@ def create_method(model, solver, io, test_case, symbolic_labels):
                 def return_test(self):
                     return pickle_test(self)
 
-    unittest.pytest.mark.solver(solver)(return_test)
+    unittest.pytest.mark.solver(solver)(unittest.pytest.mark.writer(io)(return_test))
     return return_test
 
 

--- a/pyomo/solvers/tests/checks/test_writers.py
+++ b/pyomo/solvers/tests/checks/test_writers.py
@@ -158,7 +158,7 @@ def create_method(test_name, model, solver, io, test_case, symbolic_labels):
                 def return_test(self):
                     return writer_test(self)
 
-    unittest.pytest.mark.solver(solver)(return_test)
+    unittest.pytest.mark.solver(solver)(unittest.pytest.mark.writer(io)(return_test))
     return return_test
 
 

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -20,8 +20,9 @@ from pyomo.solvers.plugins.solvers.xpress_persistent import XpressPersistent
 xpress_available = pyo.SolverFactory('xpress_persistent').available(False)
 
 
+@unittest.skipIf(not xpress_available, "xpress is not available")
+@unittest.pytest.mark.solver("xpress_persistent")
 class TestXpressPersistent(unittest.TestCase):
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_basics(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(bounds=(-10, 10))
@@ -126,7 +127,6 @@ class TestXpressPersistent(unittest.TestCase):
         del m.z
         self.assertEqual(opt.get_xpress_attribute('cols'), 2)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_vartype_change(self):
         # test for issue #3565
         m = pyo.ConcreteModel()
@@ -151,7 +151,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt._solver_model.getlb(lb, x_idx, x_idx)
         self.assertEqual(lb[0], 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_qconstraint(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -170,7 +169,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt.add_constraint(m.c1)
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_lconstraint(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -189,7 +187,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt.add_constraint(m.c2)
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_sosconstraint(self):
         m = pyo.ConcreteModel()
         m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
@@ -208,7 +205,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt.add_sos_constraint(m.c1)
         self.assertEqual(opt.get_xpress_attribute('sets'), 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_sosconstraint2(self):
         m = pyo.ConcreteModel()
         m.a = pyo.Set(initialize=[1, 2, 3], ordered=True)
@@ -226,7 +222,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt.remove_sos_constraint(m.c2)
         self.assertEqual(opt.get_xpress_attribute('sets'), 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_remove_var(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -247,7 +242,6 @@ class TestXpressPersistent(unittest.TestCase):
         opt.remove_var(m.x)
         self.assertEqual(opt.get_xpress_attribute('cols'), 1)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_column(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(within=pyo.NonNegativeReals)
@@ -267,7 +261,6 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertAlmostEqual(m.x.value, 0)
         self.assertAlmostEqual(m.y.value, 0.5)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_add_column_exceptions(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
@@ -317,7 +310,6 @@ class TestXpressPersistent(unittest.TestCase):
         # var already in solver model
         self.assertRaises(RuntimeError, opt.add_column, m, m.y, -2, [m.c], [1])
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     @unittest.skipIf(
         xpd.xpress_available and xpd.xpress.__version__ == '9.8.0',
         "Xpress 9.8 always runs global optimizer",
@@ -353,7 +345,6 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertGreater(m.x2.value, 0.0)
         self.assertGreater(m.x3.value, 0.0)
 
-    @unittest.skipIf(not xpress_available, "xpress is not available")
     def test_nonconvexqp_infeasible(self):
         """Test non-convex QP which xpress_direct should prove infeasible."""
         m = pyo.ConcreteModel()
@@ -376,6 +367,9 @@ class TestXpressPersistent(unittest.TestCase):
             results.solver.termination_condition, TerminationCondition.infeasible
         )
 
+
+@unittest.pytest.mark.solver("xpress_persistent")
+class TestXpressPersistentMock:
     def test_available(self):
         class mock_xpress:
             def __init__(self, importable, initable):

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -369,7 +369,7 @@ class TestXpressPersistent(unittest.TestCase):
 
 
 @unittest.pytest.mark.solver("xpress_persistent")
-class TestXpressPersistentMock:
+class TestXpressPersistentMock(unittest.TestCase):
     def test_available(self):
         class mock_xpress:
             def __init__(self, importable, initable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,16 +76,10 @@ markers = [
     "mpi: marks tests that require MPI",
     "neos: marks tests that require NEOS server connections",
     "importtest: marks tests that checks for warnings when importing modules",
-    "book: marks tests from the Pyomo book",
     "performance: marks performance tests",
-    "long: marks long performance tests",
-    "short: marks short performance tests",
-    "devel: marks developer-created performance tests",
-    "nl: marks nl tests",
-    "lp: marks lp tests",
-    "gams: marks gams tests",
-    "bar: marks bar tests",
     "builders: tests that should be run when testing custom (extension) builders",
+    "solver(name): mark test to run the named solver",
+    "writer(name): mark test to run the named problem writer",
 ]
 
 [tool.black]


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
Pyomo's existing pytest configuration supports marking solver tests using `pytest.mark.solver(name)`, and then running those tests using a custom `--solver name` command line argument.  However, the test selection was done by skipping tests at runtime and not deselecting the tests after collection.  Further, the markers could not be used in "normal" marker expressions (because pytest does not support accessing positional arguments in marker expressions).

This PR redesigns how we handle `solver` markers:
- the positional argument is mapped to a keyword argument (`id`).  This enables using markers expressions like `solver(id='highs')` to select tests based on the solver marker.
- an additional keyword argument (`vendor`) is also defined using a substring of `id` up to, but not including the first underscore.  This supports selecting "all" tests for a vendor.  For example `solver(vendor='gurobi')` will match `gurobi`, `gurobi_direct`, and `gurobi_persistent` solver markers.
- the `--solver` command line option is now translated into a marker expression (instead of relying on skipping tests at runtime)
- move the `solver` marker definition into the `pyproject.toml` (with all the other markers)

In addition, this PR:
- adds a `writer` marker that works analogously to the `solver` marker
- removes a number of unused pytest markers from `pyproject.toml`
- propagates the use of the `solver` marker through the solver tests in `pyomo.solvers` and `pyomo.contrib.solver`
- found a way to mark tests generated by `paarameterized.expand`

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
