### PR TITLE
Update GHA TPL cache; resolve new test failures

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -95,13 +95,13 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: 3.13
+          python: 3.12
           test_docs: 1
           TARGET: osx
           PYENV: pip
 
         - os: windows-latest
-          python: 3.14
+          python: 3.13
           test_docs: 1
           TARGET: win
           PYENV: conda

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -477,8 +477,7 @@ jobs:
         echo "$IPOPT_DIR" >> $GITHUB_PATH
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
-        NEW_PYOMO_PATH="$IPOPT_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
+        echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p $IPOPT_DIR
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
@@ -528,6 +527,10 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        # Note: we put GAMS_DIR at the *end* of PYOMO_PATH so explicitly
+        #    installed solvers will be found first.
+        echo "PYOMO_PATH=${env:PYOMO_PATH}:$GAMS_DIR" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
         $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
@@ -567,19 +570,19 @@ jobs:
       if: ${{ ! matrix.slim }}
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
-        NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
         if test -n "$WHL"; then
             # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
+            echo "Installing GAMS Python bindings from wheel"
             $PYTHON_EXE -m pip install "$WHL"
         elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
-            echo "Installing GAMS Python bindings"
+            echo "Installing GAMS Python bindings using setup.py"
             pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
             $PYTHON_EXE setup.py install
             popd
         else
+            echo "Installing GAMS Python bindings from PyPI"
             $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi
 
@@ -590,16 +593,7 @@ jobs:
         $BARON_DIR = "${env:TPL_DIR}/baron"
         echo "$BARON_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        $CURRENT_PYOMO_PATH="${env:PYOMO_PATH}"
-        # Prepend BARON_DIR with appropriate path separator
-        if ( "${{matrix.TARGET}}" -eq "win" ) {
-            $PATH_SEPARATOR = ";"
-        } else {
-            $PATH_SEPARATOR = ":"
-        }
-        $NEW_PYOMO_PATH = "$BARON_DIR$PATH_SEPARATOR$CURRENT_PYOMO_PATH"
-        echo "New PYOMO_PATH: $NEW_PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" | `
+        echo "PYOMO_PATH=$BARON_DIR:${env:PYOMO_PATH}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $URL = "https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
@@ -635,8 +629,7 @@ jobs:
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH
-        NEW_PYOMO_PATH="$GJH_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
+        echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -530,7 +530,7 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/latest"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -524,9 +524,9 @@ jobs:
         $GAMS_DIR = "${env:TPL_DIR}/gams"
         echo "$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" `
+        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
+        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
@@ -566,7 +566,7 @@ jobs:
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
       run: |
-        GAMS_DIR="$TPL_DIR/gams"
+        GAMS_DIR="${env:TPL_DIR}/gams"
         NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -489,11 +489,9 @@ jobs:
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
             else
                 curl $URL/idaes-solvers-windows-x86_64.tar.gz \
                     $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
@@ -700,6 +698,12 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
+        #
+        # [26 Feb 26] For unknown reasons, SSL verification has stopped
+        # working on GHA (even though everything is fine when run
+        # locally).  Giving up and just turning off SSL verification.
+        # Someone should revisit this in the future.
+        #
         pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -568,16 +568,21 @@ jobs:
         GAMS_DIR="$TPL_DIR/gams"
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
+        TRY_PYPI=0
+        set +e
         if test -n "$WHL"; then
             # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
             echo "Installing GAMS Python bindings from wheel"
-            $PYTHON_EXE -m pip install "$WHL"
+            $PYTHON_EXE -m pip install "$WHL" || TRY_PYPI=1
         elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
             echo "Installing GAMS Python bindings using setup.py"
             pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
-            $PYTHON_EXE setup.py install
+            $PYTHON_EXE setup.py install || TRY_PYPI=1
             popd
         else
+            TRY_PYPI=1
+        fi
+        if test $TRY_PYPI -ne 0; then
             echo "Installing GAMS Python bindings from PyPI"
             $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -513,9 +513,12 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
-      # We install using Powershell because the GAMS installer hangs
-      # when launched from bash on Windows
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      # - We install using Powershell because the GAMS installer hangs
+      #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -531,7 +534,12 @@ jobs:
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {
-            $URL = "$URL/macosx/osx_x64_64_sfx.exe"
+            $osxarch = (uname -m).Trim()
+            if ( "$osxarch" -eq "arm64" ) {
+                $URL = "$URL/macosx/osx_arm64_sfx.exe"
+            } else {
+                $URL = "$URL/macosx/osx_x64_64_sfx.exe"
+            }
         } else {
             $URL = "$URL/linux/linux_x64_64_sfx.exe"
         }
@@ -561,13 +569,18 @@ jobs:
         GAMS_DIR="$TPL_DIR/gams"
         NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
-        py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
-            ;print(v if v != "_27" else "")')
-        if test -e $GAMS_DIR/apifiles/Python/api$py_ver; then
+        pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
+        WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
+        if test -n "$WHL"; then
+            # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
+            $PYTHON_EXE -m pip install "$WHL"
+        elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
             echo "Installing GAMS Python bindings"
-            pushd $GAMS_DIR/apifiles/Python/api$py_ver
+            pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
             $PYTHON_EXE setup.py install
             popd
+        else
+            $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi
 
     - name: Install BARON

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -217,6 +217,7 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -700,7 +700,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions || exit 1
+        pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -639,7 +639,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v251017.0
+  CACHE_VER: v260223.6
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -637,6 +637,8 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            sed -i 's/wget \(.*\)/curl \1 > solvers.tgz/' get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -638,7 +638,8 @@ jobs:
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
-            sed -i 's/wget \(.*\)/curl \1 > solvers.tgz/' get.ASL
+            URL=http://www.ampl.com/netlib/ampl/solvers.tgz
+            sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -186,8 +186,9 @@ jobs:
     - name: Configure curl
       run: |
         CURLRC="$(cat <<EOF
-           retry = 0
-           max-time = 30
+           retry = 8
+           max-time = 150
+           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
@@ -484,21 +485,17 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl --max-time 150 --retry 8 \
-                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
                     -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz \
                     -o $IPOPT_TAR
             else
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz \
                     $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
@@ -636,7 +633,7 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
+            curl $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -569,7 +569,7 @@ jobs:
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
       run: |
-        GAMS_DIR="${env:TPL_DIR}/gams"
+        GAMS_DIR="$TPL_DIR/gams"
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
         if test -n "$WHL"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -593,7 +593,7 @@ jobs:
         $BARON_DIR = "${env:TPL_DIR}/baron"
         echo "$BARON_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "PYOMO_PATH=$BARON_DIR:${env:PYOMO_PATH}" | `
+        echo "PYOMO_PATH=${BARON_DIR}:${env:PYOMO_PATH}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $URL = "https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260223.6
+  CACHE_VER: v260223.7
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -638,8 +638,9 @@ jobs:
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
-            URL=http://www.ampl.com/netlib/ampl/solvers.tgz
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
             sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260223.7
+  CACHE_VER: v260228.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -485,27 +485,27 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            if test -z "$VER"; then
+                echo "FAILED identifying IPOPT release"
+                exit 1
+            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        if test "${{matrix.TARGET}}" == win; then
-            tar -xzi < $IPOPT_TAR
-        else
-            tar -xzf $IPOPT_TAR
-        fi
+        tar -xzf $IPOPT_TAR
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
+        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
       if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -302,7 +302,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip cplex docplex \
+            python -m pip install --cache-dir cache/pip 'cplex!=22.1.2.1' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -642,6 +642,10 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260303.0
+  CACHE_VER: v260303.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch
@@ -95,13 +95,13 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: 3.12
+          python: 3.13
           test_docs: 1
           TARGET: osx
           PYENV: pip
 
         - os: windows-latest
-          python: 3.13
+          python: 3.14
           test_docs: 1
           TARGET: win
           PYENV: conda
@@ -217,7 +217,6 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
-        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev
@@ -487,10 +486,6 @@ jobs:
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-            if test -z "$VER"; then
-                echo "FAILED identifying IPOPT release"
-                exit 1
-            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
@@ -515,15 +510,11 @@ jobs:
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
-        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      if: ${{ ! matrix.slim }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
-      # - We no longer install on OSX because GAMS no longer distributes
-      #   self extracting ZIP for OSX and the package is difficult [for JDS]
-      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -651,10 +642,6 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
-            # Patch get.ASL to use curl
-            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
-            cat get.ASL
             ./get.ASL
             cd ..
             make
@@ -714,13 +701,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        #
-        # [26 Feb 26] For unknown reasons, SSL verification has stopped
-        # working on GHA (even though everything is fine when run
-        # locally).  Giving up and just turning off SSL verification.
-        # Someone should revisit this in the future.
-        #
-        pyomo download-extensions --retry 3 --insecure || exit 1
+        pyomo download-extensions --retry 3 || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260303.1
+  CACHE_VER: v260228.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch
@@ -95,13 +95,13 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: 3.13
+          python: 3.12
           test_docs: 1
           TARGET: osx
           PYENV: pip
 
         - os: windows-latest
-          python: 3.14
+          python: 3.13
           test_docs: 1
           TARGET: win
           PYENV: conda
@@ -188,6 +188,7 @@ jobs:
         CURLRC="$(cat <<EOF
            retry = 8
            max-time = 150
+           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
@@ -217,6 +218,7 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev
@@ -483,38 +485,41 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl --max-time 150 --retry 8 \
-                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            if test -z "$VER"; then
+                echo "FAILED identifying IPOPT release"
+                exit 1
+            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                curl  --retry 8 --max-time 150 -L \
+                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
-        cd $IPOPT_DIR
+        cd "$IPOPT_DIR"
         if test "${{matrix.TARGET}}" == win; then
-            tar -xzi < $IPOPT_TAR
+            # tar on Windows apparently can't open "drive:\path" file names
+            tar -xzi < "$IPOPT_TAR"
         else
-            tar -xzf $IPOPT_TAR
+            tar -xzf "$IPOPT_TAR"
         fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
+        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -634,12 +639,11 @@ jobs:
         echo "${GJH_DIR}" >> $GITHUB_PATH
         echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
-        rm -rf $INSTALL_DIR
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
+            curl $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
@@ -706,7 +710,13 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions --retry 3 || exit 1
+        #
+        # [26 Feb 26] For unknown reasons, SSL verification has stopped
+        # working on GHA (even though everything is fine when run
+        # locally).  Giving up and just turning off SSL verification.
+        # Someone should revisit this in the future.
+        #
+        pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -485,7 +485,7 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -193,7 +193,11 @@ jobs:
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
-        echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        if ${{matrix.TARGET}} == win; then
+            echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
+        else
+            echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        fi
 
     - name: Update OSX
       if: matrix.TARGET == 'osx'
@@ -497,8 +501,7 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl  --retry 8 --max-time 150 -L \
-                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -634,6 +634,7 @@ jobs:
         echo "${GJH_DIR}" >> $GITHUB_PATH
         echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
+        rm -rf $INSTALL_DIR
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -72,7 +72,8 @@ jobs:
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
-        exclude_patterns: https://www.gnu.org
+        #  - All lpsolve.sourceforge.net links because SF appears to reject fro GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
 
 
   build:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -188,7 +188,6 @@ jobs:
         CURLRC="$(cat <<EOF
            retry = 8
            max-time = 150
-           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -481,6 +481,7 @@ jobs:
         echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p "$IPOPT_DIR"
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
+        rm -rf $IPOPT_TAR
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -651,6 +651,10 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260228.0
+  CACHE_VER: v260304.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch
@@ -497,12 +497,13 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz > "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz > "$IPOPT_TAR"
             else
-                IPOPT_TAR=$(echo "$IPOPT_TAR" | sed 's|/|\\|g')
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                # Note: use stdout redirection instead of -o because the
+                # shell can handle mixed "/" and "\", but curl cannot.
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz > "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -497,7 +497,8 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl  --retry 8 --max-time 150 -L \
+                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -65,7 +65,7 @@ jobs:
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
         # The timeout seconds to provide to requests, defaults to 5 seconds
-        timeout: 30
+        timeout: 60
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures
@@ -721,7 +721,7 @@ jobs:
         # locally).  Giving up and just turning off SSL verification.
         # Someone should revisit this in the future.
         #
-        pyomo download-extensions --retry 3 --insecure || exit 1
+        pyomo download-extensions --retry 3 --retry-sleep 60 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -486,12 +486,15 @@ jobs:
             URL=https://github.com/IDAES/idaes-ext
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            echo $RELEASE
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            echo $VER
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"
                 exit 1
             fi
             URL=${URL}/releases/download/$VER
+            echo $URL
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260228.0
+  CACHE_VER: v260303.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch
@@ -481,21 +481,17 @@ jobs:
         echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p "$IPOPT_DIR"
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
-        rm -rf $IPOPT_TAR
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
-            echo $RELEASE
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-            echo $VER
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"
                 exit 1
             fi
             URL=${URL}/releases/download/$VER
-            echo $URL
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -485,7 +485,8 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl --max-time 150 --retry 8 \
+                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"
@@ -493,20 +494,24 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                    -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
+                    -o $IPOPT_TAR
             else
-                curl  --retry 8 --max-time 150 -L \
-                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
-        cd "$IPOPT_DIR"
+        cd $IPOPT_DIR
         if test "${{matrix.TARGET}}" == win; then
-            # tar on Windows apparently can't open "drive:\path" file names
-            tar -xzi < "$IPOPT_TAR"
+            tar -xzi < $IPOPT_TAR
         else
-            tar -xzf "$IPOPT_TAR"
+            tar -xzf $IPOPT_TAR
         fi
         echo ""
         echo "$IPOPT_DIR"
@@ -643,14 +648,10 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl $URL > $INSTALLER
+            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
-            # Patch get.ASL to use curl
-            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
-            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -72,7 +72,7 @@ jobs:
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
-        #  - All lpsolve.sourceforge.net links because SF appears to reject fro GHA
+        #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
         exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
 
 

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -480,7 +480,7 @@ jobs:
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
-        mkdir -p $IPOPT_DIR
+        mkdir -p "$IPOPT_DIR"
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
@@ -493,15 +493,15 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
-        cd $IPOPT_DIR
-        tar -xzf $IPOPT_TAR
+        cd "$IPOPT_DIR"
+        tar -xzf "$IPOPT_TAR"
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -302,7 +302,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip cplex docplex \
+            python -m pip install --cache-dir cache/pip "cplex!=22.1.2.1" docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -191,9 +191,9 @@ jobs:
            location
         EOF
         )"
-        echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
-        echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
-        if ${{matrix.TARGET}} == win; then
+        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
+        if test "${{matrix.TARGET}}" == win; then
             echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
         else
             echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
@@ -376,7 +376,7 @@ jobs:
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.
-            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
+            if [[ "${{matrix.TARGET}}" == win && ${{matrix.python}} =~ 3.1[01] ]]; then
                 # We would like to just use something like:
                 #  - "!=9.5.1" (conda errors)
                 #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -191,8 +191,8 @@ jobs:
            location
         EOF
         )"
-        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
-        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
+        echo "$CURLRC" | sed -r 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" | sed -r 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
         if test "${{matrix.TARGET}}" == win; then
             echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
         else

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -501,6 +501,7 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
+                IPOPT_TAR=$(echo "$IPOPT_TAR" | sed 's|/|\\|g')
                 curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -584,7 +584,8 @@ jobs:
         fi
         if test $TRY_PYPI -ne 0; then
             echo "Installing GAMS Python bindings from PyPI"
-            $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
+            # Note: we are seeing segfaults with 53.1 under pytest on GHA/linux
+            $PYTHON_EXE -m pip install 'gamsapi!=53.1' gamspy-highs gamspy-ipopt
         fi
 
     - name: Install BARON

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -502,7 +502,12 @@ jobs:
             fi
         fi
         cd "$IPOPT_DIR"
-        tar -xzf "$IPOPT_TAR"
+        if test "${{matrix.TARGET}}" == win; then
+            # tar on Windows apparently can't open "drive:\path" file names
+            tar -xzi < "$IPOPT_TAR"
+        else
+            tar -xzf "$IPOPT_TAR"
+        fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -302,7 +302,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip "cplex!=22.1.2.1" docplex \
+            python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -690,8 +690,9 @@ jobs:
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
-            URL=http://www.ampl.com/netlib/ampl/solvers.tgz
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
             sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v251017.0
+  CACHE_VER: v260223.7
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -689,6 +689,8 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            sed -i 's/wget \(.*\)/curl \1 > solvers.tgz/' get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -529,8 +529,7 @@ jobs:
         echo "$IPOPT_DIR" >> $GITHUB_PATH
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
-        NEW_PYOMO_PATH="$IPOPT_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
+        echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         mkdir -p $IPOPT_DIR
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
@@ -580,6 +579,10 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        # Note: we put GAMS_DIR at the *end* of PYOMO_PATH so explicitly
+        #    installed solvers will be found first.
+        echo "PYOMO_PATH=${env:PYOMO_PATH}:$GAMS_DIR" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
         $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
@@ -619,19 +622,19 @@ jobs:
       if: ${{ ! matrix.slim }}
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
-        NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
         if test -n "$WHL"; then
             # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
+            echo "Installing GAMS Python bindings from wheel"
             $PYTHON_EXE -m pip install "$WHL"
         elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
-            echo "Installing GAMS Python bindings"
+            echo "Installing GAMS Python bindings using setup.py"
             pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
             $PYTHON_EXE setup.py install
             popd
         else
+            echo "Installing GAMS Python bindings from PyPI"
             $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi
 
@@ -642,16 +645,7 @@ jobs:
         $BARON_DIR = "${env:TPL_DIR}/baron"
         echo "$BARON_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        $CURRENT_PYOMO_PATH="${env:PYOMO_PATH}"
-        # Prepend BARON_DIR with appropriate path separator
-        if ( "${{matrix.TARGET}}" -eq "win" ) {
-            $PATH_SEPARATOR = ";"
-        } else {
-            $PATH_SEPARATOR = ":"
-        }
-        $NEW_PYOMO_PATH = "$BARON_DIR$PATH_SEPARATOR$CURRENT_PYOMO_PATH"
-        echo "New PYOMO_PATH: $NEW_PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" | `
+        echo "PYOMO_PATH=$BARON_DIR:${env:PYOMO_PATH}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $URL = "https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
@@ -687,8 +681,7 @@ jobs:
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH
-        NEW_PYOMO_PATH="$GJH_DIR:$PYOMO_PATH"
-        echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
+        echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -541,11 +541,9 @@ jobs:
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
             else
                 curl $URL/idaes-solvers-windows-x86_64.tar.gz \
                     $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
@@ -752,6 +750,12 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
+        #
+        # [26 Feb 26] For unknown reasons, SSL verification has stopped
+        # working on GHA (even though everything is fine when run
+        # locally).  Giving up and just turning off SSL verification.
+        # Someone should revisit this in the future.
+        #
         pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -752,7 +752,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions || exit 1
+        pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -576,9 +576,9 @@ jobs:
         $GAMS_DIR = "${env:TPL_DIR}/gams"
         echo "$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" `
+        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
+        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
@@ -618,7 +618,7 @@ jobs:
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
       run: |
-        GAMS_DIR="$TPL_DIR/gams"
+        GAMS_DIR="${env:TPL_DIR}/gams"
         NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -645,7 +645,7 @@ jobs:
         $BARON_DIR = "${env:TPL_DIR}/baron"
         echo "$BARON_DIR" | `
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "PYOMO_PATH=$BARON_DIR:${env:PYOMO_PATH}" | `
+        echo "PYOMO_PATH=${BARON_DIR}:${env:PYOMO_PATH}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $URL = "https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260223.7
+  CACHE_VER: v260228.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -620,16 +620,21 @@ jobs:
         GAMS_DIR="$TPL_DIR/gams"
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
+        TRY_PYPI=0
+        set +e
         if test -n "$WHL"; then
             # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
             echo "Installing GAMS Python bindings from wheel"
-            $PYTHON_EXE -m pip install "$WHL"
+            $PYTHON_EXE -m pip install "$WHL" || TRY_PYPI=1
         elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
             echo "Installing GAMS Python bindings using setup.py"
             pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
-            $PYTHON_EXE setup.py install
+            $PYTHON_EXE setup.py install || TRY_PYPI=1
             popd
         else
+            TRY_PYPI=1
+        fi
+        if test $TRY_PYPI -ne 0; then
             echo "Installing GAMS Python bindings from PyPI"
             $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -269,6 +269,7 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -238,8 +238,9 @@ jobs:
     - name: Configure curl
       run: |
         CURLRC="$(cat <<EOF
-           retry = 0
-           max-time = 30
+           retry = 8
+           max-time = 150
+           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
@@ -536,21 +537,17 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl --max-time 150 --retry 8 \
-                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
                     -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz \
                     -o $IPOPT_TAR
             else
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz \
                     $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
@@ -688,7 +685,7 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
+            curl $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -691,7 +691,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -690,7 +690,8 @@ jobs:
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
-            sed -i 's/wget \(.*\)/curl \1 > solvers.tgz/' get.ASL
+            URL=http://www.ampl.com/netlib/ampl/solvers.tgz
+            sed -i "s|wget .*|curl $URL > solvers.tgz|" get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -565,9 +565,12 @@ jobs:
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
-      # We install using Powershell because the GAMS installer hangs
-      # when launched from bash on Windows
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      # - We install using Powershell because the GAMS installer hangs
+      #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -579,11 +582,16 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/latest"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {
-            $URL = "$URL/macosx/osx_x64_64_sfx.exe"
+            $osxarch = (uname -m).Trim()
+            if ( "$osxarch" -eq "arm64" ) {
+                $URL = "$URL/macosx/osx_arm64_sfx.exe"
+            } else {
+                $URL = "$URL/macosx/osx_x64_64_sfx.exe"
+            }
         } else {
             $URL = "$URL/linux/linux_x64_64_sfx.exe"
         }
@@ -613,13 +621,18 @@ jobs:
         GAMS_DIR="$TPL_DIR/gams"
         NEW_PYOMO_PATH="$GAMS_DIR:$PYOMO_PATH"
         echo "PYOMO_PATH=$NEW_PYOMO_PATH" >> $GITHUB_ENV
-        py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
-            ;print(v if v != "_27" else "")')
-        if test -e $GAMS_DIR/apifiles/Python/api$py_ver; then
+        pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
+        WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
+        if test -n "$WHL"; then
+            # Starting in 51.2.1 < GAMS <= 53.1, GAMS bundles wheels
+            $PYTHON_EXE -m pip install "$WHL"
+        elif test -e "$GAMS_DIR/apifiles/Python/api_$pyver"; then
             echo "Installing GAMS Python bindings"
-            pushd $GAMS_DIR/apifiles/Python/api$py_ver
+            pushd "$GAMS_DIR/apifiles/Python/api_$pyver"
             $PYTHON_EXE setup.py install
             popd
+        else
+            $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
         fi
 
     - name: Install BARON

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -621,7 +621,7 @@ jobs:
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
       run: |
-        GAMS_DIR="${env:TPL_DIR}/gams"
+        GAMS_DIR="$TPL_DIR/gams"
         pyver=$($PYTHON_EXE -c 'import sys; print("%s%s" % sys.version_info[:2])')
         WHL=$(find "$GAMS_DIR/api/python/bdist" -name "*cp$pyver*.whl")
         if test -n "$WHL"; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -554,7 +554,12 @@ jobs:
             fi
         fi
         cd "$IPOPT_DIR"
-        tar -xzf "$IPOPT_TAR"
+        if test "${{matrix.TARGET}}" == win; then
+            # tar on Windows apparently can't open "drive:\path" file names
+            tar -xzi < "$IPOPT_TAR"
+        else
+            tar -xzf "$IPOPT_TAR"
+        fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -532,7 +532,7 @@ jobs:
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$IPOPT_DIR" >> $GITHUB_ENV
         echo "PYOMO_PATH=$IPOPT_DIR:$PYOMO_PATH" >> $GITHUB_ENV
-        mkdir -p $IPOPT_DIR
+        mkdir -p "$IPOPT_DIR"
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
@@ -545,15 +545,15 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o $IPOPT_TAR
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
-        cd $IPOPT_DIR
-        tar -xzf $IPOPT_TAR
+        cd "$IPOPT_DIR"
+        tar -xzf "$IPOPT_TAR"
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -694,6 +694,10 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260228.0
+  CACHE_VER: v260303.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260303.0
+  CACHE_VER: v260303.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |
@@ -269,7 +269,6 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
-        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev
@@ -539,10 +538,6 @@ jobs:
             RELEASE=$(curl --max-time 150 --retry 8 \
                 -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-            if test -z "$VER"; then
-                echo "FAILED identifying IPOPT release"
-                exit 1
-            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
@@ -567,15 +562,11 @@ jobs:
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
-        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      if: ${{ ! matrix.slim }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
-      # - We no longer install on OSX because GAMS no longer distributes
-      #   self extracting ZIP for OSX and the package is difficult [for JDS]
-      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -703,10 +694,6 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
-            # Patch get.ASL to use curl
-            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
-            cat get.ASL
             ./get.ASL
             cd ..
             make
@@ -766,13 +753,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        #
-        # [26 Feb 26] For unknown reasons, SSL verification has stopped
-        # working on GHA (even though everything is fine when run
-        # locally).  Giving up and just turning off SSL verification.
-        # Someone should revisit this in the future.
-        #
-        pyomo download-extensions --retry 3 --insecure || exit 1
+        pyomo download-extensions --retry 3 || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260303.1
+  CACHE_VER: v260228.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |
@@ -240,6 +240,7 @@ jobs:
         CURLRC="$(cat <<EOF
            retry = 8
            max-time = 150
+           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
@@ -269,6 +270,7 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        sudo apt-get update ca-certificates
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils \
             libginac-dev
@@ -535,38 +537,41 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl --max-time 150 --retry 8 \
-                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            if test -z "$VER"; then
+                echo "FAILED identifying IPOPT release"
+                exit 1
+            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
-                    -o $IPOPT_TAR
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                curl --retry 8 --max-time 150 -L \
+                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
-        cd $IPOPT_DIR
+        cd "$IPOPT_DIR"
         if test "${{matrix.TARGET}}" == win; then
-            tar -xzi < $IPOPT_TAR
+            # tar on Windows apparently can't open "drive:\path" file names
+            tar -xzi < "$IPOPT_TAR"
         else
-            tar -xzf $IPOPT_TAR
+            tar -xzf "$IPOPT_TAR"
         fi
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
+        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"
@@ -686,12 +691,11 @@ jobs:
         echo "${GJH_DIR}" >> $GITHUB_PATH
         echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
-        rm -rf $INSTALL_DIR
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
+            curl $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
@@ -758,7 +762,13 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions --retry 3 || exit 1
+        #
+        # [26 Feb 26] For unknown reasons, SSL verification has stopped
+        # working on GHA (even though everything is fine when run
+        # locally).  Giving up and just turning off SSL verification.
+        # Someone should revisit this in the future.
+        #
+        pyomo download-extensions --retry 3 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -686,6 +686,7 @@ jobs:
         echo "${GJH_DIR}" >> $GITHUB_PATH
         echo "PYOMO_PATH=$GJH_DIR:$PYOMO_PATH" >> $GITHUB_ENV
         INSTALL_DIR="${DOWNLOAD_DIR}/gjh"
+        rm -rf $INSTALL_DIR
         if test ! -e "$INSTALL_DIR/bin"; then
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -243,8 +243,8 @@ jobs:
            location
         EOF
         )"
-        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
-        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
+        echo "$CURLRC" | sed -r 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" | sed -r 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
         if test "${{matrix.TARGET}}" == win; then
             echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
         else

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -76,7 +76,7 @@ jobs:
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
         # The timeout seconds to provide to requests, defaults to 5 seconds
-        timeout: 30
+        timeout: 60
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures
@@ -773,7 +773,7 @@ jobs:
         # locally).  Giving up and just turning off SSL verification.
         # Someone should revisit this in the future.
         #
-        pyomo download-extensions --retry 3 --insecure || exit 1
+        pyomo download-extensions --retry 3 --retry-sleep 60 --insecure || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -354,7 +354,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip cplex docplex \
+            python -m pip install --cache-dir cache/pip "cplex!=22.1.2.1" docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -245,7 +245,11 @@ jobs:
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
-        echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        if ${{matrix.TARGET}} == win; then
+            echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
+        else
+            echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        fi
 
     - name: Update OSX
       if: matrix.TARGET == 'osx'
@@ -549,8 +553,7 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl --retry 8 --max-time 150 -L \
-                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260228.0
+  CACHE_VER: v260304.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |
@@ -549,14 +549,13 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz > "$IPOPT_TAR"
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
+                curl $URL/idaes-solvers-darwin-aarch64.tar.gz > "$IPOPT_TAR"
             else
-                IPOPT_TAR=$(echo "$IPOPT_TAR" | sed 's|/|\\|g')
-                echo "CURL_HOME: '${CURL_HOME}'"
-                echo "IPOPT_TAR: '${IPOPT_TAR}'"
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                # Note: use stdout redirection instead of -o because the
+                # shell can handle mixed "/" and "\", but curl cannot.
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz > "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -83,7 +83,8 @@ jobs:
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
-        exclude_patterns: https://www.gnu.org
+        #  - All lpsolve.sourceforge.net links because SF appears to reject fro GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
 
 
   build:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -243,9 +243,9 @@ jobs:
            location
         EOF
         )"
-        echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
-        echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
-        if ${{matrix.TARGET}} == win; then
+        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" | sed 's/^ +//' > ${GITHUB_WORKSPACE}/_curlrc
+        if test "${{matrix.TARGET}}" == win; then
             echo "CURL_HOME=$GITHUB_WORKSPACE" | sed 's|/|\\|g' >> $GITHUB_ENV
         else
             echo "CURL_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
@@ -428,7 +428,7 @@ jobs:
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.
-            if [[ ${{matrix.TARGET}} == win && ${{matrix.python}} =~ 3.1[01] ]]; then
+            if [[ "${{matrix.TARGET}}" == win && ${{matrix.python}} =~ 3.1[01] ]]; then
                 # We would like to just use something like:
                 #  - "!=9.5.1" (conda errors)
                 #  - "<9.5.1|>9.5.1" (conda installs 9.1.2, which also hangs)

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -553,6 +553,9 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
+                IPOPT_TAR=$(echo "$IPOPT_TAR" | sed 's|/|\\|g')
+                echo "CURL_HOME: '${CURL_HOME}'"
+                echo "IPOPT_TAR: '${IPOPT_TAR}'"
                 curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -537,7 +537,8 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl --max-time 150 --retry 8 \
+                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"
@@ -545,20 +546,24 @@ jobs:
             fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
-                curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz \
+                    -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
-                curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-darwin-aarch64.tar.gz \
+                    -o $IPOPT_TAR
             else
-                curl --retry 8 --max-time 150 -L \
-                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
-        cd "$IPOPT_DIR"
+        cd $IPOPT_DIR
         if test "${{matrix.TARGET}}" == win; then
-            # tar on Windows apparently can't open "drive:\path" file names
-            tar -xzi < "$IPOPT_TAR"
+            tar -xzi < $IPOPT_TAR
         else
-            tar -xzf "$IPOPT_TAR"
+            tar -xzf $IPOPT_TAR
         fi
         echo ""
         echo "$IPOPT_DIR"
@@ -695,14 +700,10 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl $URL > $INSTALLER
+            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
-            # Patch get.ASL to use curl
-            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
-            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -636,7 +636,8 @@ jobs:
         fi
         if test $TRY_PYPI -ne 0; then
             echo "Installing GAMS Python bindings from PyPI"
-            $PYTHON_EXE -m pip install gamspy gamspy-highs gamspy-ipopt
+            # Note: we are seeing segfaults with 53.1 under pytest on GHA/linux
+            $PYTHON_EXE -m pip install 'gamsapi!=53.1' gamspy-highs gamspy-ipopt
         fi
 
     - name: Install BARON

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -354,7 +354,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip "cplex!=22.1.2.1" docplex \
+            python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -549,7 +549,8 @@ jobs:
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o "$IPOPT_TAR"
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
+                curl --retry 8 --max-time 150 -L \
+                    $URL/idaes-solvers-windows-x86_64.tar.gz -o "$IPOPT_TAR"
             fi
         fi
         cd "$IPOPT_DIR"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -354,7 +354,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip cplex docplex \
+            python -m pip install --cache-dir cache/pip 'cplex!=22.1.2.1' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -703,6 +703,10 @@ jobs:
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
+            # Patch get.ASL to use curl
+            URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
+            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            cat get.ASL
             ./get.ASL
             cd ..
             make

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -537,27 +537,27 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            if test -z "$VER"; then
+                echo "FAILED identifying IPOPT release"
+                exit 1
+            fi
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl $URL/idaes-solvers-ubuntu2204-x86_64.tar.gz -o $IPOPT_TAR
             elif test "${{matrix.TARGET}}" == osx; then
                 curl $URL/idaes-solvers-darwin-aarch64.tar.gz -o $IPOPT_TAR
             else
-                curl $URL/idaes-solvers-windows-x86_64.tar.gz \
-                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
+                curl $URL/idaes-solvers-windows-x86_64.tar.gz -o $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR
-        if test "${{matrix.TARGET}}" == win; then
-            tar -xzi < $IPOPT_TAR
-        else
-            tar -xzf $IPOPT_TAR
-        fi
+        tar -xzf $IPOPT_TAR
         echo ""
         echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
+        $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
       if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -240,7 +240,6 @@ jobs:
         CURLRC="$(cat <<EOF
            retry = 8
            max-time = 150
-           location
         EOF
         )"
         echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -83,7 +83,7 @@ jobs:
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
-        #  - All lpsolve.sourceforge.net links because SF appears to reject fro GHA
+        #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
         exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
 
 

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -537,7 +537,7 @@ jobs:
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
             URL=https://github.com/IDAES/idaes-ext
-            RELEASE=$(curl -s -H 'Accept: application/json' ${URL}/releases/latest)
+            RELEASE=$(curl -L -s -H 'Accept: application/json' ${URL}/releases/latest)
             VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
             if test -z "$VER"; then
                 echo "FAILED identifying IPOPT release"

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -34,4 +34,5 @@ jobs:
         exclude_urls: https://pyomo-jenkins.sandia.gov/,https://pyomo.readthedocs.io/en/%s/errors.html
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
-        exclude_patterns: https://www.gnu.org
+        #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -27,7 +27,7 @@ jobs:
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
         # The timeout seconds to provide to requests, defaults to 5 seconds
-        timeout: 30
+        timeout: 60
         # Exclude:
         #  - Jenkins because it's behind a firewall
         #  - RTD because a magically-generated string triggers failures

--- a/examples/pyomo/sos/basic_sos2_example.py
+++ b/examples/pyomo/sos/basic_sos2_example.py
@@ -10,7 +10,7 @@
 import pyomo.environ as pyo
 
 # Problem borrowed from the lpsolve project documentation
-# http://lpsolve.sourceforge.net/5.0/SOS.htm
+# https://lpsolve.sourceforge.net/5.0/SOS.htm
 
 # Don't forget that you can see that actual input to the solver if you use
 # the -k command line flag:

--- a/pyomo/contrib/cp/repn/docplex_writer.py
+++ b/pyomo/contrib/cp/repn/docplex_writer.py
@@ -118,8 +118,9 @@ def _finalize_docplex(module, available):
     _time_point_dispatchers[_END_TIME] = module.end_of
 
 
-cp, docplex_available = attempt_import('docplex.cp.model', callback=_finalize_docplex)
-cp_solver, docplex_available = attempt_import('docplex.cp.solver')
+cp, _cp_model = attempt_import('docplex.cp.model', callback=_finalize_docplex)
+cp_solver, _cp_solver = attempt_import('docplex.cp.solver')
+docplex_available = _cp_model & _cp_solver
 
 logger = logging.getLogger('pyomo.contrib.cp')
 
@@ -1305,7 +1306,7 @@ class CPOptimizerSolver:
         pass
 
     def available(self, exception_flag=True):
-        return Executable('cpoptimizer').available() and docplex_available
+        return Executable('cpoptimizer') and bool(docplex_available)
 
     def license_is_valid(self):
         if CPOptimizerSolver._unrestricted_license is None:

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -70,16 +70,17 @@ class GroupDownloader:
 
                 except SystemExit:
                     _info = sys.exc_info()
-                    _cls = 'NoneType' if _info[0] is None else _info[0].__name__
-                    logger.error(f"{_cls}: {_info[1]}")
                     rc = 2
                 except Exception:
                     _info = sys.exc_info()
-                    _cls = 'NoneType' if _info[0] is None else _info[0].__name__
-                    logger.error(f"{_cls}: {_info[1]}")
                     rc = 1
 
                 # Note: we *only* get here if the downloader raised an exception
+                _cls = 'NoneType' if _info[0] is None else _info[0].__name__
+                logger.error(f"{_cls}: {_info[1]}")
+                # Release the stack frame...
+                _info = None
+
                 attempt += 1
                 if attempt <= args.retry:
                     logger.info(

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -49,10 +49,18 @@ class GroupDownloader:
             while attempt <= args.retry:
                 try:
                     ext = DownloadFactory(target, downloader=self.downloader)
-                    if hasattr(ext, "skip") and ext.skip():
+                    if getattr(ext, "skip", bool)():
+                        # If the extension has a "skip" attribute, and
+                        # calling it returns Truth, then mark this as a
+                        # skipped download and move on.
                         result = "SKIP"
                     else:
-                        ext()
+                        # If the extension has a __cell__(), then call
+                        # it.  Otherwise, assume all went well (e.g.,
+                        # the registered extension was actually a
+                        # function not a type -- and it was called when
+                        # we "created" it in the Factory call above).
+                        getattr(ext, '__call__', bool)()
                         result = " OK "
 
                     # Normal completion: SKIP or OK.  Either way, break

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -13,9 +13,6 @@ import time
 from pyomo.common.download import FileDownloader, DownloadFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
-MAX_RETRIES = 3
-RETRY_SLEEP_SECONDS = 5
-
 
 class GroupDownloader:
     def __init__(self):
@@ -36,7 +33,6 @@ class GroupDownloader:
     def _call_impl(self, args, unparsed, logger):
         results = []
         result_fmt = "[%s]  %s"
-        returncode = 0
 
         self.downloader.cacert = args.cacert
         self.downloader.insecure = args.insecure
@@ -47,49 +43,46 @@ class GroupDownloader:
             "to download the AMPL GSL binaries."
         )
 
+        returncode = 0
         for target in DownloadFactory:
-            attempt = 0
-            result = "FAIL"
-
-            while attempt < MAX_RETRIES:
+            attempt = 1
+            while attempt <= args.retry:
                 try:
                     ext = DownloadFactory(target, downloader=self.downloader)
-
                     if hasattr(ext, "skip") and ext.skip():
                         result = "SKIP"
-                    elif hasattr(ext, "__call__"):
+                    else:
                         ext()
                         result = " OK "
-                    else:
-                        result = " OK "
 
+                    # Normal completion: SKIP or OK.  Either way, break
+                    # out and bypass both the retry checks and any
+                    # update of the returncode.
                     break
 
                 except SystemExit:
                     _info = sys.exc_info()
-                    _cls = (
-                        f"{_info[0].__name__ if _info[0] is not None else 'NoneType'}: "
-                    )
-                    logger.error(_cls + str(_info[1]))
-                    if attempt + 1 == MAX_RETRIES:
-                        returncode |= 2
+                    _cls = 'NoneType' if _info[0] is None else _info[0].__name__
+                    logger.error(f"{_cls}: {_info[1]}")
+                    rc = 2
                 except Exception:
                     _info = sys.exc_info()
-                    _cls = (
-                        f"{_info[0].__name__ if _info[0] is not None else 'NoneType'}: "
+                    _cls = 'NoneType' if _info[0] is None else _info[0].__name__
+                    logger.error(f"{_cls}: {_info[1]}")
+                    rc = 1
+
+                # Note: we *only* get here if the downloader raised an exception
+                attempt += 1
+                if attempt <= args.retry:
+                    logger.info(
+                        f"Retrying download of '{target}' "
+                        f"(attempt {attempt} of {args.retry}) "
+                        f"in {args.retry_sleep} seconds"
                     )
-                    logger.error(_cls + str(_info[1]))
-                    if attempt + 1 == MAX_RETRIES:
-                        returncode |= 1
-                finally:
-                    if result != " OK ":
-                        attempt += 1
-                        if attempt < MAX_RETRIES:
-                            logger.info(
-                                f"Retrying download of '{target}' "
-                                f"(attempt {attempt + 1} of {MAX_RETRIES})"
-                            )
-                            time.sleep(RETRY_SLEEP_SECONDS)
+                    time.sleep(args.retry_sleep)
+                else:
+                    result = "FAIL"
+                    returncode |= rc
 
             results.append(result_fmt % (result, target))
 
@@ -109,7 +102,27 @@ _parser = _group_downloader.create_parser(
         'download-extensions',
         func=_group_downloader.call,
         help='Download compiled extension modules',
-        add_help=False,
+        add_help=True,
         description='This downloads all registered (compiled) extension modules',
     )
+)
+
+_parser.add_argument(
+    '-r',
+    '--retry',
+    action='store',
+    type=int,
+    dest='retry',
+    default=1,
+    help="Number of times to attempt each download",
+)
+
+_parser.add_argument(
+    '-s',
+    '--retry-sleep',
+    action='store',
+    type=int,
+    dest='retry_sleep',
+    default=15,
+    help="Seconds to sleep before retrying the download",
 )

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -31,6 +31,8 @@ class GroupDownloader:
             logger.setLevel(original_level)
 
     def _call_impl(self, args, unparsed, logger):
+        if args.retry < 1:
+            raise ValueError("--retry must be >= 1")
         results = []
         result_fmt = "[%s]  %s"
 
@@ -123,7 +125,7 @@ _parser.add_argument(
     type=int,
     dest='retry',
     default=1,
-    help="Number of times to attempt each download",
+    help="Total number of attempts for each download (must be >= 1)",
 )
 
 _parser.add_argument(

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -55,7 +55,7 @@ class GroupDownloader:
                         # skipped download and move on.
                         result = "SKIP"
                     else:
-                        # If the extension has a __cell__(), then call
+                        # If the extension has a __call__(), then call
                         # it.  Otherwise, assume all went well (e.g.,
                         # the registered extension was actually a
                         # function not a type -- and it was called when

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -6,15 +6,41 @@
 # Solutions of Sandia, LLC, the U.S. Government retains certain rights in this
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
-#
+
+import logging
 import re
+import sys
 import pyomo.common.unittest as unittest
+from pyomo.common.download import DownloadFactory
 from pyomo.common.tee import capture_output
 from pyomo.common.log import LoggingIntercept
 
 from pyomo.environ import SolverFactory
 from pyomo.scripting.driver_help import help_solvers, help_transformations
 from pyomo.scripting.pyomo_main import main
+
+
+class skipper:
+    def __init__(self, downloader):
+        pass
+
+    def __call__(self):
+        pass
+
+    def skip(self):
+        return True
+
+
+def ok(downloader):
+    pass
+
+
+def raise_exception(downloader):
+    raise RuntimeError("downloader raised RuntimeError")
+
+
+def raise_exit(downloader):
+    sys.exit(1)
 
 
 def _mock_kestrel(solvers, err=None):
@@ -125,6 +151,41 @@ class Test(unittest.TestCase):
         self.assertTrue(re.search('core.relax_integer_vars', OUT))
         # test a transformation that we know is deprecated
         self.assertTrue(re.search(r'duality.linear_dual\s+\[DEPRECATED\]', OUT))
+
+    def test_downloader(self):
+        _orig = DownloadFactory._cls
+        DownloadFactory._cls = {
+            'skipper': skipper,
+            'raise exception': raise_exception,
+            'ok': ok,
+            'raise exit': raise_exit,
+        }
+        try:
+            with (
+                capture_output() as OUT,
+                LoggingIntercept(module='pyomo', level=logging.INFO) as LOG,
+            ):
+                main(args=['download-extensions'])
+        finally:
+            DownloadFactory._cls = _orig
+
+        self.assertEqual("", OUT.getvalue())
+        self.assertEqual(
+            """\
+As of February 9, 2023, AMPL GSL can no longer be downloaded through \
+download-extensions. Visit https://portal.ampl.com/ to download the \
+AMPL GSL binaries.
+RuntimeError: downloader raised RuntimeError
+SystemExit: 1
+Finished downloading Pyomo extensions.
+The following extensions were downloaded:
+    [SKIP]  skipper
+    [FAIL]  raise exception
+    [ OK ]  ok
+    [FAIL]  raise exit
+""",
+            LOG.getvalue(),
+        )
 
 
 if __name__ == "__main__":

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -154,18 +154,19 @@ class Test(unittest.TestCase):
 
     def test_downloader(self):
         _orig = DownloadFactory._cls
-        DownloadFactory._cls = {
+        testers = {
             'skipper': skipper,
             'raise exception': raise_exception,
             'ok': ok,
             'raise exit': raise_exit,
         }
         try:
+            DownloadFactory._cls = testers
             with (
                 capture_output() as OUT,
                 LoggingIntercept(module='pyomo', level=logging.INFO) as LOG,
             ):
-                main(args=['download-extensions'])
+                self.assertEqual(3, main(args=['download-extensions']))
         finally:
             DownloadFactory._cls = _orig
 
@@ -176,6 +177,49 @@ As of February 9, 2023, AMPL GSL can no longer be downloaded through \
 download-extensions. Visit https://portal.ampl.com/ to download the \
 AMPL GSL binaries.
 RuntimeError: downloader raised RuntimeError
+SystemExit: 1
+Finished downloading Pyomo extensions.
+The following extensions were downloaded:
+    [SKIP]  skipper
+    [FAIL]  raise exception
+    [ OK ]  ok
+    [FAIL]  raise exit
+""",
+            LOG.getvalue(),
+        )
+
+        try:
+            DownloadFactory._cls = testers
+            with (
+                capture_output() as OUT,
+                LoggingIntercept(module='pyomo', level=logging.INFO) as LOG,
+            ):
+                self.assertEqual(
+                    3,
+                    main(
+                        args=[
+                            'download-extensions',
+                            '--retry',
+                            '2',
+                            '--retry-sleep',
+                            '0',
+                        ]
+                    ),
+                )
+        finally:
+            DownloadFactory._cls = _orig
+
+        self.assertEqual("", OUT.getvalue())
+        self.assertEqual(
+            """\
+As of February 9, 2023, AMPL GSL can no longer be downloaded through \
+download-extensions. Visit https://portal.ampl.com/ to download the \
+AMPL GSL binaries.
+RuntimeError: downloader raised RuntimeError
+Retrying download of 'raise exception' (attempt 2 of 2) in 0 seconds
+RuntimeError: downloader raised RuntimeError
+SystemExit: 1
+Retrying download of 'raise exit' (attempt 2 of 2) in 0 seconds
 SystemExit: 1
 Finished downloading Pyomo extensions.
 The following extensions were downloaded:

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -160,6 +160,21 @@ class Test(unittest.TestCase):
             'ok': ok,
             'raise exit': raise_exit,
         }
+
+        try:
+            DownloadFactory._cls = testers
+            with (
+                capture_output() as OUT,
+                LoggingIntercept(module='pyomo', level=logging.INFO) as LOG,
+            ):
+                with self.assertRaisesRegex(ValueError, r"--retry must be >= 1"):
+                    main(args=['download-extensions', '--retry', '0'])
+        finally:
+            DownloadFactory._cls = _orig
+
+        self.assertEqual("", OUT.getvalue())
+        self.assertEqual("", LOG.getvalue())
+
         try:
             DownloadFactory._cls = testers
             with (

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -310,10 +310,11 @@ class TestXpressPersistent(unittest.TestCase):
         m.x2 = pyo.Var()
         m.x3 = pyo.Var()
 
-        m.obj = pyo.Objective(rule=lambda m: 2 * m.x1 + m.x2 + m.x3, sense=pyo.minimize)
-        m.equ1 = pyo.Constraint(rule=lambda m: m.x1 + m.x2 + m.x3 == 1)
-        m.cone = pyo.Constraint(rule=lambda m: m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
-        m.equ2 = pyo.Constraint(rule=lambda m: m.x1 >= 0)
+        m.obj = pyo.Objective(expr=2 * m.x1 + m.x2 + m.x3, sense=pyo.minimize)
+        m.equ1 = pyo.Constraint(expr=m.x1 + m.x2 + m.x3 == 1)
+        m.nl = pyo.Constraint(expr=m.x1 * m.x2 <= m.x2 * m.x3)
+        m.cone = pyo.Constraint(expr=m.x2 * m.x2 + m.x3 * m.x3 <= m.x1 * m.x1)
+        m.equ2 = pyo.Constraint(expr=m.x1 >= 0)
 
         opt = pyo.SolverFactory('xpress_direct')
         opt.options['XSLP_SOLVER'] = 0


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This updates the GHA TPL caches.  Sort of.  We are updating GAMS to the almost-current version (52.5) because the current version (53.1) causes segfaults (at least under pytest).  The updated versions led to some test errors that this PR also resolves:
- Rework the BARON license test to rely on the LST ("times") file and not parsing the log (in the most recent BARON version the log message changed).
   - This also takes the opportunity to significantly simplify the logic around parsing and caching the BARON version / licensing information.
   - This also adds some "defensive" exceptions to catch incomplete results parsing if the Baron API ever expands/
- Update Xpress "locally optimal" test so Xpress doesn't recognize it as a conic problem it "knows how to solve"
- Update GAMS on GHA:
  - Stop installing gams distribution on OSX (self-extracting zip is no longer distributed, and I couldn't see how to (easily) install the package on GHA.
  - Update the gams Python installation for recent package layout
  - Add fallback on gamspy from PyPI if we either don't recognize the layout or didn't install the package

While working on things, some other things were cleaned up:
- Rework/simplify the `download-extensions` command
  - simplify (and document!) function control flow.
  - move retry parameters from module constants to command-line arguments.
- GHA drivers
  - standardize on use of the `curlrc` for passing standard options to curl
  - remove creation of local variables that led to obfuscation of the driver logic
  - update `test-branches` python versions to get better coverage without adding tests
- cplex: IBMDecisionOptimization released new versions of cplex and docplex that are both a bit buggy
  - cplex 22.1.2.1 errors when computing the IIS on Python 3.13 & 3.14.  It looks like the file they write to is getting closed/corrupted before the routine exits.  Either way, it results in some (fatal) error is coming out of the compiled library.  I don't see how to fix or workaround, so we are just going to ignore that release.
  - docplex 2.32.257 is missing required dependencies for Python<=3.12.  This highlighted that our tests for whether docplex is available were fragile / incomplete.  This PR updates those tests to be more robust.
- Quit attempting to verify links to SourceForge: it appears that SF is categorically rejecting connections from GHA.

NOTE: the intent is to let this PR build and generate the new caches, then we will update the PR to *unpin* GAMS (but not trigger the caches to be rebuilt).

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
