### PR TITLE
Update actions; exclude mathworks from URL checks

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -60,7 +60,7 @@ jobs:
           os: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update README.md
         shell: bash
         run: |
@@ -109,7 +109,7 @@ jobs:
           TARGET: 'py314'
           GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update README.md
         shell: bash
         run: |
@@ -142,7 +142,7 @@ jobs:
       matrix:
         python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update README.md
         shell: bash
         run: |
@@ -178,7 +178,7 @@ jobs:
           TARGET: generic_tarball
         python-version: ['3.10']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Update README.md
       shell: bash
       run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout Pyomo source
       uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Black Formatting Check
@@ -161,7 +161,7 @@ jobs:
             | tr '\n' ' ' | sed 's/ \+/ /g' >> $GITHUB_ENV
 
     #- name: Pip package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  if: matrix.PYENV == 'pip'
     #  id: pip-cache
     #  with:
@@ -169,7 +169,7 @@ jobs:
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: OS package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  if: matrix.TARGET != 'osx'
     #  id: os-cache
     #  with:
@@ -177,7 +177,7 @@ jobs:
     #    key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ ! matrix.slim }}
       id: download-cache
       with:
@@ -237,7 +237,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python }}
       if: matrix.PYENV == 'pip'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
 
@@ -785,7 +785,7 @@ jobs:
         coverage xml -i
 
     - name: Record build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
         include-hidden-files: true
@@ -806,7 +806,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
@@ -863,19 +863,19 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  id: pip-cache
     #  with:
     #    path: cache/pip
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.10
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
@@ -951,7 +951,7 @@ jobs:
 
     - name: Upload codecov reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: coverage.xml
         token: ${{ secrets.PYOMO_CODECOV_TOKEN }}
@@ -963,7 +963,7 @@ jobs:
       if: |
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: coverage-other.xml
         token: ${{ secrets.PYOMO_CODECOV_TOKEN }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -73,7 +73,8 @@ jobs:
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
         #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
-        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
+        #  - All www.mathworks.com links because MathWorks appears to reject from GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/,https://www.mathworks.com/
 
 
   build:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -140,7 +140,7 @@ jobs:
 
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure job parameters
       run: |
@@ -803,7 +803,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -859,7 +859,7 @@ jobs:
 
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Pyomo source
       uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Black Formatting Check
@@ -213,7 +213,7 @@ jobs:
             | tr '\n' ' ' | sed 's/ \+/ /g' >> $GITHUB_ENV
 
     #- name: Pip package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  if: matrix.PYENV == 'pip'
     #  id: pip-cache
     #  with:
@@ -221,7 +221,7 @@ jobs:
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: OS package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  if: matrix.TARGET != 'osx'
     #  id: os-cache
     #  with:
@@ -229,7 +229,7 @@ jobs:
     #    key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ ! matrix.slim }}
       id: download-cache
       with:
@@ -289,7 +289,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python }}
       if: matrix.PYENV == 'pip'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
 
@@ -837,7 +837,7 @@ jobs:
         coverage xml -i
 
     - name: Record build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
         include-hidden-files: true
@@ -859,7 +859,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
@@ -916,19 +916,19 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache
-    #  uses: actions/cache@v4
+    #  uses: actions/cache@v5
     #  id: pip-cache
     #  with:
     #    path: cache/pip
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.10
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
@@ -1004,7 +1004,7 @@ jobs:
 
     - name: Upload codecov reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: coverage.xml
         token: ${{ secrets.PYOMO_CODECOV_TOKEN }}
@@ -1016,7 +1016,7 @@ jobs:
       if: |
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: coverage-other.xml
         token: ${{ secrets.PYOMO_CODECOV_TOKEN }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -84,7 +84,8 @@ jobs:
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
         #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
-        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
+        #  - All www.mathworks.com links because MathWorks appears to reject from GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/,https://www.mathworks.com/
 
 
   build:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -192,7 +192,7 @@ jobs:
 
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure job parameters
       run: |
@@ -856,7 +856,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -912,7 +912,7 @@ jobs:
 
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -36,4 +36,4 @@ jobs:
         #  - All gnu.org links because they consistently fail the checker
         #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
         #  - All www.mathworks.com links because MathWorks appears to reject from GHA
-        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/,https://www.mathworks.com/

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -36,4 +36,4 @@ jobs:
         #  - All gnu.org links because they consistently fail the checker
         #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
         #  - All www.mathworks.com links because MathWorks appears to reject from GHA
-        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/,http://www.mathworks.com/
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -35,4 +35,5 @@ jobs:
         # Exclude:
         #  - All gnu.org links because they consistently fail the checker
         #  - All lpsolve.sourceforge.net links because SF appears to reject from GHA
-        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/
+        #  - All www.mathworks.com links because MathWorks appears to reject from GHA
+        exclude_patterns: https://www.gnu.org,https://lpsolve.sourceforge.net/,http://www.mathworks.com/

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: URL Checker
       uses: urlstechie/urlchecker-action@0.0.34
       with:

--- a/examples/dae/PDE_example.py
+++ b/examples/dae/PDE_example.py
@@ -7,7 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
-# Example 1 from http://www.mathworks.com/help/matlab/ref/pdepe.html
+# Example 1 from https://www.mathworks.com/help/matlab/ref/pdepe.html
 
 import pyomo.environ as pyo
 from pyomo.dae import ContinuousSet, DerivativeVar


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
We are getting deprecation warnings for GHA actions that use node<24.  This PR gets ahead of the September removeal by updating to the current release of most of the actions steps.

This also adds mathworks.com to the list of URLs excluded from the URL Checker: MathWorks urls are consistently failing (likely GHA is being blocked by MathWorks).

## Changes proposed in this PR:
- Update GHA step versions
- Add mathworks.com to the list of URLs ignored by the checker

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
