### PR TITLE
Add SetOf domain; improve config's mock yaml dumper

### DIFF
--- a/doc/OnlineDocs/explanation/experimental/solvers.rst
+++ b/doc/OnlineDocs/explanation/experimental/solvers.rst
@@ -264,9 +264,9 @@ solver's ``writer_config`` configuration option (see the
    file_determinism: FileDeterminism.ORDERED
    symbolic_solver_labels: false
    scale_model: true
-   export_nonlinear_variables: None
-   row_order: None
-   column_order: None
+   export_nonlinear_variables: null
+   row_order: null
+   column_order: null
    export_defined_variables: true
    linear_presolve: true
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -753,6 +753,8 @@ def _get_dump():
         # dump = lambda x,**y: str(x)
         # YAML uses lowercase True/False
         def dump(x, **args):
+            if x is None:
+                return "null"
             if type(x) is bool:
                 return str(x).lower()
             if type(x) is type:

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -376,50 +376,74 @@ class IsInstance:
         return f"IsInstance[{', '.join(class_names)}]"
 
 
-class ListOf:
-    """Domain validator for lists of a specified type
+class _Container:
+    """Domain validator for containers of a specified type
+
+    Incoming values are converted using the ``domain`` callable (if not
+    set / ``None``, then the ``itemtype`` is used as the ``domain``).
+    If the incoming value is iterable and *not* an instance of
+    ``itemtype``, then the incoming value is iterated over to generate
+    individual entries in the container.
 
     Parameters
     ----------
     itemtype: type
-        The type for each element in the list
+        The type for each element in the container
 
     domain: Callable
         A domain validator (callable that takes the incoming value,
         validates it, and returns the appropriate domain type) for each
-        element in the list.  If not specified, defaults to the
-        `itemtype`.
+        element in the container.  If not specified, defaults to the
+        ``itemtype``.
 
     string_lexer: Callable
         A preprocessor (lexer) called for all string values.  If
-        NOTSET, then strings are split on whitespace and/or commas
+        ``NOTSET``, then strings are split on whitespace and/or commas
         (honoring simple use of single or double quotes).  If None, then
         no tokenization is performed.
 
     """
 
-    def __init__(self, itemtype, domain=None, string_lexer=NOTSET):
+    def __init__(self, itemtype=None, domain=None, string_lexer=NOTSET):
         self.itemtype = itemtype
         if domain is None:
-            self.domain = self.itemtype
-        else:
-            self.domain = domain
+            domain = self.itemtype
         if string_lexer is NOTSET:
-            self.string_lexer = _default_string_list_lexer
-        else:
-            self.string_lexer = string_lexer
-        self.__name__ = 'ListOf(%s)' % (getattr(self.domain, '__name__', self.domain),)
+            string_lexer = _default_string_list_lexer
+
+        if domain is None:
+            raise ValueError(
+                f"{self.__class__.__name__}: either itemtype or domain must be non-None"
+            )
+        self.domain = domain
+        self.string_lexer = string_lexer
+        self.__name__ = '%s(%s)' % (
+            self.__class__.__name__,
+            getattr(self.domain, '__name__', self.domain),
+        )
 
     def __call__(self, value):
         if isinstance(value, str) and self.string_lexer is not None:
-            return [self.domain(v) for v in self.string_lexer(value)]
-        if hasattr(value, '__iter__') and not isinstance(value, self.itemtype):
-            return [self.domain(v) for v in value]
-        return [self.domain(value)]
+            return self.ReturnType(self.domain(v) for v in self.string_lexer(value))
+        if hasattr(value, '__iter__') and (
+            self.itemtype is None or not isinstance(value, self.itemtype)
+        ):
+            return self.ReturnType(self.domain(v) for v in value)
+        return self.ReturnType([self.domain(value)])
 
     def domain_name(self):
         _dn = _domain_name(self.domain) or ""
-        return f'ListOf[{_dn}]'
+        return f'{self.__class__.__name__}[{_dn}]'
+
+
+class ListOf(_Container):
+    __doc__ = _Container.__doc__.replace('container', 'list')
+    ReturnType = list
+
+
+class SetOf(_Container):
+    __doc__ = _Container.__doc__.replace('container', 'set')
+    ReturnType = set
 
 
 class Module:

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -724,10 +724,7 @@ class ConfigEnum(enum.Enum):
             return cls(arg)
 
 
-def _dump(*args, **kwds):
-    # TODO: Change the default behavior to no longer be YAML.
-    # This was a legacy decision that may no longer be the best
-    # decision, given changes to technology over the years.
+def _get_dump():
     try:
         from yaml import safe_dump as dump
     except ImportError:
@@ -737,7 +734,7 @@ def _dump(*args, **kwds):
             if type(x) is bool:
                 return str(x).lower()
             if type(x) is type:
-                return str(type(x))
+                return str(x)
             if isinstance(x, str):
                 # If the str is a number, then we need to quote it.
                 try:
@@ -747,8 +744,15 @@ def _dump(*args, **kwds):
                     return str(x)
             return str(x)
 
+    return dump
+
+
+def _dump(*args, **kwds):
+    # TODO: Change the default behavior to no longer be YAML.
+    # This was a legacy decision that may no longer be the best
+    # decision, given changes to technology over the years.
     assert '_dump' in globals()
-    globals()['_dump'] = dump
+    globals()['_dump'] = _get_dump()
     return dump(*args, **kwds)
 
 
@@ -814,7 +818,7 @@ def _value2string(prefix, value, obj):
     if value is not None:
         try:
             data = value.value(False) if value is obj else value
-            if getattr(builtins, data.__class__.__name__, None) is not None:
+            if data.__class__.__module__ == 'builtins':
                 _str += _dump(
                     data, default_flow_style=True, allow_unicode=True
                 ).rstrip()
@@ -823,7 +827,7 @@ def _value2string(prefix, value, obj):
             else:
                 _str += str(data)
         except:
-            _str += str(type(data))
+            _str += str(data)
     return _str.rstrip()
 
 
@@ -836,7 +840,7 @@ def _value2yaml(prefix, value, obj):
             if _str.endswith("..."):
                 _str = _str[:-3].rstrip()
         except:
-            _str += str(type(data))
+            _str += str(data)
     return _str.rstrip()
 
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -442,7 +442,29 @@ class ListOf(_Container):
 
 
 class SetOf(_Container):
-    __doc__ = _Container.__doc__.replace('container', 'set')
+    __doc__ = _Container.__doc__.replace('container', 'set').replace(
+        "\n    Parameters",
+        """
+    Note that :py:class:`SetOf` can be used (in conjunction with
+    :py:class:`In`) to implement a "SubsetOf" domain.  For example, you
+    can define a domain validator that admits values that are
+    convertable to :py:`int` as long as they are in the set ``{1, 3, 5}``
+    with:
+
+    ..doctest::
+
+        >>> d = SetOf(domain=In({1, 3, 5}, int))
+        >>> d([1, 5.2, 1])
+        {1, 5}
+        >>> d([1, 5, 2])
+        Traceback (most recent call last):
+          ...
+        ValueError: value 2 not in domain {1, 3, 5}
+
+    Parameters
+    """,
+    )
+
     ReturnType = set
 
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -448,7 +448,7 @@ class SetOf(_Container):
     Note that :py:class:`SetOf` can be used (in conjunction with
     :py:class:`In`) to implement a "SubsetOf" domain.  For example, you
     can define a domain validator that admits values that are
-    convertable to :py:`int` as long as they are in the set ``{1, 3, 5}``
+    convertible to :py:`int` as long as they are in the set ``{1, 3, 5}``
     with:
 
     ..doctest::

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -61,6 +61,7 @@ from pyomo.common.config import (
     In,
     IsInstance,
     ListOf,
+    SetOf,
     Module,
     Path,
     PathList,
@@ -788,6 +789,11 @@ class TestConfigDomains(unittest.TestCase):
             c.a = ["/a/b/c", 2]
 
     def test_ListOf(self):
+        with self.assertRaisesRegex(
+            ValueError, "ListOf: either itemtype or domain must be non-None"
+        ):
+            ListOf()
+
         c = ConfigDict()
         c.declare('a', ConfigValue(domain=ListOf(int), default=None))
         self.assertEqual(c.get('a').domain_name(), 'ListOf[int]')
@@ -849,6 +855,72 @@ class TestConfigDomains(unittest.TestCase):
             c.c = [0]
         c.c = [3, 6, 9]
         self.assertEqual(c.c, [3, 6, 9])
+
+    def test_SetOf(self):
+        with self.assertRaisesRegex(
+            ValueError, "SetOf: either itemtype or domain must be non-None"
+        ):
+            SetOf()
+
+        c = ConfigDict()
+        c.declare('a', ConfigValue(domain=SetOf(int), default=None))
+        self.assertEqual(c.get('a').domain_name(), 'SetOf[int]')
+
+        self.assertEqual(c.a, None)
+        c.a = 5
+        self.assertEqual(c.a, {5})
+        c.a = (5, 6.6)
+        self.assertEqual(c.a, {5, 6})
+        c.a = '7,8'
+        self.assertEqual(c.a, {7, 8})
+
+        ref = (
+            r"(?m)Failed casting a\s+to SetOf\(int\)\s+"
+            r"Error: invalid literal for int\(\) with base 10: 'a'"
+        )
+        with self.assertRaisesRegex(ValueError, ref):
+            c.a = 'a'
+
+        c.declare('b', ConfigValue(domain=SetOf(str), default=None))
+        self.assertEqual(c.get('b').domain_name(), 'SetOf[str]')
+        self.assertEqual(c.b, None)
+        c.b = "'Hello, World'"
+        self.assertEqual(c.b, {"Hello, World"})
+        c.b = "Hello, World"
+        self.assertEqual(c.b, {"Hello", "World"})
+        c.b = ("A", 6)
+        self.assertEqual(c.b, {"A", "6"})
+        with self.assertRaises(ValueError):
+            c.b = "'Hello, World"
+
+        c.declare('b1', ConfigValue(domain=SetOf(str, string_lexer=None), default=None))
+        self.assertEqual(c.get('b1').domain_name(), 'SetOf[str]')
+        self.assertEqual(c.b1, None)
+        c.b1 = "'Hello, World'"
+        self.assertEqual(c.b1, {"'Hello, World'"})
+        c.b1 = "Hello, World"
+        self.assertEqual(c.b1, {"Hello, World"})
+        c.b1 = ("A", 6)
+        self.assertEqual(c.b1, {"A", "6"})
+        c.b1 = "'Hello, World"
+        self.assertEqual(c.b1, {"'Hello, World"})
+
+        c.declare('c', ConfigValue(domain=SetOf(int, PositiveInt)))
+        self.assertEqual(c.get('c').domain_name(), 'SetOf[PositiveInt]')
+        self.assertEqual(c.c, None)
+        c.c = 6
+        self.assertEqual(c.c, {6})
+
+        ref = (
+            r"(?m)Failed casting %s\s+to SetOf\(PositiveInt\)\s+"
+            r"Error: Expected positive int, but received %s"
+        )
+        with self.assertRaisesRegex(ValueError, ref % (6.5, 6.5)):
+            c.c = 6.5
+        with self.assertRaisesRegex(ValueError, ref % (r"\[0\]", "0")):
+            c.c = [0]
+        c.c = [3, 6, 9]
+        self.assertEqual(c.c, {3, 6, 9})
 
     def test_Module(self):
         c = ConfigDict()

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3511,10 +3511,9 @@ option_2: int, default=5
         cfg = CustomConfig()
         OUT = StringIO()
         cfg.display(ostream=OUT)
-        # Note: pypy outputs "None" as "null"
         self.assertEqual(
-            "time_limit: None\nstream_solver: None\n",
-            OUT.getvalue().replace('null', 'None'),
+            "time_limit: null\nstream_solver: null\n",
+            OUT.getvalue(),
         )
 
         # Test that creating a copy of a ConfigDict with declared fields
@@ -3525,7 +3524,7 @@ option_2: int, default=5
         cfg2.display(ostream=OUT)
         self.assertEqual(
             "time_limit: 10.0\nstream_solver: false\n",
-            OUT.getvalue().replace('null', 'None'),
+            OUT.getvalue(),
         )
 
     def test_domain_name(self):
@@ -3907,8 +3906,8 @@ dict1:
         self.assertEqual(dkfc._ensure_blank_line("b\n"), "b\n\n")
 
     def test_value2str(self):
-        def d(val):
-            return _value2string("", val, NOTSET)
+        def d(val, obj=NOTSET):
+            return _value2string("", val, obj)
 
         self.assertEqual("", d(None))
         self.assertEqual("true", d(True))
@@ -3917,6 +3916,8 @@ dict1:
         self.assertEqual("1", d(1))
         self.assertEqual("a", d('a'))
         self.assertEqual("'1'", d('1'))
+        cv = ConfigValue(None)
+        self.assertEqual("null", d(cv, cv))
 
         orig = _config._dump, sys.modules['yaml']
         try:
@@ -3929,6 +3930,8 @@ dict1:
             self.assertEqual("1", d(1))
             self.assertEqual("a", d('a'))
             self.assertEqual("'1'", d('1'))
+            cv = ConfigValue(None)
+            self.assertEqual("null", d(cv, cv))
         finally:
             _config._dump, sys.modules['yaml'] = orig
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3913,7 +3913,7 @@ dict1:
         cv = ConfigValue(None)
         self.assertEqual("null", d(cv, cv))
 
-        orig = _config._dump, sys.modules['yaml']
+        orig = _config._dump, sys.modules.get('yaml', None)
         try:
             sys.modules['yaml'] = sys.modules[__name__]
             _config._dump = _config._get_dump()
@@ -3928,6 +3928,8 @@ dict1:
             self.assertEqual("null", d(cv, cv))
         finally:
             _config._dump, sys.modules['yaml'] = orig
+            if sys.modules['yaml'] is None:
+                del sys.modules['yaml']
 
 
 if __name__ == "__main__":

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3511,10 +3511,7 @@ option_2: int, default=5
         cfg = CustomConfig()
         OUT = StringIO()
         cfg.display(ostream=OUT)
-        self.assertEqual(
-            "time_limit: null\nstream_solver: null\n",
-            OUT.getvalue(),
-        )
+        self.assertEqual("time_limit: null\nstream_solver: null\n", OUT.getvalue())
 
         # Test that creating a copy of a ConfigDict with declared fields
         # in the __init__ does not result in duplicate outputs in the
@@ -3522,10 +3519,7 @@ option_2: int, default=5
         cfg2 = cfg({'time_limit': 10, 'stream_solver': 0})
         OUT = StringIO()
         cfg2.display(ostream=OUT)
-        self.assertEqual(
-            "time_limit: 10.0\nstream_solver: false\n",
-            OUT.getvalue(),
-        )
+        self.assertEqual("time_limit: 10.0\nstream_solver: false\n", OUT.getvalue())
 
     def test_domain_name(self):
         cfg = ConfigDict()

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -42,6 +42,7 @@ def yaml_load(arg):
     return yaml.load(arg, **yaml_load_args)
 
 
+import pyomo.common.config as _config
 from pyomo.common.config import (
     ConfigDict,
     ConfigValue,
@@ -77,8 +78,10 @@ from pyomo.common.config import (
     DEVELOPER_OPTION,
     _UnpickleableDomain,
     _picklable,
+    _value2string,
 )
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.modeling import NOTSET
 
 
 # Utility to redirect display() to a string
@@ -100,6 +103,14 @@ class GlobalClass:
     "test class for test_known_types"
 
     pass
+
+
+class NOOP:
+    def __getattr__(self, attr):
+        def noop(*args, **kwargs):
+            pass
+
+        return noop
 
 
 def ExampleConfig():
@@ -1575,16 +1586,11 @@ bar:
         )
 
     def test_display_nondata_type(self):
-        class NOOP:
-            def __getattr__(self, attr):
-                def noop(*args, **kwargs):
-                    pass
-
-                return noop
-
         cfg = ConfigDict()
         cfg.declare('callback', ConfigValue(default=NOOP))
-        self.assertEqual(_display(cfg), "callback: <class 'type'>\n")
+        self.assertEqual(
+            _display(cfg), "callback: <class 'pyomo.common.tests.test_config.NOOP'>\n"
+        )
 
     def test_display_userdata_declare_block(self):
         self.config.declare("foo", ConfigValue(0, int, None, None))
@@ -3151,17 +3157,11 @@ c: 1.0
         self.assertEqual(mod_copy._description, "new description")
         self.assertEqual(mod_copy._visibility, 0)
 
-    def test_template_nondata(self):
-        class NOOP:
-            def __getattr__(self, attr):
-                def noop(*args, **kwargs):
-                    pass
-
-                return noop
-
         cfg = ConfigDict()
         cfg.declare('callback', ConfigValue(default=NOOP, description="docstr"))
-        self._validateTemplate(cfg, "callback: <class 'type'>  # docstr\n")
+        self._validateTemplate(
+            cfg, "callback: <class 'pyomo.common.tests.test_config.NOOP'>  # docstr\n"
+        )
 
     def test_pickle(self):
         def anon_domain(domain):
@@ -3905,6 +3905,32 @@ dict1:
         self.assertEqual(dkfc._ensure_blank_line(""), "")
         self.assertEqual(dkfc._ensure_blank_line("a"), "a\n\n")
         self.assertEqual(dkfc._ensure_blank_line("b\n"), "b\n\n")
+
+    def test_value2str(self):
+        def d(val):
+            return _value2string("", val, NOTSET)
+
+        self.assertEqual("", d(None))
+        self.assertEqual("true", d(True))
+        self.assertEqual("<class 'int'>", d(int))
+        self.assertEqual("<class 'pyomo.common.config.ConfigDict'>", d(ConfigDict))
+        self.assertEqual("1", d(1))
+        self.assertEqual("a", d('a'))
+        self.assertEqual("'1'", d('1'))
+
+        orig = _config._dump, sys.modules['yaml']
+        try:
+            sys.modules['yaml'] = sys.modules[__name__]
+            _config._dump = _config._get_dump()
+            self.assertEqual("", d(None))
+            self.assertEqual("true", d(True))
+            self.assertEqual("<class 'int'>", d(int))
+            self.assertEqual("<class 'pyomo.common.config.ConfigDict'>", d(ConfigDict))
+            self.assertEqual("1", d(1))
+            self.assertEqual("a", d('a'))
+            self.assertEqual("'1'", d('1'))
+        finally:
+            _config._dump, sys.modules['yaml'] = orig
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

@dallan-keylogic requested that Pyomo's config system had a `SubsetOf` domain that paralleled the `ListOf` domain.  This PR refactors `ListOf` so that `SetOf` is a trivial extension.  `SubsetOf` can be easily acomplished using a combination of `SetOf` and `In` (and is documented in the SetOf docs).

While I was messing with config, I refactored the mock yaml dumper so that we could reliably test it (even on systems with yaml).  This included a subtle change to the dumper so that types are more intelligently dumped (that is, we will consistently dump the actual type and not "<class 'type'>"), and so that `None` is output in proper YAML (as `null`).

## Changes proposed in this PR:
- Add `SetOf`
- Refactor the mock yaml dumper to improve type output and support better testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
