### PR TITLE
Improved `ConstraintData.equality`, relational expression generation

### DIFF
--- a/examples/pyomobook/blocks-ch/blocks_gen.txt
+++ b/examples/pyomobook/blocks-ch/blocks_gen.txt
@@ -22,11 +22,11 @@
             2 Var Declarations
                 Power : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
-                      0 :     0 : 120.0 : 500.0 : False : False :  Reals
-                      1 :     0 : 145.0 : 500.0 : False : False :  Reals
-                      2 :     0 : 119.0 : 500.0 : False : False :  Reals
-                      3 :     0 :  42.0 : 500.0 : False : False :  Reals
-                      4 :     0 : 190.0 : 500.0 : False : False :  Reals
+                      0 :     0 : 120.0 :   500 : False : False :  Reals
+                      1 :     0 : 145.0 :   500 : False : False :  Reals
+                      2 :     0 : 119.0 :   500 : False : False :  Reals
+                      3 :     0 :  42.0 :   500 : False : False :  Reals
+                      4 :     0 : 190.0 :   500 : False : False :  Reals
                 UnitOn : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
                       0 :     0 :  None :     1 : False :  True : Binary
@@ -46,11 +46,11 @@
 
             1 Constraint Declarations
                 limit_ramp : Size=4, Index=TIME, Active=True
-                    Key : Lower : Body                                                    : Upper                       : Active
-                      1 : -50.0 : Generator[G_EAST].Power[1] - Generator[G_EAST].Power[0] : Generator[G_EAST].RampLimit :   True
-                      2 : -50.0 : Generator[G_EAST].Power[2] - Generator[G_EAST].Power[1] : Generator[G_EAST].RampLimit :   True
-                      3 : -50.0 : Generator[G_EAST].Power[3] - Generator[G_EAST].Power[2] : Generator[G_EAST].RampLimit :   True
-                      4 : -50.0 : Generator[G_EAST].Power[4] - Generator[G_EAST].Power[3] : Generator[G_EAST].RampLimit :   True
+                    Key : Lower : Body                                                    : Upper : Active
+                      1 : -50.0 : Generator[G_EAST].Power[1] - Generator[G_EAST].Power[0] :  50.0 :   True
+                      2 : -50.0 : Generator[G_EAST].Power[2] - Generator[G_EAST].Power[1] :  50.0 :   True
+                      3 : -50.0 : Generator[G_EAST].Power[3] - Generator[G_EAST].Power[2] :  50.0 :   True
+                      4 : -50.0 : Generator[G_EAST].Power[4] - Generator[G_EAST].Power[3] :  50.0 :   True
 
             7 Declarations: MaxPower RampLimit Power UnitOn limit_ramp CostCoef Cost
         Generator[G_MAIN] : Active=True
@@ -67,11 +67,11 @@
             2 Var Declarations
                 Power : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
-                      0 :     0 : 120.0 : 500.0 : False : False :  Reals
-                      1 :     0 : 145.0 : 500.0 : False : False :  Reals
-                      2 :     0 : 119.0 : 500.0 : False : False :  Reals
-                      3 :     0 :  42.0 : 500.0 : False : False :  Reals
-                      4 :     0 : 190.0 : 500.0 : False : False :  Reals
+                      0 :     0 : 120.0 :   500 : False : False :  Reals
+                      1 :     0 : 145.0 :   500 : False : False :  Reals
+                      2 :     0 : 119.0 :   500 : False : False :  Reals
+                      3 :     0 :  42.0 :   500 : False : False :  Reals
+                      4 :     0 : 190.0 :   500 : False : False :  Reals
                 UnitOn : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
                       0 :     0 :  None :     1 : False :  True : Binary
@@ -91,11 +91,11 @@
 
             1 Constraint Declarations
                 limit_ramp : Size=4, Index=TIME, Active=True
-                    Key : Lower : Body                                                    : Upper                       : Active
-                      1 : -50.0 : Generator[G_MAIN].Power[1] - Generator[G_MAIN].Power[0] : Generator[G_MAIN].RampLimit :   True
-                      2 : -50.0 : Generator[G_MAIN].Power[2] - Generator[G_MAIN].Power[1] : Generator[G_MAIN].RampLimit :   True
-                      3 : -50.0 : Generator[G_MAIN].Power[3] - Generator[G_MAIN].Power[2] : Generator[G_MAIN].RampLimit :   True
-                      4 : -50.0 : Generator[G_MAIN].Power[4] - Generator[G_MAIN].Power[3] : Generator[G_MAIN].RampLimit :   True
+                    Key : Lower : Body                                                    : Upper : Active
+                      1 : -50.0 : Generator[G_MAIN].Power[1] - Generator[G_MAIN].Power[0] :  50.0 :   True
+                      2 : -50.0 : Generator[G_MAIN].Power[2] - Generator[G_MAIN].Power[1] :  50.0 :   True
+                      3 : -50.0 : Generator[G_MAIN].Power[3] - Generator[G_MAIN].Power[2] :  50.0 :   True
+                      4 : -50.0 : Generator[G_MAIN].Power[4] - Generator[G_MAIN].Power[3] :  50.0 :   True
 
             7 Declarations: MaxPower RampLimit Power UnitOn limit_ramp CostCoef Cost
 
@@ -124,11 +124,11 @@
             2 Var Declarations
                 Power : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
-                      0 :     0 : 120.0 : 500.0 : False : False :  Reals
-                      1 :     0 : 145.0 : 500.0 : False : False :  Reals
-                      2 :     0 : 119.0 : 500.0 : False : False :  Reals
-                      3 :     0 :  42.0 : 500.0 : False : False :  Reals
-                      4 :     0 : 190.0 : 500.0 : False : False :  Reals
+                      0 :     0 : 120.0 :   500 : False : False :  Reals
+                      1 :     0 : 145.0 :   500 : False : False :  Reals
+                      2 :     0 : 119.0 :   500 : False : False :  Reals
+                      3 :     0 :  42.0 :   500 : False : False :  Reals
+                      4 :     0 : 190.0 :   500 : False : False :  Reals
                 UnitOn : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
                       0 :     0 :  None :     1 : False :  True : Binary
@@ -148,11 +148,11 @@
 
             1 Constraint Declarations
                 limit_ramp : Size=4, Index=TIME, Active=True
-                    Key : Lower : Body                                                    : Upper                       : Active
-                      1 : -50.0 : Generator[G_EAST].Power[1] - Generator[G_EAST].Power[0] : Generator[G_EAST].RampLimit :   True
-                      2 : -50.0 : Generator[G_EAST].Power[2] - Generator[G_EAST].Power[1] : Generator[G_EAST].RampLimit :   True
-                      3 : -50.0 : Generator[G_EAST].Power[3] - Generator[G_EAST].Power[2] : Generator[G_EAST].RampLimit :   True
-                      4 : -50.0 : Generator[G_EAST].Power[4] - Generator[G_EAST].Power[3] : Generator[G_EAST].RampLimit :   True
+                    Key : Lower : Body                                                    : Upper : Active
+                      1 : -50.0 : Generator[G_EAST].Power[1] - Generator[G_EAST].Power[0] :  50.0 :   True
+                      2 : -50.0 : Generator[G_EAST].Power[2] - Generator[G_EAST].Power[1] :  50.0 :   True
+                      3 : -50.0 : Generator[G_EAST].Power[3] - Generator[G_EAST].Power[2] :  50.0 :   True
+                      4 : -50.0 : Generator[G_EAST].Power[4] - Generator[G_EAST].Power[3] :  50.0 :   True
 
             7 Declarations: MaxPower RampLimit Power UnitOn limit_ramp CostCoef Cost
         Generator[G_MAIN] : Active=True
@@ -169,11 +169,11 @@
             2 Var Declarations
                 Power : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
-                      0 :     0 : 120.0 : 500.0 : False : False :  Reals
-                      1 :     0 : 145.0 : 500.0 : False : False :  Reals
-                      2 :     0 : 119.0 : 500.0 : False : False :  Reals
-                      3 :     0 :  42.0 : 500.0 : False : False :  Reals
-                      4 :     0 : 190.0 : 500.0 : False : False :  Reals
+                      0 :     0 : 120.0 :   500 : False : False :  Reals
+                      1 :     0 : 145.0 :   500 : False : False :  Reals
+                      2 :     0 : 119.0 :   500 : False : False :  Reals
+                      3 :     0 :  42.0 :   500 : False : False :  Reals
+                      4 :     0 : 190.0 :   500 : False : False :  Reals
                 UnitOn : Size=5, Index=TIME
                     Key : Lower : Value : Upper : Fixed : Stale : Domain
                       0 :     0 :  None :     1 : False :  True : Binary
@@ -193,11 +193,11 @@
 
             1 Constraint Declarations
                 limit_ramp : Size=4, Index=TIME, Active=True
-                    Key : Lower : Body                                                    : Upper                       : Active
-                      1 : -50.0 : Generator[G_MAIN].Power[1] - Generator[G_MAIN].Power[0] : Generator[G_MAIN].RampLimit :   True
-                      2 : -50.0 : Generator[G_MAIN].Power[2] - Generator[G_MAIN].Power[1] : Generator[G_MAIN].RampLimit :   True
-                      3 : -50.0 : Generator[G_MAIN].Power[3] - Generator[G_MAIN].Power[2] : Generator[G_MAIN].RampLimit :   True
-                      4 : -50.0 : Generator[G_MAIN].Power[4] - Generator[G_MAIN].Power[3] : Generator[G_MAIN].RampLimit :   True
+                    Key : Lower : Body                                                    : Upper : Active
+                      1 : -50.0 : Generator[G_MAIN].Power[1] - Generator[G_MAIN].Power[0] :  50.0 :   True
+                      2 : -50.0 : Generator[G_MAIN].Power[2] - Generator[G_MAIN].Power[1] :  50.0 :   True
+                      3 : -50.0 : Generator[G_MAIN].Power[3] - Generator[G_MAIN].Power[2] :  50.0 :   True
+                      4 : -50.0 : Generator[G_MAIN].Power[4] - Generator[G_MAIN].Power[3] :  50.0 :   True
 
             7 Declarations: MaxPower RampLimit Power UnitOn limit_ramp CostCoef Cost
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -355,10 +355,24 @@ class ConstraintData(ActiveComponentData):
         if expr.__class__ is EqualityExpression:
             return True
         elif expr.__class__ is RangedExpression:
-            # TODO: this is a very restrictive form of structural equality.
             lb = expr.arg(0)
-            if lb is not None and lb is expr.arg(2):
-                return True
+            if lb is not None:
+                # Note that checking native_types is sufficient:
+                # constant expressions should have already been
+                # simplified by the expression system.  If the user
+                # explicitly created relational expressions with
+                # constant arguments, then we assume they knew what they
+                # were doing.
+                if lb.__class__ in native_types:
+                    ub = expr.arg(2)
+                    if ub.__class__ in native_types:
+                        return lb == ub
+                else:
+                    # TBD: this is a very restrictive form of structural
+                    # equality.  In the future it might be "nice" to
+                    # look for mathematical equivalence - but that is
+                    # expensive and likely not worth the effort.
+                    return lb is expr.arg(2)
         return False
 
     @property

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -37,7 +37,10 @@ from pyomo.core.expr import (
     RangedExpression,
 )
 from pyomo.core.expr.expr_common import _type_check_exception_arg
-from pyomo.core.expr.relational_expr import TrivialRelationalExpression
+from pyomo.core.expr.relational_expr import (
+    TrivialRelationalExpression,
+    tuple_to_relational_expr,
+)
 from pyomo.core.expr.template_expr import templatize_constraint
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
@@ -415,61 +418,15 @@ class ConstraintData(ActiveComponentData):
                     "using '<=', '>=', or '=='." % (self.name,)
                 )
             self._expr = expr
-            return
 
         elif expr.__class__ is tuple:  # or expr_type is list:
-            for arg in expr:
-                if (
-                    arg is None
-                    or arg.__class__ in native_numeric_types
-                    or isinstance(arg, NumericValue)
-                ):
-                    continue
-                raise ValueError(
-                    "Constraint '%s' does not have a proper value. "
-                    "Constraint expressions expressed as tuples must "
-                    "contain native numeric types or Pyomo NumericValue "
-                    "objects. Tuple %s contained invalid type, %s"
-                    % (self.name, expr, type(arg).__name__)
-                )
-            if len(expr) == 2:
-                #
-                # Form equality expression
-                #
-                if expr[0] is None or expr[1] is None:
-                    raise ValueError(
-                        "Constraint '%s' does not have a proper value. "
-                        "Equality Constraints expressed as 2-tuples "
-                        "cannot contain None [received %s]" % (self.name, expr)
-                    )
-                self._expr = EqualityExpression(expr)
-                return
-            elif len(expr) == 3:
-                #
-                # Form (ranged) inequality expression
-                #
-                if expr[0] is None:
-                    self._expr = InequalityExpression(expr[1:], False)
-                elif expr[2] is None:
-                    self._expr = InequalityExpression(expr[:2], False)
-                else:
-                    self._expr = RangedExpression(expr, False)
-                return
-            else:
-                raise ValueError(
-                    "Constraint '%s' does not have a proper value. "
-                    "Found a tuple of length %d. Expecting a tuple of "
-                    "length 2 or 3:\n"
-                    "    Equality:   (left, right)\n"
-                    "    Inequality: (lower, expression, upper)"
-                    % (self.name, len(expr))
-                )
-        #
-        # Ignore an 'empty' constraint
-        #
-        if expr is Constraint.Skip:
+            self.set_value(tuple_to_relational_expr(expr))
+
+        elif expr is Constraint.Skip:
+            #
+            # Ignore (and remove) an 'empty' constraint
+            #
             del self.parent_component()[self.index()]
-            return
 
         elif expr is None:
             raise ValueError(_rule_returned_none_error % (self.name,))
@@ -492,14 +449,14 @@ class ConstraintData(ActiveComponentData):
             except AttributeError:
                 pass
 
-        raise ValueError(
-            "Constraint '%s' does not have a proper "
-            "value. Found %s '%s'\nExpecting a tuple or "
-            "relational expression. Examples:"
-            "\n   sum(model.costs) == model.income"
-            "\n   (0, model.price[item], 50)"
-            % (self.name, type(expr).__name__, str(expr))
-        )
+            raise ValueError(
+                "Constraint '%s' does not have a proper "
+                "value. Found %s '%s'\nExpecting a tuple or "
+                "relational expression. Examples:"
+                "\n   sum(model.costs) == model.income"
+                "\n   (0, model.price[item], 50)"
+                % (self.name, type(expr).__name__, str(expr))
+            )
 
     def lslack(self):
         """

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -365,14 +365,12 @@ def inequality(lower=None, body=None, upper=None, strict=False):
 
     .. note:: Pyomo does not support constructing
        :class:`RangedExpression` objects using Python's chained
-       comparison syntax (``lb <= body <= ub``).  Python relies on the
-       pairwise comparisons returning intermediates that are convertible
-       to ``bool``, which is incompatible with Pyomo's operator
-       overloading.  Instead, :class:`RangedExpression` objects should
-       be created using this function.
+       comparison syntax (``lb <= body <= ub``).
 
-    Edge cases
-    ----------
+       Python relies on the pairwise comparisons returning intermediates
+       that are convertible to :class:`bool`, which is incompatible with
+       Pyomo's operator overloading.  Instead, :class:`RangedExpression`
+       objects should be created using this function.
 
     :func:`inequality` allows for any (or all) of `lower`, `body`, and
     `upper` to be ``None``.  What gets returned from the function
@@ -405,32 +403,26 @@ def inequality(lower=None, body=None, upper=None, strict=False):
     All None
        If all arguments are ``None``, then ``None`` is returned
 
+
     Parameters
     ----------
+
     lower : int | float | NumericValue | None
         The expression for the lower bound
 
     body : int | float | NumericValue | None
         The expression for the body of a ranged constraint
 
-    lower : int | float | NumericValue | None
+    upper : int | float | NumericValue | None
         The expression for the upper bound
 
     strict : bool
-        If :const:`True`, construct strict inequalities (``<``);
-        otherwise use ``<=``.
+        If ``True``, construct strict inequalities (``<``); otherwise
+        use ``<=``.
 
     Returns
     -------
-    expr : RangedExpression | InequalityExpression | NumericValue | int | float | None
-
-        An expression.  The return value depends on the values of
-        ``lower``, ``body``, and ``upper``:
-
-           - :class:`RangedExpression` if none are :const:`None`
-           - :class:`InequalityExpression` if exactly one is :const:`None`
-           - The non-None argument if exactly one is non-None
-           - :const:`None` if all arguments are :const:`None`
+    RangedExpression | InequalityExpression | NumericValue | int | float | None
 
     """
     _genexpr = _lt_dispatcher if strict else _le_dispatcher

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -634,6 +634,12 @@ def _le_native_ineq(a, b):
     b0, b1 = b.args
     lhs = _le_dispatcher[a.__class__, b0.__class__](a, b0)
     if lhs.__class__ is InequalityExpression:
+        bounds = (_lt_dispatcher if b.strict else _le_dispatcher)[
+            a.__class__, b1.__class__
+        ](a, b1)
+        if bounds.__class__ is bool and not bounds:
+            # Trivial infeasible bounds
+            return False
         return RangedExpression((a, b0, b1), (False, b._strict))
     elif lhs:
         # Trivial (feasible) LHS
@@ -657,6 +663,12 @@ def _le_ineq_native(a, b):
     a0, a1 = a.args
     rhs = _le_dispatcher[a1.__class__, b.__class__](a1, b)
     if rhs.__class__ is InequalityExpression:
+        bounds = (_lt_dispatcher if a.strict else _le_dispatcher)[
+            a0.__class__, b.__class__
+        ](a0, b)
+        if bounds.__class__ is bool and not bounds:
+            # Trivial infeasible bounds
+            return False
         return RangedExpression((a0, a1, b), (a._strict, False))
     elif rhs:
         # Trivial (feasible) RHS
@@ -758,6 +770,10 @@ def _lt_native_ineq(a, b):
     b0, b1 = b.args
     lhs = _lt_dispatcher[a.__class__, b0.__class__](a, b0)
     if lhs.__class__ is InequalityExpression:
+        bounds = _lt_dispatcher[a.__class__, b1.__class__](a, b1)
+        if bounds.__class__ is bool and not bounds:
+            # Trivial infeasible bounds
+            return False
         return RangedExpression((a, b0, b1), (True, b._strict))
     elif lhs:
         # Trivial (feasible) LHS
@@ -781,6 +797,10 @@ def _lt_ineq_native(a, b):
     a0, a1 = a.args
     rhs = _lt_dispatcher[a1.__class__, b.__class__](a1, b)
     if rhs.__class__ is InequalityExpression:
+        bounds = _lt_dispatcher[a0.__class__, b.__class__](a0, b)
+        if bounds.__class__ is bool and not bounds:
+            # Trivial infeasible bounds
+            return False
         return RangedExpression((a0, a1, b), (a._strict, True))
     elif rhs:
         # Trivial (feasible) RHS

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -365,10 +365,45 @@ def inequality(lower=None, body=None, upper=None, strict=False):
 
     .. note:: Pyomo does not support constructing
        :class:`RangedExpression` objects using Python's chained
-       comparison syntax (``lb <= body <= ub``).  Python relies on
-       shortcut Boolean evaluation, which is incompatible with Pyomo's
-       operator overloading.  Instead, :class:`RangedExpression` objects
-       should be created using this function.
+       comparison syntax (``lb <= body <= ub``).  Python relies on the
+       pairwise comparisons returning intermediates that are convertable
+       to ``bool``, which is incompatible with Pyomo's operator
+       overloading.  Instead, :class:`RangedExpression` objects should
+       be created using this function.
+
+    Edge cases
+    ----------
+
+    :func:`inequality` allows for any (or all) of `lower`, `body`, and
+    `upper` to be ``None``.  What gets returned from the function
+    depends on the number and type of values provided:
+
+    No arguments are ``None``
+       If `lower`, `body`, and `upper` are all non-``None``, then the
+       function will return a :class:`RangedExpression`, unless two
+       adjacent arguments (either `lower` and `body`, or `body` and
+       `upper`) are both constants (e.g., native numeric types or
+       immutable :class:`Param` objects).  If there are two adjacent
+       constant values, then that pair is evaluated.  If the result is
+       ``False``, then the constraint is known to be trivially
+       infeasible and :func:`inequality` will return ``False``.  If the
+       result is ``True``, then the return value is as if the "outer"
+       (`lower` or `upper`) argument had been ``None`` (see the following).
+
+    One argument is ``None``
+       If one of `lower`, `body`, or `upper` is ``None``, then
+       :func:`inequality` will return an :class:`InequalityExpression`
+       object, unless both arguments are constants (e.g., native numeric
+       types or immutable :class:`Param` objects), in which case the
+       expression will be evaluated and the resulting :class:`bool`
+       returned.
+
+    Two arguments are ``None``
+       If two of `lower`, `body`, or `upper` are ``None``, then the
+       rmaining argument is returned from :func:`inequality`.
+
+    All None
+       If all arguments are ``None``, then ``None`` is returned
 
     Parameters
     ----------

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -366,7 +366,7 @@ def inequality(lower=None, body=None, upper=None, strict=False):
     .. note:: Pyomo does not support constructing
        :class:`RangedExpression` objects using Python's chained
        comparison syntax (``lb <= body <= ub``).  Python relies on the
-       pairwise comparisons returning intermediates that are convertable
+       pairwise comparisons returning intermediates that are convertible
        to ``bool``, which is incompatible with Pyomo's operator
        overloading.  Instead, :class:`RangedExpression` objects should
        be created using this function.
@@ -400,7 +400,7 @@ def inequality(lower=None, body=None, upper=None, strict=False):
 
     Two arguments are ``None``
        If two of `lower`, `body`, or `upper` are ``None``, then the
-       rmaining argument is returned from :func:`inequality`.
+       remaining argument is returned from :func:`inequality`.
 
     All None
        If all arguments are ``None``, then ``None`` is returned

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -629,9 +629,22 @@ def _le_expr_ineq(a, b):
     return RangedExpression((a,) + b.args, (False, b._strict))
 
 
+def _le_native_ineq(a, b):
+    b0, b1 = b.args
+    lhs = _le_dispatcher[a.__class__, b0.__class__](a, b0)
+    if lhs.__class__ is InequalityExpression:
+        return RangedExpression((a, b0, b1), (False, b._strict))
+    elif lhs:
+        # Trivial (feasible) LHS
+        return b
+    else:
+        # Trivial infeasible LHS
+        return False
+
+
 def _le_param_ineq(a, b):
     if a.is_constant():
-        a = a.value
+        return _le_native_ineq(a.value, b)
     return RangedExpression((a,) + b.args, (False, b._strict))
 
 
@@ -639,9 +652,22 @@ def _le_ineq_expr(a, b):
     return RangedExpression(a.args + (b,), (a._strict, False))
 
 
+def _le_ineq_native(a, b):
+    a0, a1 = a.args
+    rhs = _le_dispatcher[a1.__class__, b.__class__](a1, b)
+    if rhs.__class__ is InequalityExpression:
+        return RangedExpression((a0, a1, b), (a._strict, False))
+    elif rhs:
+        # Trivial (feasible) RHS
+        return a
+    else:
+        # Trivial infeasible RHS
+        return False
+
+
 def _le_ineq_param(a, b):
     if b.is_constant():
-        b = b.value
+        return _le_ineq_native(a, b.value)
     return RangedExpression(a.args + (b,), (a._strict, False))
 
 
@@ -684,7 +710,7 @@ _le_type_handler_mapping = _binary_op_dispatcher_type_mapping(
         (ARG_TYPE.NATIVE, ARG_TYPE.NATIVE): _le_native,
         (ARG_TYPE.NATIVE, ARG_TYPE.PARAM): _le_any_param,
         (ARG_TYPE.NATIVE, ARG_TYPE.OTHER): _le_expr,
-        (ARG_TYPE.NATIVE, ARG_TYPE.INEQUALITY): _le_expr_ineq,
+        (ARG_TYPE.NATIVE, ARG_TYPE.INEQUALITY): _le_native_ineq,
         (ARG_TYPE.NATIVE, ARG_TYPE.INVALID_RELATIONAL): _le_invalid,
         (ARG_TYPE.PARAM, ARG_TYPE.NATIVE): _le_param_any,
         (ARG_TYPE.PARAM, ARG_TYPE.PARAM): _le_param_param,
@@ -696,7 +722,7 @@ _le_type_handler_mapping = _binary_op_dispatcher_type_mapping(
         (ARG_TYPE.OTHER, ARG_TYPE.OTHER): _le_expr,
         (ARG_TYPE.OTHER, ARG_TYPE.INEQUALITY): _le_expr_ineq,
         (ARG_TYPE.OTHER, ARG_TYPE.INVALID_RELATIONAL): _le_invalid,
-        (ARG_TYPE.INEQUALITY, ARG_TYPE.NATIVE): _le_ineq_expr,
+        (ARG_TYPE.INEQUALITY, ARG_TYPE.NATIVE): _le_ineq_native,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.PARAM): _le_ineq_param,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.OTHER): _le_ineq_expr,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.INEQUALITY): _le_invalid,
@@ -727,9 +753,22 @@ def _lt_expr_ineq(a, b):
     return RangedExpression((a,) + b.args, (True, b._strict))
 
 
+def _lt_native_ineq(a, b):
+    b0, b1 = b.args
+    lhs = _lt_dispatcher[a.__class__, b0.__class__](a, b0)
+    if lhs.__class__ is InequalityExpression:
+        return RangedExpression((a, b0, b1), (True, b._strict))
+    elif lhs:
+        # Trivial (feasible) LHS
+        return b
+    else:
+        # Trivial infeasible LHS
+        return False
+
+
 def _lt_param_ineq(a, b):
     if a.is_constant():
-        a = a.value
+        return _lt_native_ineq(a.value, b)
     return RangedExpression((a,) + b.args, (True, b._strict))
 
 
@@ -737,9 +776,22 @@ def _lt_ineq_expr(a, b):
     return RangedExpression(a.args + (b,), (a._strict, True))
 
 
+def _lt_ineq_native(a, b):
+    a0, a1 = a.args
+    rhs = _lt_dispatcher[a1.__class__, b.__class__](a1, b)
+    if rhs.__class__ is InequalityExpression:
+        return RangedExpression((a0, a1, b), (a._strict, True))
+    elif rhs:
+        # Trivial (feasible) RHS
+        return a
+    else:
+        # Trivial infeasible RHS
+        return False
+
+
 def _lt_ineq_param(a, b):
     if b.is_constant():
-        b = b.value
+        return _lt_ineq_native(a, b.value)
     return RangedExpression(a.args + (b,), (a._strict, True))
 
 
@@ -782,7 +834,7 @@ _lt_type_handler_mapping = _binary_op_dispatcher_type_mapping(
         (ARG_TYPE.NATIVE, ARG_TYPE.NATIVE): _lt_native,
         (ARG_TYPE.NATIVE, ARG_TYPE.PARAM): _lt_any_param,
         (ARG_TYPE.NATIVE, ARG_TYPE.OTHER): _lt_expr,
-        (ARG_TYPE.NATIVE, ARG_TYPE.INEQUALITY): _lt_expr_ineq,
+        (ARG_TYPE.NATIVE, ARG_TYPE.INEQUALITY): _lt_native_ineq,
         (ARG_TYPE.NATIVE, ARG_TYPE.INVALID_RELATIONAL): _lt_invalid,
         (ARG_TYPE.PARAM, ARG_TYPE.NATIVE): _lt_param_any,
         (ARG_TYPE.PARAM, ARG_TYPE.PARAM): _lt_param_param,
@@ -794,7 +846,7 @@ _lt_type_handler_mapping = _binary_op_dispatcher_type_mapping(
         (ARG_TYPE.OTHER, ARG_TYPE.OTHER): _lt_expr,
         (ARG_TYPE.OTHER, ARG_TYPE.INEQUALITY): _lt_expr_ineq,
         (ARG_TYPE.OTHER, ARG_TYPE.INVALID_RELATIONAL): _lt_invalid,
-        (ARG_TYPE.INEQUALITY, ARG_TYPE.NATIVE): _lt_ineq_expr,
+        (ARG_TYPE.INEQUALITY, ARG_TYPE.NATIVE): _lt_ineq_native,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.PARAM): _lt_ineq_param,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.OTHER): _lt_ineq_expr,
         (ARG_TYPE.INEQUALITY, ARG_TYPE.INEQUALITY): _lt_invalid,

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -340,7 +340,7 @@ class TrivialRelationalExpression(InequalityExpression):
 
 
 def inequality(lower=None, body=None, upper=None, strict=False):
-    """A utility function that can be used to declare inequality and
+    r"""A utility function that can be used to declare inequality and
     ranged inequality expressions.
 
     The expression::

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -340,52 +340,88 @@ class TrivialRelationalExpression(InequalityExpression):
 
 
 def inequality(lower=None, body=None, upper=None, strict=False):
-    """
-    A utility function that can be used to declare inequality and
-    ranged inequality expressions.  The expression::
-
-        inequality(2, model.x)
-
-    is equivalent to the expression::
-
-        2 <= model.x
+    """A utility function that can be used to declare inequality and
+    ranged inequality expressions.
 
     The expression::
 
+        inequality(2, model.x)
+
+    is equivalent to:
+
+    .. math::
+
+        2 \leq x
+
+    and the expression::
+
         inequality(2, model.x, 3)
 
-    is equivalent to the expression::
+    is equivalent to:
 
-        2 <= model.x <= 3
+    .. math::
 
-    .. note:: This ranged inequality syntax is deprecated in Pyomo.
-        This function provides a mechanism for expressing
-        ranged inequalities without chained inequalities.
+        2 \leq x \leq 3
 
-    args:
-        lower: an expression defines a lower bound
-        body: an expression defines the body of a ranged constraint
-        upper: an expression defines an upper bound
-        strict (bool): A boolean value that indicates whether the inequality
-            is strict.  Default is :const:`False`.
+    .. note:: Pyomo does not support constructing
+       :class:`RangedExpression` objects using Python's chained
+       comparison syntax (``lb <= body <= ub``).  Python relies on
+       shortcut Boolean evaluation, which is incompatible with Pyomo's
+       operator overloading.  Instead, :class:`RangedExpression` objects
+       should be created using this function.
 
-    Returns:
-        A relational expression.  The expression is an inequality
-        if any of the values :attr:`lower`, :attr:`body` or
-        :attr:`upper` is :const:`None`.  Otherwise, the expression
-        is a ranged inequality.
+    Parameters
+    ----------
+    lower : int | float | NumericValue | None
+        The expression for the lower bound
+
+    body : int | float | NumericValue | None
+        The expression for the body of a ranged constraint
+
+    lower : int | float | NumericValue | None
+        The expression for the upper bound
+
+    strict : bool
+        If :const:`True`, construct strict inequalities (``<``);
+        otherwise use ``<=``.
+
+    Returns
+    -------
+    expr : RangedExpression | InequalityExpression | NumericValue | int | float | None
+
+        An expression.  The return value depends on the values of
+        ``lower``, ``body``, and ``upper``:
+
+           - :class:`RangedExpression` if none are :const:`None`
+           - :class:`InequalityExpression` if exactly one is :const:`None`
+           - The non-None argument if exaclty one is non-None
+           - :const:`None` if all arguments are :const:`None`
+
     """
-    if lower is None:
-        if body is None or upper is None:
-            raise ValueError("Invalid inequality expression.")
-        return InequalityExpression((body, upper), strict)
+    _genexpr = _lt_dispatcher if strict else _le_dispatcher
     if body is None:
-        if lower is None or upper is None:
-            raise ValueError("Invalid inequality expression.")
-        return InequalityExpression((lower, upper), strict)
-    if upper is None:
-        return InequalityExpression((lower, body), strict)
-    return RangedExpression((lower, body, upper), strict)
+        lower, body = body, lower
+    if lower is not None:
+        expr = _genexpr[lower.__class__, body.__class__](lower, body)
+        # If the LHS of the ranged inequality evaluated to a bool, we
+        # need to do some special processing:
+        #  - False: the LHS is trivially infeasible.  Return False.
+        #  - True: the LHS is trivially feasible. Leave body unchanged
+        #    so that it can be compared to the RHS
+        #
+        # ...otherwise, "replace" body with the resulting inequality and
+        # then process the RHS
+        if expr.__class__ is bool:
+            if not expr:
+                return False
+        else:
+            body = expr
+    if upper is not None:
+        if body is not None:
+            body = _genexpr[body.__class__, upper.__class__](body, upper)
+        else:
+            body = upper
+    return body
 
 
 class EqualityExpression(RelationalExpression):

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -394,7 +394,7 @@ def inequality(lower=None, body=None, upper=None, strict=False):
 
            - :class:`RangedExpression` if none are :const:`None`
            - :class:`InequalityExpression` if exactly one is :const:`None`
-           - The non-None argument if exaclty one is non-None
+           - The non-None argument if exactly one is non-None
            - :const:`None` if all arguments are :const:`None`
 
     """

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -401,6 +401,7 @@ def inequality(lower=None, body=None, upper=None, strict=False):
     _genexpr = _lt_dispatcher if strict else _le_dispatcher
     if body is None:
         lower, body = body, lower
+    expr = body
     if lower is not None:
         expr = _genexpr[lower.__class__, body.__class__](lower, body)
         # If the LHS of the ranged inequality evaluated to a bool, we
@@ -418,10 +419,10 @@ def inequality(lower=None, body=None, upper=None, strict=False):
             body = expr
     if upper is not None:
         if body is not None:
-            body = _genexpr[body.__class__, upper.__class__](body, upper)
+            expr = _genexpr[body.__class__, upper.__class__](body, upper)
         else:
-            body = upper
-    return body
+            expr = upper
+    return expr
 
 
 class EqualityExpression(RelationalExpression):

--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -478,10 +478,24 @@ class NotEqualExpression(RelationalExpression):
 
 
 def tuple_to_relational_expr(args):
-    if len(args) == 2:
-        return EqualityExpression(args)
-    else:
-        return inequality(*args)
+    if len(args) == 3:
+        return inequality(*args, strict=False)
+    elif len(args) == 2:
+        lhs, rhs = args
+        ans = _eq_dispatcher[lhs.__class__, rhs.__class__](lhs, rhs)
+        if ans is NotImplemented:
+            raise ValueError(
+                "Cannot create EqualityExpression from argument types "
+                f"'{type(lhs).__name__}' and '{type(rhs).__name__}'"
+            )
+        return ans
+    raise ValueError(
+        "Cannot convert tuple to relational expression. "
+        f"Found a tuple of length {len(args)}. Expecting a tuple of "
+        "length 2 or 3:\n"
+        "    Equality:   (left, right)\n"
+        "    Inequality: (lower, expression, upper)"
+    )
 
 
 def _invalid_relational(op_type, op_str, a, b):

--- a/pyomo/core/plugins/transform/nonnegative_transform.py
+++ b/pyomo/core/plugins/transform/nonnegative_transform.py
@@ -433,6 +433,8 @@ class NonNegativeTransformation(IsomorphicTransformation):
         and so attr='X', and 1 is a key of vars.
 
         """
+        if lb is None and ub is None:
+            return Constraint.Skip
         return (
             lb,
             sum(c * model.__getattribute__(attr)[v] for (v, c) in vars.items()),

--- a/pyomo/core/tests/transform/test_add_slacks.py
+++ b/pyomo/core/tests/transform/test_add_slacks.py
@@ -183,7 +183,10 @@ class TestAddSlacks(unittest.TestCase):
     def test_badModel_err(self):
         model = ConcreteModel()
         model.x = Var(within=NonNegativeReals)
-        model.rule1 = Constraint(expr=inequality(6, model.x, 5))
+        model.p = Param(initialize=5, mutable=True)
+        # Note: use a mutable param so expression generation doesn't
+        # immediately recognize the infeasibility
+        model.rule1 = Constraint(expr=inequality(6, model.x, model.p))
         self.assertRaisesRegex(
             RuntimeError,
             "Lower bound exceeds upper bound in constraint rule1*",

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -1873,7 +1873,11 @@ class MiscConTests(unittest.TestCase):
         model.x = Var()
         model.L = Param(initialize=0)
         model.U = Param(initialize=1)
-        model.o = Constraint(rule=rule1)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"The constraint expression resolved to a trivial Boolean \(False\)",
+        ):
+            model.o = Constraint(rule=rule1)
 
         #
         def rule1(model):

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -267,6 +267,44 @@ class TestConstraintCreation(unittest.TestCase):
         self.assertIs(model.c.body, model.y)
         self.assertEqual(model.c.upper, 1)
 
+        def rule(model):
+            return (float(0), model.y, float(0))
+
+        model.d = Constraint(rule=rule)
+
+        self.assertEqual(model.d.equality, True)
+        self.assertEqual(model.d.lower, 0)
+        self.assertIs(model.d.body, model.y)
+        self.assertEqual(model.d.upper, 0)
+
+        model.p = Param(mutable=True)
+        e = model.p * 2 + 1
+
+        def rule(model):
+            return (e, model.y, e)
+
+        model.e = Constraint(rule=rule)
+
+        self.assertEqual(model.e.equality, True)
+        self.assertIs(model.e.lower, e)
+        self.assertIs(model.e.body, model.y)
+        self.assertIs(model.e.upper, e)
+
+        #
+        # Note: because we do not test for symbolic equivalence, the
+        # following will be seen as a ranged inequality and not an
+        # equality:
+        #
+        def rule(model):
+            return (e, model.y, model.p * 2 + 1)
+
+        model.f = Constraint(rule=rule)
+
+        self.assertEqual(model.f.equality, False)
+        self.assertIs(model.f.lower, e)
+        self.assertIs(model.f.body, model.y)
+        self.assertIsNot(model.f.upper, e)
+
     def test_tuple_construct_invalid_2sided_inequality(self):
         model = self.create_model(abstract=True)
 

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -190,15 +190,28 @@ class TestConstraintCreation(unittest.TestCase):
     def test_tuple_construct_unbounded_inequality(self):
         model = self.create_model()
 
+        # Note: inequality with only a single non-None returns the non-None value
+
         def rule(model):
             return (None, model.y, None)
 
-        model.c = Constraint(rule=rule)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Constraint 'c' does not have a proper value. Found ScalarVar 'y'",
+        ):
+            model.c = Constraint(rule=rule)
 
-        self.assertEqual(model.c.equality, False)
-        self.assertEqual(model.c.lower, None)
-        self.assertIs(model.c.body, model.y)
-        self.assertEqual(model.c.upper, None)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Constraint 'c' does not have a proper value. Found ScalarVar 'y'",
+        ):
+            model.c = (model.y, None, None)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Constraint 'c' does not have a proper value. Found ScalarVar 'y'",
+        ):
+            model.c = (None, None, model.y)
 
         model = self.create_model()
 
@@ -1374,16 +1387,24 @@ class Test2DArrayCon(unittest.TestCase):
 class MiscConTests(unittest.TestCase):
     def test_infeasible(self):
         m = ConcreteModel()
+        m.x = Var()
         m.c = Constraint(expr=Constraint.Infeasible)
         self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, None)
         self.assertEqual(m.c.body, 1)
         self.assertEqual(m.c.ub, 0)
 
-        m.c = (0, 1, 2)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid constraint expression. The constraint expression resolved "
+            r"to a trivial Boolean \(True\) instead of a Pyomo object.",
+        ):
+            m.c = (0, 1, 2)
+
+        m.c = (0, m.x, 2)
         self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, 0)
-        self.assertEqual(m.c.body, 1)
+        self.assertEqual(m.c.body, m.x)
         self.assertEqual(m.c.ub, 2)
 
         m.c = Constraint.Infeasible
@@ -1394,16 +1415,24 @@ class MiscConTests(unittest.TestCase):
 
     def test_feasible(self):
         m = ConcreteModel()
+        m.x = Var()
         m.c = Constraint(expr=Constraint.Feasible)
         self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, None)
         self.assertEqual(m.c.body, 0)
         self.assertEqual(m.c.ub, 0)
 
-        m.c = (0, 1, 2)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid constraint expression. The constraint expression resolved "
+            r"to a trivial Boolean \(True\) instead of a Pyomo object.",
+        ):
+            m.c = (0, 1, 2)
+
+        m.c = (0, m.x, 2)
         self.assertIn(None, m.c._data)
         self.assertEqual(m.c.lb, 0)
-        self.assertEqual(m.c.body, 1)
+        self.assertEqual(m.c.body, m.x)
         self.assertEqual(m.c.ub, 2)
 
         m.c = Constraint.Feasible
@@ -2019,9 +2048,8 @@ class MiscConTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Constraint 'c' does not have a proper value. "
-            "Equality Constraints expressed as 2-tuples cannot "
-            "contain None",
+            "Cannot create EqualityExpression from argument types "
+            "'ScalarVar' and 'NoneType'",
         ):
             m.c = (m.x, None)
 

--- a/pyomo/core/tests/unit/test_relational_expr.py
+++ b/pyomo/core/tests/unit/test_relational_expr.py
@@ -224,7 +224,7 @@ class TestGenerate_RangedExpression(unittest.TestCase):
         #     <   c
         #    / \
         #   a   b
-        e = inequality(m.a, m.b, m.c, strict=True)
+        e = (m.a < m.b) < m.c
         self.assertIs(type(e), RangedExpression)
         self.assertEqual(e.nargs(), 3)
         self.assertIs(e.arg(0), m.a)
@@ -239,7 +239,7 @@ class TestGenerate_RangedExpression(unittest.TestCase):
         #     <=  c
         #    / \
         #   a   b
-        e = inequality(m.a, m.b, m.c)
+        e = (m.a <= m.b) <= m.c
         self.assertIs(type(e), RangedExpression)
         self.assertEqual(e.nargs(), 3)
         self.assertIs(e.arg(0), m.a)
@@ -254,37 +254,29 @@ class TestGenerate_RangedExpression(unittest.TestCase):
         #     >   c
         #    / \
         #   a   b
-        e = inequality(upper=m.c, body=m.b, lower=m.a, strict=True)
+        e = (m.a > m.b) > m.c
         self.assertIs(type(e), RangedExpression)
         self.assertEqual(e.nargs(), 3)
-        self.assertIs(e.arg(2), m.c)
-        self.assertIs(e.arg(1), m.b)
-        self.assertIs(e.arg(0), m.a)
-        # self.assertEqual(len(e._strict), 2)
-        self.assertEqual(e._strict[0], True)
-        self.assertEqual(e._strict[1], True)
+        self.assertEqual(e.args, (m.c, m.b, m.a))
+        self.assertEqual(e.strict, (True, True))
 
         #       >=
         #      / \
         #     >=  c
         #    / \
         #   a   b
-        e = inequality(upper=m.c, body=m.b, lower=m.a)
+        e = (m.a >= m.b) >= m.c
         self.assertIs(type(e), RangedExpression)
         self.assertEqual(e.nargs(), 3)
-        self.assertIs(e.arg(2), m.c)
-        self.assertIs(e.arg(1), m.b)
-        self.assertIs(e.arg(0), m.a)
-        # self.assertEqual(len(e._strict), 2)
-        self.assertEqual(e._strict[0], False)
-        self.assertEqual(e._strict[1], False)
+        self.assertEqual(e.args, (m.c, m.b, m.a))
+        self.assertEqual(e.strict, (False, False))
 
         #       <=
         #      / \
         #     <=  0
         #    / \
         #   0   a
-        e = inequality(0, m.a, 0)
+        e = (0 <= m.a) <= 0
         self.assertIs(type(e), RangedExpression)
         self.assertEqual(e.nargs(), 3)
         self.assertIs(e.arg(2), 0)
@@ -299,15 +291,126 @@ class TestGenerate_RangedExpression(unittest.TestCase):
         #     <  0
         #    / \
         #   0   a
-        e = inequality(0, m.a, 0, True)
+        e = (0 < m.a) < 0
+        self.assertIs(e, False)
+
+    def test_inequality_fcn(self):
+        m = self.m
+
+        self.assertEqual(inequality(None, None, None), None)
+
+        self.assertEqual(inequality(0, None, None), 0)
+        self.assertEqual(inequality(None, 0, None), 0)
+        self.assertEqual(inequality(None, None, 0), 0)
+
+        self.assertEqual(inequality(m.a, None, None), m.a)
+        self.assertEqual(inequality(None, m.a, None), m.a)
+        self.assertEqual(inequality(None, None, m.a), m.a)
+
+        self.assertEqual(inequality(None, 0, 0), True)
+        self.assertEqual(inequality(0, None, 0), True)
+        self.assertEqual(inequality(0, 0, None), True)
+        self.assertEqual(inequality(None, 0, 1), True)
+        self.assertEqual(inequality(0, None, 1), True)
+        self.assertEqual(inequality(0, 1, None), True)
+        self.assertEqual(inequality(None, 1, 0), False)
+        self.assertEqual(inequality(1, None, 0), False)
+        self.assertEqual(inequality(1, 0, None), False)
+
+        self.assertEqual(inequality(0, 0, 0), True)
+        self.assertEqual(inequality(0, 1, 2), True)
+
+        e = inequality(m.a, 0, 1)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (m.a, 0))
+        self.assertEqual(e.strict, False)
+
+        e = inequality(0, m.a, 1)
         self.assertIs(type(e), RangedExpression)
-        self.assertEqual(e.nargs(), 3)
-        self.assertIs(e.arg(2), 0)
-        self.assertIs(e.arg(1), m.a)
-        self.assertIs(e.arg(0), 0)
-        # self.assertEqual(len(e._strict), 2)
-        self.assertEqual(e._strict[0], True)
-        self.assertEqual(e._strict[1], True)
+        self.assertEqual(e.args, (0, m.a, 1))
+        self.assertEqual(e.strict, (False, False))
+
+        e = inequality(0, 1, m.a)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (1, m.a))
+        self.assertEqual(e.strict, False)
+
+        e = inequality(m.a, 0, 0)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (m.a, 0))
+        self.assertEqual(e.strict, False)
+
+        e = inequality(0, m.a, 0)
+        self.assertIs(type(e), RangedExpression)
+        self.assertEqual(e.args, (0, m.a, 0))
+        self.assertEqual(e.strict, (False, False))
+
+        e = inequality(0, 0, m.a)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (0, m.a))
+        self.assertEqual(e.strict, False)
+
+        self.assertEqual(inequality(m.a, 1, 0), False)
+        self.assertEqual(inequality(1, m.a, 0), False)
+        self.assertEqual(inequality(1, 0, m.a), False)
+
+        e = inequality(m.a, m.b, m.c)
+        self.assertIs(type(e), RangedExpression)
+        self.assertEqual(e.args, (m.a, m.b, m.c))
+        self.assertEqual(e.strict, (False, False))
+
+    def test_strict_inequality_fcn(self):
+        m = self.m
+
+        self.assertEqual(inequality(None, None, None, True), None)
+
+        self.assertEqual(inequality(0, None, None, True), 0)
+        self.assertEqual(inequality(None, 0, None, True), 0)
+        self.assertEqual(inequality(None, None, 0, True), 0)
+
+        self.assertEqual(inequality(m.a, None, None, True), m.a)
+        self.assertEqual(inequality(None, m.a, None, True), m.a)
+        self.assertEqual(inequality(None, None, m.a, True), m.a)
+
+        self.assertEqual(inequality(None, 0, 0, True), False)
+        self.assertEqual(inequality(0, None, 0, True), False)
+        self.assertEqual(inequality(0, 0, None, True), False)
+        self.assertEqual(inequality(None, 0, 1, True), True)
+        self.assertEqual(inequality(0, None, 1, True), True)
+        self.assertEqual(inequality(0, 1, None, True), True)
+        self.assertEqual(inequality(None, 1, 0, True), False)
+        self.assertEqual(inequality(1, None, 0, True), False)
+        self.assertEqual(inequality(1, 0, None, True), False)
+
+        self.assertEqual(inequality(0, 0, 0, True), False)
+        self.assertEqual(inequality(0, 1, 2, True), True)
+
+        e = inequality(m.a, 0, 1, True)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (m.a, 0))
+        self.assertEqual(e.strict, True)
+
+        e = inequality(0, m.a, 1, True)
+        self.assertIs(type(e), RangedExpression)
+        self.assertEqual(e.args, (0, m.a, 1))
+        self.assertEqual(e.strict, (True, True))
+
+        e = inequality(0, 1, m.a, True)
+        self.assertIs(type(e), InequalityExpression)
+        self.assertEqual(e.args, (1, m.a))
+        self.assertEqual(e.strict, True)
+
+        self.assertEqual(inequality(m.a, 0, 0, True), False)
+        self.assertEqual(inequality(0, m.a, 0, True), False)
+        self.assertEqual(inequality(0, 0, m.a, True), False)
+        self.assertEqual(inequality(m.a, 1, 0, True), False)
+        self.assertEqual(inequality(1, m.a, 0, True), False)
+        self.assertEqual(inequality(1, 0, m.a, True), False)
+
+        e = inequality(m.a, m.b, m.c, True)
+        self.assertIs(type(e), RangedExpression)
+        self.assertEqual(e.args, (m.a, m.b, m.c))
+        self.assertEqual(e.strict, (True, True))
 
     def test_val1(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_relational_expr.py
+++ b/pyomo/core/tests/unit/test_relational_expr.py
@@ -197,17 +197,11 @@ class TestGenerate_RelationalExpression(unittest.TestCase):
         # self.assertEqual(len(e._strict), 1)
         self.assertEqual(e._strict, False)
 
-        try:
-            inequality(None, None)
-            self.fail("expected invalid inequality error.")
-        except ValueError:
-            pass
-
-        try:
-            inequality(m.a, None)
-            self.fail("expected invalid inequality error.")
-        except ValueError:
-            pass
+        # Trivial cases that do not result in inequalities...
+        self.assertEqual(inequality(m.a, None, None), m.a)
+        self.assertEqual(inequality(None, m.a, None), m.a)
+        self.assertEqual(inequality(None, None, m.a), m.a)
+        self.assertEqual(inequality(None, None, None), None)
 
 
 class TestGenerate_RangedExpression(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
+++ b/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseRelational(Base):
-    NUM_TESTS = 26
+    NUM_TESTS = 28
 
     def tearDown(self):
         pass
@@ -66,6 +66,8 @@ class BaseRelational(Base):
         self.eq = self.m.x == self.m.q
         self.le = self.m.x <= self.m.q
         self.lt = self.m.x < self.m.p
+        self.le2 = self.m.q <= self.m.x
+        self.lt2 = self.m.p < self.m.x
         self.ranged = inequality(self.m.p, self.m.x, self.m.q)
 
         # self.TEMPLATE = [
@@ -105,6 +107,8 @@ class BaseRelational(Base):
                 # 24:
                 self.ranged,
                 self.native2,
+                self.le2,
+                self.lt2,
             ]
         )
 
@@ -155,6 +159,8 @@ class TestEquality(BaseRelational, unittest.TestCase):
             # 24:
             (self.invalid, self.ranged, False),
             (self.invalid, self.native2, False),
+            (self.invalid, self.le2, False),
+            (self.invalid, self.lt2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -224,6 +230,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.asbinary, self.native2, EqualityExpression((self.bin, 8))),
+            (
+                self.asbinary,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.asbinary,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -281,6 +299,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.zero, self.native2, False),
+            (
+                self.zero,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.zero,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -338,6 +368,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.one, self.native2, False),
+            (
+                self.one,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.one,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -395,6 +437,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native, self.native2, False),
+            (
+                self.native,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -456,6 +510,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.npv, self.native2, EqualityExpression((self.npv, 8))),
+            (
+                self.npv,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.npv,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -513,6 +579,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param, self.native2, False),
+            (
+                self.param,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.param,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -614,6 +692,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param_mut, self.native2, EqualityExpression((self.param_mut, 8))),
+            (
+                self.param_mut,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.param_mut,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -675,6 +765,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.var, self.native2, EqualityExpression((self.var, 8))),
+            (
+                self.var,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.var,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -788,6 +890,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mon_native, self.native2, EqualityExpression((self.mon_native, 8))),
+            (
+                self.mon_native,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mon_native,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -889,6 +1003,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mon_param, self.native2, EqualityExpression((self.mon_param, 8))),
+            (
+                self.mon_param,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mon_param,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -982,6 +1108,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mon_npv, self.native2, EqualityExpression((self.mon_npv, 8))),
+            (
+                self.mon_npv,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mon_npv,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1055,6 +1193,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.linear, self.native2, EqualityExpression((self.linear, 8))),
+            (
+                self.linear,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.linear,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1116,6 +1266,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.sum, self.native2, EqualityExpression((self.sum, 8))),
+            (
+                self.sum,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.sum,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1185,6 +1347,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.other, self.native2, EqualityExpression((self.other, 8))),
+            (
+                self.other,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.other,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1258,6 +1432,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l0, self.native2, False),
+            (
+                self.mutable_l0,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mutable_l0,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1331,6 +1517,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l1, self.native2, EqualityExpression((self.l1, 8))),
+            (
+                self.mutable_l1,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mutable_l1,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1404,6 +1602,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l2, self.native2, EqualityExpression((self.l2, 8))),
+            (
+                self.mutable_l2,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mutable_l2,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1461,6 +1671,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param0, self.native2, False),
+            (
+                self.param0,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.param0,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1518,6 +1740,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param1, self.native2, False),
+            (
+                self.param1,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.param1,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1591,6 +1825,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l3, self.native2, EqualityExpression((self.l3, 8))),
+            (
+                self.mutable_l3,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.mutable_l3,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1752,6 +1998,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 self.native2,
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
+            ),
+            (
+                self.eq,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.eq,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
             ),
         ]
         self._run_cases(tests, operator.eq)
@@ -1915,6 +2173,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.le,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -2076,6 +2346,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 self.native2,
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
             ),
         ]
         self._run_cases(tests, operator.eq)
@@ -2239,6 +2521,18 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.ranged,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.ranged,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -2296,6 +2590,366 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native2, self.native2, True),
+            (
+                self.native2,
+                self.le2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native2,
+                self.lt2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+        ]
+        self._run_cases(tests, operator.eq)
+
+    def test_eq_le2(self):
+        tests = [
+            (self.le2, self.invalid, False),
+            (
+                self.le2,
+                self.asbinary,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.zero,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.one,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 4:
+            (
+                self.le2,
+                self.native,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.npv,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.param,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.param_mut,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 8:
+            (
+                self.le2,
+                self.var,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.mon_native,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.mon_param,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.mon_npv,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 12:
+            (
+                self.le2,
+                self.linear,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.sum,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.other,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.mutable_l0,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 16:
+            (
+                self.le2,
+                self.mutable_l1,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.mutable_l2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.param0,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.param1,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 20:
+            (
+                self.le2,
+                self.mutable_l3,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.eq,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.le,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.le2,
+                self.ranged,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.le2,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+        ]
+        self._run_cases(tests, operator.eq)
+
+    def test_eq_lt2(self):
+        tests = [
+            (self.lt2, self.invalid, False),
+            (
+                self.lt2,
+                self.asbinary,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.zero,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.one,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 4:
+            (
+                self.lt2,
+                self.native,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.npv,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.param,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.param_mut,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 8:
+            (
+                self.lt2,
+                self.var,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.mon_native,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.mon_param,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.mon_npv,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 12:
+            (
+                self.lt2,
+                self.linear,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.sum,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.other,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.mutable_l0,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 16:
+            (
+                self.lt2,
+                self.mutable_l1,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.mutable_l2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.param0,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.param1,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 20:
+            (
+                self.lt2,
+                self.mutable_l3,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.eq,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.le,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.lt2,
+                self.ranged,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.lt2,
+                self.le2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt2,
+                "Cannot create an EqualityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -2346,6 +3000,8 @@ class TestInequality(BaseRelational, unittest.TestCase):
             # 24:
             (self.invalid, self.ranged, NotImplemented),
             (self.invalid, self.native2, NotImplemented),
+            (self.invalid, self.le2, NotImplemented),
+            (self.invalid, self.lt2, NotImplemented),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2457,6 +3113,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.asbinary, self.native2, InequalityExpression((self.bin, 8), False)),
+            (
+                self.asbinary,
+                self.le2,
+                RangedExpression((self.bin,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.asbinary,
+                self.lt2,
+                RangedExpression((self.bin,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2516,6 +3182,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.zero, self.native2, True),
+            (
+                self.zero,
+                self.le2,
+                RangedExpression((0,) + self.le2.args, (False, False)),
+            ),
+            (self.zero, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2575,6 +3247,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.one, self.native2, True),
+            (
+                self.one,
+                self.le2,
+                RangedExpression((1,) + self.le2.args, (False, False)),
+            ),
+            (self.one, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2642,6 +3320,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native, self.native2, True),
+            (
+                self.native,
+                self.le2,
+                RangedExpression((5,) + self.le2.args, (False, False)),
+            ),
+            (self.native, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2737,6 +3421,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.npv, self.native2, InequalityExpression((self.npv, 8), False)),
+            (
+                self.npv,
+                self.le2,
+                RangedExpression((self.npv,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.npv,
+                self.lt2,
+                RangedExpression((self.npv,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2791,7 +3485,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.le,
                 RangedExpression((6,) + self.le.args, (False, False)),
             ),
-            (self.param, self.lt, RangedExpression((6,) + self.lt.args, (False, True))),
+            (self.param, self.lt, False),
             # 24
             (
                 self.param,
@@ -2800,6 +3494,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param, self.native2, True),
+            (
+                self.param,
+                self.le2,
+                RangedExpression((6,) + self.le2.args, (False, False)),
+            ),
+            (self.param, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2939,6 +3639,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.param_mut, 8), False),
             ),
+            (
+                self.param_mut,
+                self.le2,
+                RangedExpression((self.param_mut,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.param_mut,
+                self.lt2,
+                RangedExpression((self.param_mut,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3034,6 +3744,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.var, self.native2, InequalityExpression((self.var, 8), False)),
+            (
+                self.var,
+                self.le2,
+                RangedExpression((self.var,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.var,
+                self.lt2,
+                RangedExpression((self.var,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3172,6 +3892,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.mon_native,
                 self.native2,
                 InequalityExpression((self.mon_native, 8), False),
+            ),
+            (
+                self.mon_native,
+                self.le2,
+                RangedExpression((self.mon_native,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mon_native,
+                self.lt2,
+                RangedExpression((self.mon_native,) + self.lt2.args, (False, True)),
             ),
         ]
         self._run_cases(tests, operator.le)
@@ -3312,6 +4042,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.mon_param, 8), False),
             ),
+            (
+                self.mon_param,
+                self.le2,
+                RangedExpression((self.mon_param,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mon_param,
+                self.lt2,
+                RangedExpression((self.mon_param,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3427,6 +4167,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.mon_npv, 8), False),
             ),
+            (
+                self.mon_npv,
+                self.le2,
+                RangedExpression((self.mon_npv,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mon_npv,
+                self.lt2,
+                RangedExpression((self.mon_npv,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3538,6 +4288,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.linear, self.native2, InequalityExpression((self.linear, 8), False)),
+            (
+                self.linear,
+                self.le2,
+                RangedExpression(((self.linear,) + self.le2.args), (False, False)),
+            ),
+            (
+                self.linear,
+                self.lt2,
+                RangedExpression(((self.linear,) + self.lt2.args), (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3633,6 +4393,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.sum, self.native2, InequalityExpression((self.sum, 8), False)),
+            (
+                self.sum,
+                self.le2,
+                RangedExpression((self.sum,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.sum,
+                self.lt2,
+                RangedExpression((self.sum,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3732,6 +4502,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.other, self.native2, InequalityExpression((self.other, 8), False)),
+            (
+                self.other,
+                self.le2,
+                RangedExpression((self.other,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.other,
+                self.lt2,
+                RangedExpression((self.other,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3839,6 +4619,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l0, self.native2, True),
+            (
+                self.mutable_l0,
+                self.le2,
+                RangedExpression((self.l0,) + self.le2.args, (False, False)),
+            ),
+            (self.mutable_l0, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3950,6 +4736,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l1, self.native2, InequalityExpression((self.l1, 8), False)),
+            (
+                self.mutable_l1,
+                self.le2,
+                RangedExpression((self.l1,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mutable_l1,
+                self.lt2,
+                RangedExpression((self.l1,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4061,6 +4857,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l2, self.native2, InequalityExpression((self.l2, 8), False)),
+            (
+                self.mutable_l2,
+                self.le2,
+                RangedExpression((self.l2,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mutable_l2,
+                self.lt2,
+                RangedExpression((self.l2,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4128,6 +4934,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param0, self.native2, True),
+            (
+                self.param0,
+                self.le2,
+                RangedExpression((0,) + self.le2.args, (False, False)),
+            ),
+            (self.param0, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4195,6 +5007,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param1, self.native2, True),
+            (
+                self.param1,
+                self.le2,
+                RangedExpression((1,) + self.le2.args, (False, False)),
+            ),
+            (self.param1, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4306,6 +5124,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l3, self.native2, InequalityExpression((self.l3, 8), False)),
+            (
+                self.mutable_l3,
+                self.le2,
+                RangedExpression((self.l3,) + self.le2.args, (False, False)),
+            ),
+            (
+                self.mutable_l3,
+                self.lt2,
+                RangedExpression((self.l3,) + self.lt2.args, (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4468,6 +5296,18 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.eq,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.eq,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4609,6 +5449,18 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 RangedExpression((self.le.args + (8,)), (False, False)),
             ),
+            (
+                self.le,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4718,6 +5570,18 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions are relational expressions",
             ),
             (self.lt, self.native2, self.lt),
+            (
+                self.lt,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4880,6 +5744,18 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.ranged,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.ranged,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4938,11 +5814,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.le,
                 RangedExpression((8,) + self.le.args, (False, False)),
             ),
-            (
-                self.native2,
-                self.lt,
-                RangedExpression((8,) + self.lt.args, (False, True)),
-            ),
+            (self.native2, self.lt, False),
             # 24
             (
                 self.native2,
@@ -4951,6 +5823,290 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native2, self.native2, True),
+            (
+                self.native2,
+                self.le2,
+                RangedExpression((8,) + self.le2.args, (False, False)),
+            ),
+            (self.native2, self.lt2, False),
+        ]
+        self._run_cases(tests, operator.le)
+
+    def test_le_le2(self):
+        tests = [
+            (self.le2, self.invalid, NotImplemented),
+            (
+                self.le2,
+                self.asbinary,
+                RangedExpression((self.le2.args + (self.bin,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.zero,
+                RangedExpression((self.le2.args + (0,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.one,
+                RangedExpression((self.le2.args + (1,)), (False, False)),
+            ),
+            # 4:
+            (
+                self.le2,
+                self.native,
+                RangedExpression((self.le2.args + (5,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.npv,
+                RangedExpression((self.le2.args + (self.npv,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.param,
+                RangedExpression((self.le2.args + (6,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.param_mut,
+                RangedExpression((self.le2.args + (self.param_mut,)), (False, False)),
+            ),
+            # 8:
+            (
+                self.le2,
+                self.var,
+                RangedExpression((self.le2.args + (self.var,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.mon_native,
+                RangedExpression((self.le2.args + (self.mon_native,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.mon_param,
+                RangedExpression((self.le2.args + (self.mon_param,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.mon_npv,
+                RangedExpression((self.le2.args + (self.mon_npv,)), (False, False)),
+            ),
+            # 12:
+            (
+                self.le2,
+                self.linear,
+                RangedExpression((self.le2.args + (self.linear,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.sum,
+                RangedExpression((self.le2.args + (self.sum,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.other,
+                RangedExpression((self.le2.args + (self.other,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.mutable_l0,
+                RangedExpression((self.le2.args + (self.l0,)), (False, False)),
+            ),
+            # 16:
+            (
+                self.le2,
+                self.mutable_l1,
+                RangedExpression((self.le2.args + (self.l1,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.mutable_l2,
+                RangedExpression((self.le2.args + (self.l2,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.param0,
+                RangedExpression((self.le2.args + (0,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.param1,
+                RangedExpression((self.le2.args + (1,)), (False, False)),
+            ),
+            # 20:
+            (
+                self.le2,
+                self.mutable_l3,
+                RangedExpression((self.le2.args + (self.l3,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.eq,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.le,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.le2,
+                self.ranged,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.native2,
+                RangedExpression((self.le2.args + (8,)), (False, False)),
+            ),
+            (
+                self.le2,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+        ]
+        self._run_cases(tests, operator.le)
+
+    def test_le_lt2(self):
+        tests = [
+            (self.lt2, self.invalid, NotImplemented),
+            (
+                self.lt2,
+                self.asbinary,
+                RangedExpression((self.lt2.args + (self.bin,)), (True, False)),
+            ),
+            (self.lt2, self.zero, False),
+            (self.lt2, self.one, False),
+            # 4:
+            (self.lt2, self.native, False),
+            (
+                self.lt2,
+                self.npv,
+                RangedExpression((self.lt2.args + (self.npv,)), (True, False)),
+            ),
+            (self.lt2, self.param, False),
+            (
+                self.lt2,
+                self.param_mut,
+                RangedExpression((self.lt2.args + (self.param_mut,)), (True, False)),
+            ),
+            # 8:
+            (
+                self.lt2,
+                self.var,
+                RangedExpression((self.lt2.args + (self.var,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.mon_native,
+                RangedExpression((self.lt2.args + (self.mon_native,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.mon_param,
+                RangedExpression((self.lt2.args + (self.mon_param,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.mon_npv,
+                RangedExpression((self.lt2.args + (self.mon_npv,)), (True, False)),
+            ),
+            # 12:
+            (
+                self.lt2,
+                self.linear,
+                RangedExpression((self.lt2.args + (self.linear,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.sum,
+                RangedExpression((self.lt2.args + (self.sum,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.other,
+                RangedExpression((self.lt2.args + (self.other,)), (True, False)),
+            ),
+            (self.lt2, self.mutable_l0, False),
+            # 16:
+            (
+                self.lt2,
+                self.mutable_l1,
+                RangedExpression((self.lt2.args + (self.l1,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.mutable_l2,
+                RangedExpression((self.lt2.args + (self.l2,)), (True, False)),
+            ),
+            (self.lt2, self.param0, False),
+            (self.lt2, self.param1, False),
+            # 20:
+            (
+                self.lt2,
+                self.mutable_l3,
+                RangedExpression((self.lt2.args + (self.l3,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.eq,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.le,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.lt2,
+                self.ranged,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.native2,
+                RangedExpression((self.lt2.args + (8,)), (True, False)),
+            ),
+            (
+                self.lt2,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -5001,6 +6157,8 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
             # 24:
             (self.invalid, self.ranged, NotImplemented),
             (self.invalid, self.native2, NotImplemented),
+            (self.invalid, self.le2, NotImplemented),
+            (self.invalid, self.lt2, NotImplemented),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5100,6 +6258,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.asbinary, self.native2, InequalityExpression((self.bin, 8), True)),
+            (
+                self.asbinary,
+                self.le2,
+                RangedExpression((self.bin,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.asbinary,
+                self.lt2,
+                RangedExpression((self.bin,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5159,6 +6327,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.zero, self.native2, True),
+            (
+                self.zero,
+                self.le2,
+                RangedExpression((0,) + self.le2.args, (True, False)),
+            ),
+            (self.zero, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5210,6 +6384,8 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.one, self.native2, True),
+            (self.one, self.le2, RangedExpression((1,) + self.le2.args, (True, False))),
+            (self.one, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5273,6 +6449,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native, self.native2, True),
+            (
+                self.native,
+                self.le2,
+                RangedExpression((5,) + self.le2.args, (True, False)),
+            ),
+            (self.native, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5364,6 +6546,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.npv, self.native2, InequalityExpression((self.npv, 8), True)),
+            (
+                self.npv,
+                self.le2,
+                RangedExpression((self.npv,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.npv,
+                self.lt2,
+                RangedExpression((self.npv,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5414,7 +6606,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param, self.le, RangedExpression((6,) + self.le.args, (True, False))),
-            (self.param, self.lt, RangedExpression((6,) + self.lt.args, (True, True))),
+            (self.param, self.lt, False),
             # 24
             (
                 self.param,
@@ -5423,6 +6615,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param, self.native2, True),
+            (
+                self.param,
+                self.le2,
+                RangedExpression((6,) + self.le2.args, (True, False)),
+            ),
+            (self.param, self.lt2, False),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5558,6 +6756,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.param_mut, 8), True),
             ),
+            (
+                self.param_mut,
+                self.le2,
+                RangedExpression((self.param_mut,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.param_mut,
+                self.lt2,
+                RangedExpression((self.param_mut,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5649,6 +6857,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.var, self.native2, InequalityExpression((self.var, 8), True)),
+            (
+                self.var,
+                self.le2,
+                RangedExpression((self.var,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.var,
+                self.lt2,
+                RangedExpression((self.var,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5788,6 +7006,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.mon_native, 8), True),
             ),
+            (
+                self.mon_native,
+                self.le2,
+                RangedExpression((self.mon_native,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mon_native,
+                self.lt2,
+                RangedExpression((self.mon_native,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5923,6 +7151,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 InequalityExpression((self.mon_param, 8), True),
             ),
+            (
+                self.mon_param,
+                self.le2,
+                RangedExpression((self.mon_param,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mon_param,
+                self.lt2,
+                RangedExpression((self.mon_param,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6034,6 +7272,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mon_npv, self.native2, InequalityExpression((self.mon_npv, 8), True)),
+            (
+                self.mon_npv,
+                self.le2,
+                RangedExpression((self.mon_npv,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mon_npv,
+                self.lt2,
+                RangedExpression((self.mon_npv,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6145,6 +7393,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.linear, self.native2, InequalityExpression((self.linear, 8), True)),
+            (
+                self.linear,
+                self.le2,
+                RangedExpression(((self.linear,) + self.le2.args), (True, False)),
+            ),
+            (
+                self.linear,
+                self.lt2,
+                RangedExpression(((self.linear,) + self.lt2.args), (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6236,6 +7494,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.sum, self.native2, InequalityExpression((self.sum, 8), True)),
+            (
+                self.sum,
+                self.le2,
+                RangedExpression((self.sum,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.sum,
+                self.lt2,
+                RangedExpression((self.sum,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6335,6 +7603,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.other, self.native2, InequalityExpression((self.other, 8), True)),
+            (
+                self.other,
+                self.le2,
+                RangedExpression((self.other,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.other,
+                self.lt2,
+                RangedExpression((self.other,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6442,6 +7720,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l0, self.native2, True),
+            (
+                self.mutable_l0,
+                self.le2,
+                RangedExpression((self.l0,) + self.le2.args, (True, False)),
+            ),
+            (self.mutable_l0, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6553,6 +7837,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l1, self.native2, InequalityExpression((self.l1, 8), True)),
+            (
+                self.mutable_l1,
+                self.le2,
+                RangedExpression((self.l1,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mutable_l1,
+                self.lt2,
+                RangedExpression((self.l1,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6664,6 +7958,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l2, self.native2, InequalityExpression((self.l2, 8), True)),
+            (
+                self.mutable_l2,
+                self.le2,
+                RangedExpression((self.l2,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mutable_l2,
+                self.lt2,
+                RangedExpression((self.l2,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6727,6 +8031,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param0, self.native2, True),
+            (
+                self.param0,
+                self.le2,
+                RangedExpression((0,) + self.le2.args, (True, False)),
+            ),
+            (self.param0, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6790,6 +8100,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.param1, self.native2, True),
+            (
+                self.param1,
+                self.le2,
+                RangedExpression((1,) + self.le2.args, (True, False)),
+            ),
+            (self.param1, self.lt2, self.lt2),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6901,6 +8217,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.mutable_l3, self.native2, InequalityExpression((self.l3, 8), True)),
+            (
+                self.mutable_l3,
+                self.le2,
+                RangedExpression((self.l3,) + self.le2.args, (True, False)),
+            ),
+            (
+                self.mutable_l3,
+                self.lt2,
+                RangedExpression((self.l3,) + self.lt2.args, (True, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7063,6 +8389,18 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.eq,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.eq,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7200,6 +8538,18 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.native2,
                 RangedExpression((self.le.args + (8,)), (False, True)),
             ),
+            (
+                self.le,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7309,6 +8659,18 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions are relational expressions",
             ),
             (self.lt, self.native2, self.lt),
+            (
+                self.lt,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7471,6 +8833,18 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.ranged,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.ranged,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7525,11 +8899,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.le,
                 RangedExpression((8,) + self.le.args, (True, False)),
             ),
-            (
-                self.native2,
-                self.lt,
-                RangedExpression((8,) + self.lt.args, (True, True)),
-            ),
+            (self.native2, self.lt, False),
             # 24
             (
                 self.native2,
@@ -7538,5 +8908,289 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "sub-expressions is a relational expression",
             ),
             (self.native2, self.native2, False),
+            (
+                self.native2,
+                self.le2,
+                RangedExpression((8,) + self.le2.args, (True, False)),
+            ),
+            (self.native2, self.lt2, False),
+        ]
+        self._run_cases(tests, operator.lt)
+
+    def test_lt_le2(self):
+        tests = [
+            (self.le2, self.invalid, NotImplemented),
+            (
+                self.le2,
+                self.asbinary,
+                RangedExpression((self.le2.args + (self.bin,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.zero,
+                RangedExpression((self.le2.args + (0,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.one,
+                RangedExpression((self.le2.args + (1,)), (False, True)),
+            ),
+            # 4:
+            (
+                self.le2,
+                self.native,
+                RangedExpression((self.le2.args + (5,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.npv,
+                RangedExpression((self.le2.args + (self.npv,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.param,
+                RangedExpression((self.le2.args + (6,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.param_mut,
+                RangedExpression((self.le2.args + (self.param_mut,)), (False, True)),
+            ),
+            # 8:
+            (
+                self.le2,
+                self.var,
+                RangedExpression((self.le2.args + (self.var,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.mon_native,
+                RangedExpression((self.le2.args + (self.mon_native,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.mon_param,
+                RangedExpression((self.le2.args + (self.mon_param,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.mon_npv,
+                RangedExpression((self.le2.args + (self.mon_npv,)), (False, True)),
+            ),
+            # 12:
+            (
+                self.le2,
+                self.linear,
+                RangedExpression((self.le2.args + (self.linear,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.sum,
+                RangedExpression((self.le2.args + (self.sum,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.other,
+                RangedExpression((self.le2.args + (self.other,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.mutable_l0,
+                RangedExpression((self.le2.args + (self.l0,)), (False, True)),
+            ),
+            # 16:
+            (
+                self.le2,
+                self.mutable_l1,
+                RangedExpression((self.le2.args + (self.l1,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.mutable_l2,
+                RangedExpression((self.le2.args + (self.l2,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.param0,
+                RangedExpression((self.le2.args + (0,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.param1,
+                RangedExpression((self.le2.args + (1,)), (False, True)),
+            ),
+            # 20:
+            (
+                self.le2,
+                self.mutable_l3,
+                RangedExpression((self.le2.args + (self.l3,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.eq,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.le,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.le2,
+                self.ranged,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.native2,
+                RangedExpression((self.le2.args + (8,)), (False, True)),
+            ),
+            (
+                self.le2,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.le2,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+        ]
+        self._run_cases(tests, operator.lt)
+
+    def test_lt_lt2(self):
+        tests = [
+            (self.lt2, self.invalid, NotImplemented),
+            (
+                self.lt2,
+                self.asbinary,
+                RangedExpression((self.lt2.args + (self.bin,)), (True, True)),
+            ),
+            (self.lt2, self.zero, False),
+            (self.lt2, self.one, False),
+            # 4:
+            (self.lt2, self.native, False),
+            (
+                self.lt2,
+                self.npv,
+                RangedExpression((self.lt2.args + (self.npv,)), (True, True)),
+            ),
+            (self.lt2, self.param, False),
+            (
+                self.lt2,
+                self.param_mut,
+                RangedExpression((self.lt2.args + (self.param_mut,)), (True, True)),
+            ),
+            # 8:
+            (
+                self.lt2,
+                self.var,
+                RangedExpression((self.lt2.args + (self.var,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.mon_native,
+                RangedExpression((self.lt2.args + (self.mon_native,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.mon_param,
+                RangedExpression((self.lt2.args + (self.mon_param,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.mon_npv,
+                RangedExpression((self.lt2.args + (self.mon_npv,)), (True, True)),
+            ),
+            # 12:
+            (
+                self.lt2,
+                self.linear,
+                RangedExpression((self.lt2.args + (self.linear,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.sum,
+                RangedExpression((self.lt2.args + (self.sum,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.other,
+                RangedExpression((self.lt2.args + (self.other,)), (True, True)),
+            ),
+            (self.lt2, self.mutable_l0, False),
+            # 16:
+            (
+                self.lt2,
+                self.mutable_l1,
+                RangedExpression((self.lt2.args + (self.l1,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.mutable_l2,
+                RangedExpression((self.lt2.args + (self.l2,)), (True, True)),
+            ),
+            (self.lt2, self.param0, False),
+            (self.lt2, self.param1, False),
+            # 20:
+            (
+                self.lt2,
+                self.mutable_l3,
+                RangedExpression((self.lt2.args + (self.l3,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.eq,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.le,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            # 24
+            (
+                self.lt2,
+                self.ranged,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.native2,
+                RangedExpression((self.lt2.args + (8,)), (True, True)),
+            ),
+            (
+                self.lt2,
+                self.le2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt2,
+                self.lt2,
+                "Cannot create an InequalityExpression where both "
+                "sub-expressions are relational expressions",
+            ),
         ]
         self._run_cases(tests, operator.lt)

--- a/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
+++ b/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseRelational(Base):
-    NUM_TESTS = 25
+    NUM_TESTS = 26
 
     def tearDown(self):
         pass
@@ -62,6 +62,7 @@ class BaseRelational(Base):
         # self.m.d = Disjunct()
         # self.bin = self.m.d.indicator_var.as_numeric()
 
+        self.native2 = 8
         self.eq = self.m.x == self.m.q
         self.le = self.m.x <= self.m.q
         self.lt = self.m.x < self.m.p
@@ -101,7 +102,9 @@ class BaseRelational(Base):
                 self.eq,
                 self.le,
                 self.lt,
+                # 24:
                 self.ranged,
+                self.native2,
             ]
         )
 
@@ -151,6 +154,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
             (self.invalid, self.lt, False),
             # 24:
             (self.invalid, self.ranged, False),
+            (self.invalid, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -219,6 +223,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.asbinary, self.native2, EqualityExpression((self.bin, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -275,6 +280,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.zero, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -331,6 +337,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.one, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -387,6 +394,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.native, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -447,6 +455,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.npv, self.native2, EqualityExpression((self.npv, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -503,6 +512,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -603,6 +613,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param_mut, self.native2, EqualityExpression((self.param_mut, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -663,6 +674,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.var, self.native2, EqualityExpression((self.var, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -775,6 +787,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mon_native, self.native2, EqualityExpression((self.mon_native, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -875,6 +888,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mon_param, self.native2, EqualityExpression((self.mon_param, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -967,6 +981,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mon_npv, self.native2, EqualityExpression((self.mon_npv, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1039,6 +1054,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.linear, self.native2, EqualityExpression((self.linear, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1099,6 +1115,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.sum, self.native2, EqualityExpression((self.sum, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1167,6 +1184,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.other, self.native2, EqualityExpression((self.other, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1239,6 +1257,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l0, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1311,6 +1330,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l1, self.native2, EqualityExpression((self.l1, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1383,6 +1403,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l2, self.native2, EqualityExpression((self.l2, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1439,6 +1460,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param0, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1495,6 +1517,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param1, self.native2, False),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1567,6 +1590,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l3, self.native2, EqualityExpression((self.l3, 8))),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -1722,6 +1746,12 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 self.ranged,
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
+            ),
+            (
+                self.eq,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
             ),
         ]
         self._run_cases(tests, operator.eq)
@@ -1879,6 +1909,12 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.le,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -2034,6 +2070,12 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 self.ranged,
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
+            ),
+            (
+                self.lt,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
             ),
         ]
         self._run_cases(tests, operator.eq)
@@ -2191,6 +2233,69 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.ranged,
+                self.native2,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+        ]
+        self._run_cases(tests, operator.eq)
+
+    def test_eq_native2(self):
+        tests = [
+            (self.native2, self.invalid, False),
+            (self.native2, self.asbinary, EqualityExpression((self.bin, 8))),
+            (self.native2, self.zero, False),
+            (self.native2, self.one, False),
+            # 4:
+            (self.native2, self.native, False),
+            (self.native2, self.npv, EqualityExpression((self.npv, 8))),
+            (self.native2, self.param, False),
+            (self.native2, self.param_mut, EqualityExpression((self.param_mut, 8))),
+            # 8:
+            (self.native2, self.var, EqualityExpression((self.var, 8))),
+            (self.native2, self.mon_native, EqualityExpression((self.mon_native, 8))),
+            (self.native2, self.mon_param, EqualityExpression((self.mon_param, 8))),
+            (self.native2, self.mon_npv, EqualityExpression((self.mon_npv, 8))),
+            # 12:
+            (self.native2, self.linear, EqualityExpression((self.linear, 8))),
+            (self.native2, self.sum, EqualityExpression((self.sum, 8))),
+            (self.native2, self.other, EqualityExpression((self.other, 8))),
+            (self.native2, self.mutable_l0, False),
+            # 16:
+            (self.native2, self.mutable_l1, EqualityExpression((self.l1, 8))),
+            (self.native2, self.mutable_l2, EqualityExpression((self.l2, 8))),
+            (self.native2, self.param0, False),
+            (self.native2, self.param1, False),
+            # 20:
+            (self.native2, self.mutable_l3, EqualityExpression((self.l3, 8))),
+            (
+                self.native2,
+                self.eq,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native2,
+                self.le,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native2,
+                self.lt,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            # 24
+            (
+                self.native2,
+                self.ranged,
+                "Cannot create an EqualityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (self.native2, self.native2, True),
         ]
         self._run_cases(tests, operator.eq)
 
@@ -2240,6 +2345,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
             (self.invalid, self.lt, NotImplemented),
             # 24:
             (self.invalid, self.ranged, NotImplemented),
+            (self.invalid, self.native2, NotImplemented),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2350,6 +2456,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.asbinary, self.native2, InequalityExpression((self.bin, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2408,6 +2515,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.zero, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2466,6 +2574,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.one, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2532,6 +2641,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.native, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2626,6 +2736,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.npv, self.native2, InequalityExpression((self.npv, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2688,6 +2799,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2822,6 +2934,11 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.param_mut,
+                self.native2,
+                InequalityExpression((self.param_mut, 8), False),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -2916,6 +3033,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.var, self.native2, InequalityExpression((self.var, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3049,6 +3167,11 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.ranged,
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
+            ),
+            (
+                self.mon_native,
+                self.native2,
+                InequalityExpression((self.mon_native, 8), False),
             ),
         ]
         self._run_cases(tests, operator.le)
@@ -3184,6 +3307,11 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.mon_param,
+                self.native2,
+                InequalityExpression((self.mon_param, 8), False),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3293,6 +3421,11 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.ranged,
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
+            ),
+            (
+                self.mon_npv,
+                self.native2,
+                InequalityExpression((self.mon_npv, 8), False),
             ),
         ]
         self._run_cases(tests, operator.le)
@@ -3404,6 +3537,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.linear, self.native2, InequalityExpression((self.linear, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3498,6 +3632,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.sum, self.native2, InequalityExpression((self.sum, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3596,6 +3731,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.other, self.native2, InequalityExpression((self.other, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3702,6 +3838,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l0, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3812,6 +3949,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l1, self.native2, InequalityExpression((self.l1, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3922,6 +4060,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l2, self.native2, InequalityExpression((self.l2, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -3988,6 +4127,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param0, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4054,6 +4194,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param1, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4164,6 +4305,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l3, self.native2, InequalityExpression((self.l3, 8), False)),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4320,6 +4462,12 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.eq,
+                self.native2,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4456,6 +4604,11 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.le,
+                self.native2,
+                RangedExpression((self.le.args + (8,)), (False, False)),
+            ),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4467,28 +4620,16 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.asbinary,
                 RangedExpression((self.lt.args + (self.bin,)), (True, False)),
             ),
-            (
-                self.lt,
-                self.zero,
-                RangedExpression((self.lt.args + (0,)), (True, False)),
-            ),
-            (self.lt, self.one, RangedExpression((self.lt.args + (1,)), (True, False))),
+            (self.lt, self.zero, False),
+            (self.lt, self.one, False),
             # 4:
-            (
-                self.lt,
-                self.native,
-                RangedExpression((self.lt.args + (5,)), (True, False)),
-            ),
+            (self.lt, self.native, False),
             (
                 self.lt,
                 self.npv,
                 RangedExpression((self.lt.args + (self.npv,)), (True, False)),
             ),
-            (
-                self.lt,
-                self.param,
-                RangedExpression((self.lt.args + (6,)), (True, False)),
-            ),
+            (self.lt, self.param, self.lt),
             (
                 self.lt,
                 self.param_mut,
@@ -4531,11 +4672,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.other,
                 RangedExpression((self.lt.args + (self.other,)), (True, False)),
             ),
-            (
-                self.lt,
-                self.mutable_l0,
-                RangedExpression((self.lt.args + (self.l0,)), (True, False)),
-            ),
+            (self.lt, self.mutable_l0, False),
             # 16:
             (
                 self.lt,
@@ -4547,16 +4684,8 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.mutable_l2,
                 RangedExpression((self.lt.args + (self.l2,)), (True, False)),
             ),
-            (
-                self.lt,
-                self.param0,
-                RangedExpression((self.lt.args + (0,)), (True, False)),
-            ),
-            (
-                self.lt,
-                self.param1,
-                RangedExpression((self.lt.args + (1,)), (True, False)),
-            ),
+            (self.lt, self.param0, False),
+            (self.lt, self.param1, False),
             # 20:
             (
                 self.lt,
@@ -4588,6 +4717,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (self.lt, self.native2, self.lt),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4744,6 +4874,83 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.ranged,
+                self.native2,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+        ]
+        self._run_cases(tests, operator.le)
+
+    def test_le_native2(self):
+        tests = [
+            (self.native2, self.invalid, NotImplemented),
+            (self.native2, self.asbinary, InequalityExpression((8, self.bin), False)),
+            (self.native2, self.zero, False),
+            (self.native2, self.one, False),
+            # 4:
+            (self.native2, self.native, False),
+            (self.native2, self.npv, InequalityExpression((8, self.npv), False)),
+            (self.native2, self.param, False),
+            (
+                self.native2,
+                self.param_mut,
+                InequalityExpression((8, self.param_mut), False),
+            ),
+            # 8:
+            (self.native2, self.var, InequalityExpression((8, self.var), False)),
+            (
+                self.native2,
+                self.mon_native,
+                InequalityExpression((8, self.mon_native), False),
+            ),
+            (
+                self.native2,
+                self.mon_param,
+                InequalityExpression((8, self.mon_param), False),
+            ),
+            (
+                self.native2,
+                self.mon_npv,
+                InequalityExpression((8, self.mon_npv), False),
+            ),
+            # 12:
+            (self.native2, self.linear, InequalityExpression((8, self.linear), False)),
+            (self.native2, self.sum, InequalityExpression((8, self.sum), False)),
+            (self.native2, self.other, InequalityExpression((8, self.other), False)),
+            (self.native2, self.mutable_l0, False),
+            # 16:
+            (self.native2, self.mutable_l1, InequalityExpression((8, self.l1), False)),
+            (self.native2, self.mutable_l2, InequalityExpression((8, self.l2), False)),
+            (self.native2, self.param0, False),
+            (self.native2, self.param1, False),
+            # 20:
+            (self.native2, self.mutable_l3, InequalityExpression((8, self.l3), False)),
+            (
+                self.native2,
+                self.eq,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native2,
+                self.le,
+                RangedExpression((8,) + self.le.args, (False, False)),
+            ),
+            (
+                self.native2,
+                self.lt,
+                RangedExpression((8,) + self.lt.args, (False, True)),
+            ),
+            # 24
+            (
+                self.native2,
+                self.ranged,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (self.native2, self.native2, True),
         ]
         self._run_cases(tests, operator.le)
 
@@ -4793,6 +5000,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
             (self.invalid, self.lt, NotImplemented),
             # 24:
             (self.invalid, self.ranged, NotImplemented),
+            (self.invalid, self.native2, NotImplemented),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -4891,6 +5099,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.asbinary, self.native2, InequalityExpression((self.bin, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -4949,6 +5158,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.zero, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -4999,6 +5209,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.one, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5061,6 +5272,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.native, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5151,6 +5363,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.npv, self.native2, InequalityExpression((self.npv, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5209,6 +5422,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5339,6 +5553,11 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.param_mut,
+                self.native2,
+                InequalityExpression((self.param_mut, 8), True),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5429,6 +5648,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.var, self.native2, InequalityExpression((self.var, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5563,6 +5783,11 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.mon_native,
+                self.native2,
+                InequalityExpression((self.mon_native, 8), True),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5693,6 +5918,11 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (
+                self.mon_param,
+                self.native2,
+                InequalityExpression((self.mon_param, 8), True),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5803,6 +6033,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mon_npv, self.native2, InequalityExpression((self.mon_npv, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -5913,6 +6144,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.linear, self.native2, InequalityExpression((self.linear, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6003,6 +6235,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.sum, self.native2, InequalityExpression((self.sum, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6101,6 +6334,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.other, self.native2, InequalityExpression((self.other, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6207,6 +6441,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l0, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6317,6 +6552,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l1, self.native2, InequalityExpression((self.l1, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6427,6 +6663,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l2, self.native2, InequalityExpression((self.l2, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6489,6 +6726,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param0, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6551,6 +6789,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.param1, self.native2, True),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6661,6 +6900,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
+            (self.mutable_l3, self.native2, InequalityExpression((self.l3, 8), True)),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6817,6 +7057,12 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.eq,
+                self.native2,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6949,6 +7195,11 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.le,
+                self.native2,
+                RangedExpression((self.le.args + (8,)), (False, True)),
+            ),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -6960,24 +7211,16 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.asbinary,
                 RangedExpression((self.lt.args + (self.bin,)), (True, True)),
             ),
-            (self.lt, self.zero, RangedExpression((self.lt.args + (0,)), (True, True))),
-            (self.lt, self.one, RangedExpression((self.lt.args + (1,)), (True, True))),
+            (self.lt, self.zero, False),
+            (self.lt, self.one, False),
             # 4:
-            (
-                self.lt,
-                self.native,
-                RangedExpression((self.lt.args + (5,)), (True, True)),
-            ),
+            (self.lt, self.native, False),
             (
                 self.lt,
                 self.npv,
                 RangedExpression((self.lt.args + (self.npv,)), (True, True)),
             ),
-            (
-                self.lt,
-                self.param,
-                RangedExpression((self.lt.args + (6,)), (True, True)),
-            ),
+            (self.lt, self.param, False),
             (
                 self.lt,
                 self.param_mut,
@@ -7020,11 +7263,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.other,
                 RangedExpression((self.lt.args + (self.other,)), (True, True)),
             ),
-            (
-                self.lt,
-                self.mutable_l0,
-                RangedExpression((self.lt.args + (self.l0,)), (True, True)),
-            ),
+            (self.lt, self.mutable_l0, False),
             # 16:
             (
                 self.lt,
@@ -7036,16 +7275,8 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.mutable_l2,
                 RangedExpression((self.lt.args + (self.l2,)), (True, True)),
             ),
-            (
-                self.lt,
-                self.param0,
-                RangedExpression((self.lt.args + (0,)), (True, True)),
-            ),
-            (
-                self.lt,
-                self.param1,
-                RangedExpression((self.lt.args + (1,)), (True, True)),
-            ),
+            (self.lt, self.param0, False),
+            (self.lt, self.param1, False),
             # 20:
             (
                 self.lt,
@@ -7077,6 +7308,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (self.lt, self.native2, self.lt),
         ]
         self._run_cases(tests, operator.lt)
 
@@ -7233,5 +7465,78 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
+            (
+                self.ranged,
+                self.native2,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+        ]
+        self._run_cases(tests, operator.lt)
+
+    def test_lt_native2(self):
+        tests = [
+            (self.native2, self.invalid, NotImplemented),
+            (self.native2, self.asbinary, InequalityExpression((8, self.bin), True)),
+            (self.native2, self.zero, False),
+            (self.native2, self.one, False),
+            # 4:
+            (self.native2, self.native, False),
+            (self.native2, self.npv, InequalityExpression((8, self.npv), True)),
+            (self.native2, self.param, False),
+            (
+                self.native2,
+                self.param_mut,
+                InequalityExpression((8, self.param_mut), True),
+            ),
+            # 8:
+            (self.native2, self.var, InequalityExpression((8, self.var), True)),
+            (
+                self.native2,
+                self.mon_native,
+                InequalityExpression((8, self.mon_native), True),
+            ),
+            (
+                self.native2,
+                self.mon_param,
+                InequalityExpression((8, self.mon_param), True),
+            ),
+            (self.native2, self.mon_npv, InequalityExpression((8, self.mon_npv), True)),
+            # 12:
+            (self.native2, self.linear, InequalityExpression((8, self.linear), True)),
+            (self.native2, self.sum, InequalityExpression((8, self.sum), True)),
+            (self.native2, self.other, InequalityExpression((8, self.other), True)),
+            (self.native2, self.mutable_l0, False),
+            # 16:
+            (self.native2, self.mutable_l1, InequalityExpression((8, self.l1), True)),
+            (self.native2, self.mutable_l2, InequalityExpression((8, self.l2), True)),
+            (self.native2, self.param0, False),
+            (self.native2, self.param1, False),
+            # 20:
+            (self.native2, self.mutable_l3, InequalityExpression((8, self.l3), True)),
+            (
+                self.native2,
+                self.eq,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (
+                self.native2,
+                self.le,
+                RangedExpression((8,) + self.le.args, (True, False)),
+            ),
+            (
+                self.native2,
+                self.lt,
+                RangedExpression((8,) + self.lt.args, (True, True)),
+            ),
+            # 24
+            (
+                self.native2,
+                self.ranged,
+                "Cannot create an InequalityExpression where one of the "
+                "sub-expressions is a relational expression",
+            ),
+            (self.native2, self.native2, False),
         ]
         self._run_cases(tests, operator.lt)

--- a/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
+++ b/pyomo/core/tests/unit/test_relational_expr_dispatcher.py
@@ -222,7 +222,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.asbinary,
                 self.ranged,
@@ -291,7 +291,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.zero,
                 self.ranged,
@@ -360,7 +360,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.one,
                 self.ranged,
@@ -429,7 +429,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.native,
                 self.ranged,
@@ -502,7 +502,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.npv,
                 self.ranged,
@@ -571,7 +571,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.param,
                 self.ranged,
@@ -684,7 +684,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.param_mut,
                 self.ranged,
@@ -757,7 +757,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.var,
                 self.ranged,
@@ -882,7 +882,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mon_native,
                 self.ranged,
@@ -995,7 +995,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mon_param,
                 self.ranged,
@@ -1100,7 +1100,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mon_npv,
                 self.ranged,
@@ -1185,7 +1185,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.linear,
                 self.ranged,
@@ -1258,7 +1258,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.sum,
                 self.ranged,
@@ -1339,7 +1339,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.other,
                 self.ranged,
@@ -1424,7 +1424,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l0,
                 self.ranged,
@@ -1509,7 +1509,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l1,
                 self.ranged,
@@ -1594,7 +1594,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l2,
                 self.ranged,
@@ -1663,7 +1663,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.param0,
                 self.ranged,
@@ -1732,7 +1732,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.param1,
                 self.ranged,
@@ -1817,7 +1817,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l3,
                 self.ranged,
@@ -1986,7 +1986,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.eq,
                 self.ranged,
@@ -2160,7 +2160,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le,
                 self.ranged,
@@ -2334,7 +2334,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt,
                 self.ranged,
@@ -2508,7 +2508,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.ranged,
                 self.ranged,
@@ -2582,7 +2582,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where one of the "
                 "sub-expressions is a relational expression",
             ),
-            # 24
+            # 24:
             (
                 self.native2,
                 self.ranged,
@@ -2751,7 +2751,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le2,
                 self.ranged,
@@ -2925,7 +2925,7 @@ class TestEquality(BaseRelational, unittest.TestCase):
                 "Cannot create an EqualityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt2,
                 self.ranged,
@@ -3105,7 +3105,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.bin,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.asbinary,
                 self.ranged,
@@ -3174,7 +3174,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
             ),
             (self.zero, self.le, RangedExpression((0,) + self.le.args, (False, False))),
             (self.zero, self.lt, RangedExpression((0,) + self.lt.args, (False, True))),
-            # 24
+            # 24:
             (
                 self.zero,
                 self.ranged,
@@ -3239,7 +3239,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
             ),
             (self.one, self.le, RangedExpression((1,) + self.le.args, (False, False))),
             (self.one, self.lt, RangedExpression((1,) + self.lt.args, (False, True))),
-            # 24
+            # 24:
             (
                 self.one,
                 self.ranged,
@@ -3312,7 +3312,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((5,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.native,
                 self.ranged,
@@ -3413,7 +3413,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.npv,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.npv,
                 self.ranged,
@@ -3486,7 +3486,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((6,) + self.le.args, (False, False)),
             ),
             (self.param, self.lt, False),
-            # 24
+            # 24:
             (
                 self.param,
                 self.ranged,
@@ -3627,7 +3627,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.param_mut,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.param_mut,
                 self.ranged,
@@ -3736,7 +3736,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.var,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.var,
                 self.ranged,
@@ -3881,7 +3881,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_native,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_native,
                 self.ranged,
@@ -4030,7 +4030,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_param,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_param,
                 self.ranged,
@@ -4155,7 +4155,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_npv,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_npv,
                 self.ranged,
@@ -4280,7 +4280,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression(((self.linear,) + self.lt.args), (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.linear,
                 self.ranged,
@@ -4385,7 +4385,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.sum,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.sum,
                 self.ranged,
@@ -4494,7 +4494,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.other,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.other,
                 self.ranged,
@@ -4611,7 +4611,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l0,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l0,
                 self.ranged,
@@ -4728,7 +4728,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l1,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l1,
                 self.ranged,
@@ -4849,7 +4849,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l2,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l2,
                 self.ranged,
@@ -4926,7 +4926,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((0,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.param0,
                 self.ranged,
@@ -4999,7 +4999,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((1,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.param1,
                 self.ranged,
@@ -5116,7 +5116,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l3,) + self.lt.args, (False, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l3,
                 self.ranged,
@@ -5283,7 +5283,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.eq,
                 self.ranged,
@@ -5437,7 +5437,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le,
                 self.ranged,
@@ -5562,7 +5562,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt,
                 self.ranged,
@@ -5731,7 +5731,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.ranged,
                 self.ranged,
@@ -5815,7 +5815,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((8,) + self.le.args, (False, False)),
             ),
             (self.native2, self.lt, False),
-            # 24
+            # 24:
             (
                 self.native2,
                 self.ranged,
@@ -5958,7 +5958,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le2,
                 self.ranged,
@@ -6083,7 +6083,7 @@ class TestInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt2,
                 self.ranged,
@@ -6250,7 +6250,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.bin,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.asbinary,
                 self.ranged,
@@ -6319,7 +6319,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
             ),
             (self.zero, self.le, RangedExpression((0,) + self.le.args, (True, False))),
             (self.zero, self.lt, RangedExpression((0,) + self.lt.args, (True, True))),
-            # 24
+            # 24:
             (
                 self.zero,
                 self.ranged,
@@ -6376,7 +6376,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
             ),
             (self.one, self.le, RangedExpression((1,) + self.le.args, (True, False))),
             (self.one, self.lt, RangedExpression((1,) + self.lt.args, (True, True))),
-            # 24
+            # 24:
             (
                 self.one,
                 self.ranged,
@@ -6441,7 +6441,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((5,) + self.le.args, (True, False)),
             ),
             (self.native, self.lt, RangedExpression((5,) + self.lt.args, (True, True))),
-            # 24
+            # 24:
             (
                 self.native,
                 self.ranged,
@@ -6538,7 +6538,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.npv,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.npv,
                 self.ranged,
@@ -6607,7 +6607,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
             ),
             (self.param, self.le, RangedExpression((6,) + self.le.args, (True, False))),
             (self.param, self.lt, False),
-            # 24
+            # 24:
             (
                 self.param,
                 self.ranged,
@@ -6744,7 +6744,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.param_mut,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.param_mut,
                 self.ranged,
@@ -6849,7 +6849,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.var,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.var,
                 self.ranged,
@@ -6994,7 +6994,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_native,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_native,
                 self.ranged,
@@ -7139,7 +7139,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_param,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_param,
                 self.ranged,
@@ -7264,7 +7264,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.mon_npv,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mon_npv,
                 self.ranged,
@@ -7385,7 +7385,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression(((self.linear,) + self.lt.args), (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.linear,
                 self.ranged,
@@ -7486,7 +7486,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.sum,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.sum,
                 self.ranged,
@@ -7595,7 +7595,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.other,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.other,
                 self.ranged,
@@ -7712,7 +7712,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l0,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l0,
                 self.ranged,
@@ -7829,7 +7829,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l1,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l1,
                 self.ranged,
@@ -7950,7 +7950,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l2,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l2,
                 self.ranged,
@@ -8023,7 +8023,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((0,) + self.le.args, (True, False)),
             ),
             (self.param0, self.lt, RangedExpression((0,) + self.lt.args, (True, True))),
-            # 24
+            # 24:
             (
                 self.param0,
                 self.ranged,
@@ -8092,7 +8092,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((1,) + self.le.args, (True, False)),
             ),
             (self.param1, self.lt, RangedExpression((1,) + self.lt.args, (True, True))),
-            # 24
+            # 24:
             (
                 self.param1,
                 self.ranged,
@@ -8209,7 +8209,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 self.lt,
                 RangedExpression((self.l3,) + self.lt.args, (True, True)),
             ),
-            # 24
+            # 24:
             (
                 self.mutable_l3,
                 self.ranged,
@@ -8376,7 +8376,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.eq,
                 self.ranged,
@@ -8526,7 +8526,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le,
                 self.ranged,
@@ -8651,7 +8651,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt,
                 self.ranged,
@@ -8820,7 +8820,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.ranged,
                 self.ranged,
@@ -8900,7 +8900,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 RangedExpression((8,) + self.le.args, (True, False)),
             ),
             (self.native2, self.lt, False),
-            # 24
+            # 24:
             (
                 self.native2,
                 self.ranged,
@@ -9043,7 +9043,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.le2,
                 self.ranged,
@@ -9168,7 +9168,7 @@ class TestStrictInequality(BaseRelational, unittest.TestCase):
                 "Cannot create an InequalityExpression where both "
                 "sub-expressions are relational expressions",
             ),
-            # 24
+            # 24:
             (
                 self.lt2,
                 self.ranged,

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -117,7 +117,12 @@ class ComplementarityData(BlockData):
             _e1, _e2 = _e2, _e1
         #
         if _e2[0] is None and _e2[2] is None:
-            self.c = Constraint(expr=(None, _e2[1], None))
+            # FIXME: this is making an unbounded RangedExpression -
+            # which makes little sense.  When we rework Complimentarity,
+            # we should determine how to avoid this overhead.
+            self.c = Constraint(
+                expr=EXPR.RangedExpression((None, _e2[1], None), strict=False)
+            )
             self.c._complementarity_type = 3
         elif _e2[2] is None:
             self.c = Constraint(expr=_e2[0] <= _e2[1])

--- a/pyomo/solvers/tests/models/LP_compiled.py
+++ b/pyomo/solvers/tests/models/LP_compiled.py
@@ -16,6 +16,7 @@ from pyomo.core import (
     RangeSet,
     ConstraintList,
 )
+from pyomo.core.expr import EqualityExpression, RangedExpression
 from pyomo.solvers.tests.models.base import _BaseTestModel, register_model
 from pyomo.repn.beta.matrix import compile_block_linear_constraints
 
@@ -82,27 +83,30 @@ class LP_compiled(_BaseTestModel):
         model.c.add((-1.0, model.x[10], -1.0))
         model.c.add((1.0, model.x[11], 1.0))
         model.c.add((1.0, model.x[12], 1.0))
-        cdata = model.c.add((0, 1, 3))
+        cdata = model.c.add(RangedExpression((0, 1, 3), False))
         assert cdata.lower == 0
         assert cdata.upper == 3
         assert cdata.body() == 1
         assert not cdata.equality
-        cdata = model.c.add((0, 2, 3))
+        cdata = model.c.add(RangedExpression((0, 2, 3), False))
         assert cdata.lower == 0
         assert cdata.upper == 3
         assert cdata.body() == 2
         assert not cdata.equality
-        cdata = model.c.add((0, 1, None))
+        # Note this is a redundant test, left in to preserve the
+        # baseline.  RangedExpression does not manipulate the arguments
+        # like the old tuple notation did.
+        cdata = model.c.add(RangedExpression((None, 0, 1), False))
         assert cdata.lower is None
         assert cdata.upper == 1
         assert cdata.body() == 0
         assert not cdata.equality
-        cdata = model.c.add((None, 0, 1))
+        cdata = model.c.add(RangedExpression((None, 0, 1), False))
         assert cdata.lower is None
         assert cdata.upper == 1
         assert cdata.body() == 0
         assert not cdata.equality
-        cdata = model.c.add((1, 1))
+        cdata = model.c.add(EqualityExpression((1, 1)))
         assert cdata.lower == 1
         assert cdata.upper == 1
         assert cdata.body() == 1

--- a/pyomo/solvers/tests/models/LP_trivial_constraints.py
+++ b/pyomo/solvers/tests/models/LP_trivial_constraints.py
@@ -16,6 +16,7 @@ from pyomo.core import (
     RangeSet,
     ConstraintList,
 )
+from pyomo.core.expr.relational_expr import EqualityExpression, RangedExpression
 from pyomo.solvers.tests.models.base import _BaseTestModel, register_model
 
 
@@ -45,27 +46,30 @@ class LP_trivial_constraints(_BaseTestModel):
         model.c = ConstraintList()
         model.c.add(model.x >= -2)
         model.c.add(model.y <= 3)
-        cdata = model.c.add((0, 1, 3))
+        cdata = model.c.add(RangedExpression((0, 1, 3), False))
         assert cdata.lower == 0
         assert cdata.upper == 3
         assert cdata.body() == 1
         assert not cdata.equality
-        cdata = model.c.add((0, 2, 3))
+        cdata = model.c.add(RangedExpression((0, 2, 3), False))
         assert cdata.lower == 0
         assert cdata.upper == 3
         assert cdata.body() == 2
         assert not cdata.equality
-        cdata = model.c.add((0, 1, None))
+        # Note this is a redundant test, left in to preserve the
+        # baseline.  RangedExpression does not manipulate the arguments
+        # like the old tuple notation did.
+        cdata = model.c.add(RangedExpression((None, 0, 1), False))
         assert cdata.lower is None
         assert cdata.upper == 1
         assert cdata.body() == 0
         assert not cdata.equality
-        cdata = model.c.add((None, 0, 1))
+        cdata = model.c.add(RangedExpression((None, 0, 1), False))
         assert cdata.lower is None
         assert cdata.upper == 1
         assert cdata.body() == 0
         assert not cdata.equality
-        cdata = model.c.add((1, 1))
+        cdata = model.c.add(EqualityExpression((1, 1)))
         assert cdata.lower == 1
         assert cdata.upper == 1
         assert cdata.body() == 1


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #2093 .

## Summary/Motivation:

The original motivation of this PR was to resolve #2093.  The Issue stemmed from the `ConstraintData.equality` property sometimes returning False for things that are obviously equality constraints due to the use of `is` for comparing the lower and upper bounds.  This PR makes a modification of the property so that `native_types` in the lower/upper bounds are compared using `==` and everything else is compared with `is`.  This is related to the (abandoned) PR #2097), where we used `is_constant()` to determine if we should use `==` or `is`.  The difference here is the switch to `native_types` - both for efficiency and clarity of the intent.

As part of working through this, we came across inconsistencies in when constant expressions were resolved: the move of the relational expression generation logic to a multiple dispatch model caused constant relational expressions generated from operator overloading to be resolved to `bool`.  This behavior was *not* promulgated to the `inequality()` function, or to the specification of constraints using "tuple notation".  This PR overhauls `inequality()` and the tuple processing to be consistent with the relational expression logic.  It also removed redundant logic, and funnels all expression generation through the relational expression dispatchers.

### Update [13 Apr]

Resolved a number of additional edge cases, mostly related to resolving trivial portions of ranged constraints, including 
- `inequality(0, 0, None)` should be `True` (and not 0), and 
- Ranged constraints should check that trivial bounds are feasible (e.g., `inequality(1, m.x, 0)` should be `False`).

As part of this update, I added about 2000 lines of relational expression tests.  Unfortunately, GitHub gets confused when trying to render the diff.  The actual changes are adding 3 arguments (`native2` (a larger native constant) and `le2` / `lt2` which are the same as `le` / `lt`, but with the argument order reversed).  This meant adding 3 tests to the end of each test method, plus adding 3 new test methods (`test_XX_native2`, `test_XX_le2`, and `test_XX_lt2`) for each of the 3 test classes.

Buried in this are a handful of baseline changes, all due to the expression system being more thorough and consistent with resolving constant portions of expressions when generating expressions.

## Changes proposed in this PR:
- use `==` for comparing constraint bounds for `native_types` in `ConstraintData.equality`
- rework `inequality()` to build on relational expression dispatcher
- improve implementation of `tuple_to_relational_expr` to make it consistent with constraint behavior (and build on `inequality()`)
- simplify `ConstraintData.set_value()` to call `tuple_to_relational_expr`
- add workarounds for unbounded constraints in the `nonnegative_transform` and `Complementarity`
- update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
