### PR TITLE
IPOPT test bug: version checking incorrect

### DIFF
--- a/pyomo/contrib/solver/tests/solvers/test_ipopt.py
+++ b/pyomo/contrib/solver/tests/solvers/test_ipopt.py
@@ -1974,7 +1974,7 @@ class TestIpopt(unittest.TestCase):
         ipopt_instance = ipopt.Ipopt()
         results = ipopt_instance.solve(model)
         timing_info = results.timing_info
-        if ipopt_instance.version()[0:2] <= (3, 13):
+        if ipopt_instance.version()[:2] <= (3, 13):
             # We are running an older version of IPOPT (<= 3.13)
             self.assertIn('IPOPT (w/o function evaluations)', timing_info.keys())
             self.assertIn('NLP function evaluations', timing_info.keys())

--- a/pyomo/contrib/solver/tests/solvers/test_ipopt.py
+++ b/pyomo/contrib/solver/tests/solvers/test_ipopt.py
@@ -12,12 +12,9 @@ import os
 import stat
 import subprocess
 import sys
-import time
-import threading
 from contextlib import contextmanager
 
 import pyomo.environ as pyo
-from pyomo.common.envvar import is_windows
 from pyomo.common.fileutils import ExecutableData
 from pyomo.common.config import ConfigDict, ADVANCED_OPTION
 from pyomo.common.errors import ApplicationError, MouseTrap
@@ -1977,7 +1974,7 @@ class TestIpopt(unittest.TestCase):
         ipopt_instance = ipopt.Ipopt()
         results = ipopt_instance.solve(model)
         timing_info = results.timing_info
-        if ipopt_instance.version()[0:1] <= (3, 13):
+        if ipopt_instance.version()[0:2] <= (3, 13):
             # We are running an older version of IPOPT (<= 3.13)
             self.assertIn('IPOPT (w/o function evaluations)', timing_info.keys())
             self.assertIn('NLP function evaluations', timing_info.keys())


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
I installed IPOPT 3.14 while I was refreshing my environment, and what do you know, we have a bug! We don't check the second item in this test, only the first, so this fixes it. I also removed some unused imports.

## Changes proposed in this PR:
- Fix version checking bug
- Remove unused imports

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
