### PR TITLE
MPC Load Data Ignore Expressions

### DIFF
--- a/pyomo/contrib/mpc/data/interpolation.py
+++ b/pyomo/contrib/mpc/data/interpolation.py
@@ -71,7 +71,10 @@ def _get_interp_expr_vec(time_set, time_data, data, indexes=None):
     expr = [None] * len(time_set)
     for i, (h, t) in enumerate(zip(indexes, time_set)):
         l = h - 1
-        expr[i] = data[l] + (data[h] - data[l]) / (time_data[h] - time_data[l]) * (
-            t - time_data[l]
-        )
+        if data[l] is None or data[h] is None:
+            expr[i] = None
+        else:
+            expr[i] = data[l] + (data[h] - data[l]) / (time_data[h] - time_data[l]) * (
+                t - time_data[l]
+            )
     return expr

--- a/pyomo/contrib/mpc/data/tests/test_series_data.py
+++ b/pyomo/contrib/mpc/data/tests/test_series_data.py
@@ -144,6 +144,20 @@ class TestSeriesData(unittest.TestCase):
             new_data,
         )
 
+    def test_get_data_interpolate_none(self):
+        m = self._make_model()
+        data_dict = {m.var[:, "A"]: [1, 2, 3], m.var[:, "B"]: [None, None, None]}
+        data = TimeSeriesData(data_dict, m.time)
+
+        new_t = [0.05, 0.15]
+        new_data = data.get_interpolated_data(new_t)
+        self.assertEqual(
+            TimeSeriesData(
+                {m.var[:, "A"]: [1.5, 2.5], m.var[:, "B"]: [None, None]}, new_t
+            ),
+            new_data,
+        )
+
     def test_get_data_interpolate_range_check(self):
         m = self._make_model()
         data_dict = {m.var[:, "A"]: [1, 2, 3], m.var[:, "B"]: [2, 4, 6]}

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -81,9 +81,9 @@ def load_data_from_series(
         var = model.find_component(cuid)
         if var is None:
             _raise_invalid_cuid(cuid, model)
-        elif var.ctype == Expression and ignore_named_expressions:
-            continue
         elif var.ctype == Expression:
+            if ignore_named_expressions:
+                continue
             raise TypeError("Cannot load data for named Expression")
         for idx, val in zip(time_indices, vals):
             t = time_list[idx]

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -36,9 +36,9 @@ def load_data_from_scalar(data, model, time, ignore_named_expressions=False):
         var = model.find_component(cuid)
         if var is None:
             _raise_invalid_cuid(cuid, model)
-        elif var.ctype == Expression and ignore_named_expressions:
-            continue
         elif var.ctype == Expression:
+            if ignore_named_expressions:
+                continue
             raise TypeError("Cannot load data for named Expression")
         # TODO: Time points should probably use find_nearest_index
         # This will have to happen in the calling function, as data

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -184,9 +184,9 @@ def load_data_from_interval(
         var = model.find_component(cuid)
         if var is None:
             _raise_invalid_cuid(cuid, model)
-        elif var.ctype == Expression and ignore_named_expressions:
-            continue
         elif var.ctype == Expression:
+            if ignore_named_expressions:
+                continue
             raise TypeError("Cannot load data for named Expression")
         for i, t in zip(idx_list, time):
             if i is None:

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -7,7 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
-from pyomo.environ import Expression
+from pyomo.core.base import Expression
 from pyomo.contrib.mpc.data.dynamic_data_base import _is_iterable
 from pyomo.contrib.mpc.data.find_nearest_index import (
     find_nearest_index,

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -19,7 +19,7 @@ def _raise_invalid_cuid(cuid, model):
     raise RuntimeError("Cannot find a component %s on block %s" % (cuid, model))
 
 
-def load_data_from_scalar(data, model, time):
+def load_data_from_scalar(data, model, time, ignore_named_expressions=False):
     """A function to load ScalarData into a model
 
     Arguments
@@ -27,16 +27,19 @@ def load_data_from_scalar(data, model, time):
     data: ~scalar_data.ScalarData
     model: BlockData
     time: Iterable
+    ignore_named_expressions: Bool
 
     """
     data = data.get_data()
     t_iter = time if _is_iterable(time) else (time,)
     for cuid, val in data.items():
         var = model.find_component(cuid)
-        if var.ctype == Expression:
-            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
+        elif var.ctype == Expression and ignore_named_expressions:
+            continue
+        elif var.ctype == Expression:
+            raise TypeError("Cannot load data for named Expression")
         # TODO: Time points should probably use find_nearest_index
         # This will have to happen in the calling function, as data
         # doesn't have a list of time points to check.
@@ -47,7 +50,13 @@ def load_data_from_scalar(data, model, time):
             var.set_value(val)
 
 
-def load_data_from_series(data, model, time, tolerance=0.0):
+def load_data_from_series(
+    data, 
+    model, 
+    time, 
+    tolerance=0.0, 
+    ignore_named_expressions=False,
+):
     """A function to load TimeSeriesData into a model
 
     Arguments
@@ -55,6 +64,7 @@ def load_data_from_series(data, model, time, tolerance=0.0):
     data: TimeSeriesData
     model: BlockData
     time: Iterable
+    ignore_named_expressions: Bool
 
     """
     time_list = list(time)
@@ -73,10 +83,12 @@ def load_data_from_series(data, model, time, tolerance=0.0):
     data = data.get_data()
     for cuid, vals in data.items():
         var = model.find_component(cuid)
-        if var.ctype == Expression:
-            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
+        elif var.ctype == Expression and ignore_named_expressions:
+            continue
+        elif var.ctype == Expression:
+            raise TypeError("Cannot load data for named Expression")
         for idx, val in zip(time_indices, vals):
             t = time_list[idx]
             var[t].set_value(val)
@@ -90,6 +102,7 @@ def load_data_from_interval(
     prefer_left=True,
     exclude_left_endpoint=True,
     exclude_right_endpoint=False,
+    ignore_named_expressions=False,
 ):
     """A function to load IntervalData into a model
 
@@ -109,6 +122,7 @@ def load_data_from_interval(
     prefer_left: Bool
     exclude_left_endpoint: Bool
     exclude_right_endpoint: Bool
+    ignore_named_expressions: Bool
 
     """
     if prefer_left and exclude_right_endpoint and not exclude_left_endpoint:
@@ -172,10 +186,12 @@ def load_data_from_interval(
     data = data.get_data()
     for cuid, vals in data.items():
         var = model.find_component(cuid)
-        if var.ctype == Expression:
-            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
+        elif var.ctype == Expression and ignore_named_expressions:
+            continue
+        elif var.ctype == Expression:
+            raise TypeError("Cannot load data for named Expression")
         for i, t in zip(idx_list, time):
             if i is None:
                 # t could not be found in an interval. This is fine.

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -7,6 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
+from pyomo.environ import Expression
 from pyomo.contrib.mpc.data.dynamic_data_base import _is_iterable
 from pyomo.contrib.mpc.data.find_nearest_index import (
     find_nearest_index,
@@ -32,6 +33,8 @@ def load_data_from_scalar(data, model, time):
     t_iter = time if _is_iterable(time) else (time,)
     for cuid, val in data.items():
         var = model.find_component(cuid)
+        if var.ctype == Expression:
+            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
         # TODO: Time points should probably use find_nearest_index
@@ -70,6 +73,8 @@ def load_data_from_series(data, model, time, tolerance=0.0):
     data = data.get_data()
     for cuid, vals in data.items():
         var = model.find_component(cuid)
+        if var.ctype == Expression:
+            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
         for idx, val in zip(time_indices, vals):
@@ -167,6 +172,8 @@ def load_data_from_interval(
     data = data.get_data()
     for cuid, vals in data.items():
         var = model.find_component(cuid)
+        if var.ctype == Expression:
+            continue
         if var is None:
             _raise_invalid_cuid(cuid, model)
         for i, t in zip(idx_list, time):

--- a/pyomo/contrib/mpc/interfaces/load_data.py
+++ b/pyomo/contrib/mpc/interfaces/load_data.py
@@ -51,11 +51,7 @@ def load_data_from_scalar(data, model, time, ignore_named_expressions=False):
 
 
 def load_data_from_series(
-    data, 
-    model, 
-    time, 
-    tolerance=0.0, 
-    ignore_named_expressions=False,
+    data, model, time, tolerance=0.0, ignore_named_expressions=False
 ):
     """A function to load TimeSeriesData into a model
 

--- a/pyomo/contrib/mpc/interfaces/model_interface.py
+++ b/pyomo/contrib/mpc/interfaces/model_interface.py
@@ -170,6 +170,7 @@ class DynamicModelInterface:
         prefer_left=None,
         exclude_left_endpoint=None,
         exclude_right_endpoint=None,
+        ignore_named_expressions=False,
     ):
         """Method to load data into the model.
 
@@ -189,6 +190,10 @@ class DynamicModelInterface:
         time_points: Iterable (optional)
             Subset of time points into which data should be loaded.
             Default of None corresponds to loading into all time points.
+
+        ignore_named_expressions: (optional)
+            ignore data for named expressions, otherwise a TypeError will
+            be raise on encountering a named expression.
 
         """
         if time_points is None:
@@ -211,10 +216,21 @@ class DynamicModelInterface:
             # This covers the case of non-time-indexed variables
             # as keys.
             _error_if_used(prefer_left, excl_left, excl_right, type(data))
-            load_data_from_scalar(data, self.model, time_points)
+            load_data_from_scalar(
+                data,
+                self.model,
+                time_points,
+                ignore_named_expressions=ignore_named_expressions,
+            )
         elif isinstance(data, TimeSeriesData):
             _error_if_used(prefer_left, excl_left, excl_right, type(data))
-            load_data_from_series(data, self.model, time_points, tolerance=tolerance)
+            load_data_from_series(
+                data,
+                self.model,
+                time_points,
+                tolerance=tolerance,
+                ignore_named_expressions=ignore_named_expressions,
+            )
         elif isinstance(data, IntervalData):
             prefer_left = True if prefer_left is None else prefer_left
             excl_left = prefer_left if excl_left is None else excl_left
@@ -227,6 +243,7 @@ class DynamicModelInterface:
                 prefer_left=prefer_left,
                 exclude_left_endpoint=excl_left,
                 exclude_right_endpoint=excl_right,
+                ignore_named_expressions=ignore_named_expressions,
             )
 
     def copy_values_at_time(self, source_time=None, target_time=None):

--- a/pyomo/contrib/mpc/interfaces/tests/test_interface.py
+++ b/pyomo/contrib/mpc/interfaces/tests/test_interface.py
@@ -138,9 +138,11 @@ class TestDynamicModelInterface(unittest.TestCase):
             pyo.ComponentUID(m.scalar): 6.0,
             pyo.ComponentUID(m.scalar_squared): 6.0,
         }
-        interface.load_data(data)
+        interface.load_data(data, ignore_named_expressions=True)
         self.assertEqual(m.scalar.value, 6.0)
         self.assertEqual(pyo.value(m.scalar_squared), 36.0)
+        with self.assertRaises(TypeError):
+            interface.load_data(data)
 
     def test_load_data_at_time_all(self):
         # NOTE: load_data_at_time has been deprecated
@@ -218,11 +220,13 @@ class TestDynamicModelInterface(unittest.TestCase):
         }
         # Need to provide data to load_data that can be interpreted
         # as a TimeSeriesData
-        interface.load_data((data, m.time))
+        interface.load_data((data, m.time), ignore_named_expressions=True)
         for i, t in enumerate(m.time):
             self.assertEqual(m.input[t].value, data_list[i])
         for i in m.var.index_set():
             self.assertEqual(pyo.value(m.var_squared[i]), pyo.value(m.var[i] ** 2))
+        with self.assertRaises(TypeError):
+            interface.load_data((data, m.time))
 
     def test_load_data_from_ScalarData_to_point(self):
         m = self._make_model()

--- a/pyomo/contrib/mpc/interfaces/tests/test_interface.py
+++ b/pyomo/contrib/mpc/interfaces/tests/test_interface.py
@@ -29,6 +29,7 @@ class TestDynamicModelInterface(unittest.TestCase):
         )
         m.input = pyo.Var(m.time, initialize={i: 1.0 - i * 0.1 for i in m.time})
         m.scalar = pyo.Var(initialize=0.5)
+        m.scalar_squared = pyo.Expression(expr=m.scalar**2)
         m.var_squared = pyo.Expression(
             m.time,
             m.comp,
@@ -128,6 +129,19 @@ class TestDynamicModelInterface(unittest.TestCase):
         interface.load_data(data)
         self.assertEqual(m.scalar.value, 6.0)
 
+    def test_load_scalar_data_expr(self):
+        # load_scalar_data has been removed. Instead we simply call
+        # load_data
+        m = self._make_model()
+        interface = DynamicModelInterface(m, m.time)
+        data = {
+            pyo.ComponentUID(m.scalar): 6.0,
+            pyo.ComponentUID(m.scalar_squared): 6.0,
+        }
+        interface.load_data(data)
+        self.assertEqual(m.scalar.value, 6.0)
+        self.assertEqual(pyo.value(m.scalar_squared), 36.0)
+
     def test_load_data_at_time_all(self):
         # NOTE: load_data_at_time has been deprecated
         m = self._make_model()
@@ -193,6 +207,22 @@ class TestDynamicModelInterface(unittest.TestCase):
         interface.load_data((data, m.time))
         for i, t in enumerate(m.time):
             self.assertEqual(m.input[t].value, data_list[i])
+
+    def test_load_data_from_dict_indexed_var_list_data_expr(self):
+        m = self._make_model()
+        interface = DynamicModelInterface(m, m.time)
+        data_list = [2, 3, 4]
+        data = {
+            pyo.ComponentUID(m.input): data_list,
+            pyo.ComponentUID(m.var_squared): data_list,
+        }
+        # Need to provide data to load_data that can be interpreted
+        # as a TimeSeriesData
+        interface.load_data((data, m.time))
+        for i, t in enumerate(m.time):
+            self.assertEqual(m.input[t].value, data_list[i])
+        for i in m.var.index_set():
+            self.assertEqual(pyo.value(m.var_squared[i]), pyo.value(m.var[i] ** 2))
 
     def test_load_data_from_ScalarData_to_point(self):
         m = self._make_model()


### PR DESCRIPTION
## Fixes None

## Summary/Motivation:
When loading MPC data into a model, if a data key is an ``Expression``, the model will get messed up because the expression will be replaced.  This PR makes loading MPC data into a model ignore expressions.

## Changes proposed in this PR:
- Ignore expressions when loading MPC data into a model
- When interpolating MPC data if a data point is None make the interpolated value None

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
