### PR TITLE
Add pre-commit hooks for black formatting and spell-checking

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -81,6 +81,4 @@ Bimap = "Bimap"
 cmo = "cmo"
 # Substituters
 Substituters = "Substituters"
-# numpy array.flags.writeable property - not a typo
-writeable = "writeable"
 # AS NEEDED: Add More Words Below

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -81,4 +81,6 @@ Bimap = "Bimap"
 cmo = "cmo"
 # Substituters
 Substituters = "Substituters"
+# numpy array.flags.writeable property - not a typo
+writeable = "writeable"
 # AS NEEDED: Add More Words Below

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Pre-commit hooks for Pyomo
+# See https://pre-commit.com for more information
+#
+# Setup (one-time):
+#   pip install pre-commit
+#   pre-commit install
+#
+# After setup, hooks run automatically on 'git commit'
+# To run manually on all files: pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        # Exclusions match pyproject.toml [tool.black] extend-exclude
+        exclude: |
+          (?x)^(
+            examples/pyomobook/python-ch/BadIndent\.py|
+            pyomo/tpl/.*|
+            pyomo/dataportal/_parse_table_datacmds\.py
+          )$
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.27.0
+    hooks:
+      - id: typos
+        args: ["--config", ".github/workflows/typos.toml"]

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -49,6 +49,28 @@ determine correct configuration, so if you are running ``black``
 indirectly (for example, using an IDE integration), please ensure you
 are not overriding the project-level configuration set in that file.
 
+Pre-commit Hooks (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To avoid formatting failures in CI, you can set up
+`pre-commit <https://pre-commit.com/>`_ hooks that automatically run
+``black`` and the spell-checker on staged files before each commit:
+
+::
+
+   pip install pre-commit
+   pre-commit install
+
+After installation, hooks run automatically when you run ``git commit``.
+To manually run hooks on all files:
+
+::
+
+   pre-commit run --all-files
+
+This is optional but recommended, as it catches formatting and spelling
+issues locally before they reach CI.
+
 Online Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
 with the ``napoleon`` extension enabled. For API documentation we use of one of these 
 `supported styles for docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_, 


### PR DESCRIPTION
Fixes #3895

## Summary

Adds optional pre-commit hooks to help contributors catch formatting and spelling issues locally before CI.

## Changes

- Add `.pre-commit-config.yaml` with:
  - `black` hook (exclusions match `pyproject.toml`)
  - `typos` hook (uses existing `.github/workflows/typos.toml` config)
- Update `contribution_guide.rst` with setup instructions

## Usage (Optional)

```bash
pip install pre-commit
pre-commit install
```

After setup, hooks run automatically on `git commit` for staged files only.

### Legal Acknowledgement

By contributing to this software project, I have read the contribution guide and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.