### PR TITLE
TrustRegion: remove direct manipulation of `sys.stdout` / `sys.__stdout__`

### DIFF
--- a/pyomo/contrib/trustregion/tests/test_TRF.py
+++ b/pyomo/contrib/trustregion/tests/test_TRF.py
@@ -15,10 +15,10 @@
 
 import logging
 import sys
-from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.tee import capture_output
 from pyomo.environ import (
     Var,
     ConcreteModel,
@@ -124,12 +124,13 @@ class TestTrustRegionConfig(unittest.TestCase):
             'trustregion', globalization_strategy='funnel'
         )  # Set Funnel strategy
 
-        log_OUTPUT = StringIO()
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             solve_status = self.try_solve()
-        sys.stdout = sys.__stdout__
 
         # Assertions
         self.assertTrue(solve_status)
@@ -141,12 +142,13 @@ class TestTrustRegionConfig(unittest.TestCase):
             'trustregion', globalization_strategy='filter'
         )  # Set Filter strategy (default)
 
-        log_OUTPUT = StringIO()
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             solve_status = self.try_solve()
-        sys.stdout = sys.__stdout__
 
         # Assertions
         self.assertTrue(solve_status)
@@ -259,19 +261,18 @@ class TestTrustRegionMethod(unittest.TestCase):
         self.decision_variables = [self.m.z[0], self.m.z[1], self.m.z[2]]
 
     def test_solver(self):
-        # Check the log contents
-        log_OUTPUT = StringIO()
-        # Check the printed contents
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             result = trust_region_method(
                 self.m,
                 self.decision_variables,
                 self.ext_fcn_surrogate_map_rule,
                 self.config,
             )
-        sys.stdout = sys.__stdout__
         # Check the log to make sure it is capturing
         self.assertIn('Iteration 0', log_OUTPUT.getvalue())
         # Check the printed output
@@ -314,12 +315,13 @@ class TestTrustRegionMethod(unittest.TestCase):
         )
 
         # Run the solver
-        log_OUTPUT = StringIO()
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             solve_status = self.TRF.solve(self.m, self.decision_variables)
-        sys.stdout = sys.__stdout__
 
         # Assertions
         self.assertTrue(solve_status)  # Solver should succeed

--- a/pyomo/contrib/trustregion/tests/test_examples.py
+++ b/pyomo/contrib/trustregion/tests/test_examples.py
@@ -14,11 +14,11 @@
 # ____________________________________________________________________________________
 
 import logging
-from io import StringIO
 import sys
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.tee import capture_output
 from pyomo.contrib.trustregion.examples import example1, example2
 from pyomo.environ import SolverFactory
 
@@ -30,14 +30,13 @@ logger = logging.getLogger('pyomo.contrib.trustregion')
 )
 class TestTrustRegionMethod(unittest.TestCase):
     def test_example1(self):
-        # Check the log contents
-        log_OUTPUT = StringIO()
-        # Check the printed contents
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             example1.main()
-        sys.stdout = sys.__stdout__
         # Check number of iterations - which should be 4 total
         self.assertIn('Iteration 0', log_OUTPUT.getvalue())
         self.assertIn('Iteration 4', log_OUTPUT.getvalue())
@@ -58,14 +57,13 @@ class TestTrustRegionMethod(unittest.TestCase):
         self.assertIn('None :   True : 0.2770447887637415', print_OUTPUT.getvalue())
 
     def test_example2(self):
-        # Check the log contents
-        log_OUTPUT = StringIO()
-        # Check the printed contents
-        print_OUTPUT = StringIO()
-        sys.stdout = print_OUTPUT
-        with LoggingIntercept(log_OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with (
+            capture_output() as print_OUTPUT,
+            LoggingIntercept(
+                None, 'pyomo.contrib.trustregion', logging.INFO
+            ) as log_OUTPUT,
+        ):
             example2.main()
-        sys.stdout = sys.__stdout__
         # Check the number of iterations - which should be 70ish, but not 80
         self.assertIn('Iteration 0', log_OUTPUT.getvalue())
         self.assertIn('Iteration 70', log_OUTPUT.getvalue())

--- a/pyomo/contrib/trustregion/tests/test_util.py
+++ b/pyomo/contrib/trustregion/tests/test_util.py
@@ -13,7 +13,6 @@
 # U.S. Department of Energy's Office of Fossil Energy and Carbon Management.
 # ____________________________________________________________________________________
 
-from io import StringIO
 import sys
 import logging
 
@@ -21,6 +20,7 @@ import pyomo.common.unittest as unittest
 
 from pyomo.contrib.trustregion.util import IterationLogger, minIgnoreNone, maxIgnoreNone
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.tee import capture_output
 
 
 class TestUtil(unittest.TestCase):
@@ -70,12 +70,12 @@ class TestUtil(unittest.TestCase):
         self.iterLogger.newIteration(
             self.iteration, self.thetak, self.objk, self.radius, self.stepNorm
         )
-        OUTPUT = StringIO()
-        with LoggingIntercept(OUTPUT, 'pyomo.contrib.trustregion', logging.INFO):
+        with LoggingIntercept(None, 'pyomo.contrib.trustregion', logging.INFO) as LOG:
             self.iterLogger.logIteration()
-        self.assertIn('Iteration 0', OUTPUT.getvalue())
-        self.assertIn('feasibility =', OUTPUT.getvalue())
-        self.assertIn('stepNorm =', OUTPUT.getvalue())
+        LOG = LOG.getvalue()
+        self.assertIn('Iteration 0', LOG)
+        self.assertIn('feasibility =', LOG)
+        self.assertIn('stepNorm =', LOG)
 
     def test_updateIteration(self):
         self.iterLogger.newIteration(
@@ -117,10 +117,8 @@ class TestUtil(unittest.TestCase):
         self.iterLogger.newIteration(
             self.iteration, self.thetak, self.objk, self.radius, self.stepNorm
         )
-        OUTPUT = StringIO()
-        sys.stdout = OUTPUT
-        self.iterLogger.printIteration()
-        sys.stdout = sys.__stdout__
+        with capture_output() as OUTPUT:
+            self.iterLogger.printIteration()
         self.assertIn(str(self.radius), OUTPUT.getvalue())
         self.assertIn(str(self.iteration), OUTPUT.getvalue())
         self.assertIn(str(self.thetak), OUTPUT.getvalue())


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The trustregion tests directly manipulate `sys.stdout` -- and in particular -- restore it to the `sys.__stdout__`.  This can foul up some testing / redirection logic, particularly if the test fails (raises an exception) before restoring the state.  This PR updates the trustregion tests to use `capture_output()` instead of directly manipulating `sys.stdout`.

## Changes proposed in this PR:
- Use the `caputure_output()` context manager instead of directly manipulating `sys.stdout`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
