### PR TITLE
Minor efficiency change to sensitivity toolbox Pynumero calculations

### DIFF
--- a/pyomo/contrib/sensitivity_toolbox/pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/pynumero.py
@@ -80,14 +80,8 @@ def get_dsdp_dfdp(model, theta):
     col_remap = {mv_map[id(v)]: i for i, v in enumerate(s_list + theta)}
     _coo_reorder_cols(J, remap=col_remap)
     J = J.tocsc()
-    dB = -(
-        J
-        @ scipy.sparse.vstack(
-            (scipy.sparse.coo_matrix((ns, np)), scipy.sparse.identity(np))
-        ).tocsc()
-    )
     # Calculate sensitivity matrix
-    dsdp = scipy.sparse.linalg.spsolve(J[:, range(ns)], dB)
+    dsdp = -scipy.sparse.linalg.spsolve(J[:, :ns], J[:, ns:] @ scipy.sparse.identity(np))
     # Get a map of state vars to columns
     s_map = {id(v): i for i, v in enumerate(s_list)}
     # Get the outputs we are interested in from the list of output vars

--- a/pyomo/contrib/sensitivity_toolbox/pynumero.py
+++ b/pyomo/contrib/sensitivity_toolbox/pynumero.py
@@ -81,7 +81,9 @@ def get_dsdp_dfdp(model, theta):
     _coo_reorder_cols(J, remap=col_remap)
     J = J.tocsc()
     # Calculate sensitivity matrix
-    dsdp = -scipy.sparse.linalg.spsolve(J[:, :ns], J[:, ns:] @ scipy.sparse.identity(np))
+    dsdp = -scipy.sparse.linalg.spsolve(
+        J[:, :ns], J[:, ns:] @ scipy.sparse.identity(np)
+    )
     # Get a map of state vars to columns
     s_map = {id(v): i for i, v in enumerate(s_list)}
     # Get the outputs we are interested in from the list of output vars


### PR DESCRIPTION
## Fixes None

Minor simplification to calculating sensitivity matrix with Pynumero in sensitivity toolbox

## Summary/Motivation:

I realized there is an extra step of stacking a zero matrix and identity matrix when I could have just used a slice of the Jacobian.  This fix may make it slightly faster and use slightly less memory, but since these are sparse matrixes, I doubt it will matter much.

Here is the math:

The problem Jacobian.  x are dependent variables and p are independent. 

$$
	\textbf{J} = 
	\left[
	\begin{matrix}
	\frac{\partial f_1}{\partial x_1} & \dots &\frac{\partial f_1}{\partial x_{N_x}} \\
	\vdots & \ddots & \vdots \\
	\frac{\partial f_{N_f}}{\partial x_1} & \dots &\frac{\partial f_{N_f}}{\partial x_{N_x}} \\
	\end{matrix}
	\Biggr{|}
	\begin{matrix}
	\frac{\partial f_1}{\partial p_1} & \dots &\frac{\partial f_1}{\partial p_{N_p}} \\
	\vdots & \ddots & \vdots \\
	\frac{\partial f_{N_f}}{\partial p_1} & \dots &\frac{\partial f_{N_f}}{\partial p_{N_p}} \\
	\end{matrix}
	\right]
	=
	\left[\textbf{J}_x | \textbf{J}_p \right]
$$

Then solve the linear equations to get the sensitivity matrix:

$$
\mathbf{J}_x \frac{\partial x}{\partial p} = -\mathbf{J}_p I_{n_p}
$$


## Changes proposed in this PR:
- Remove extra step from calculation of sensitivity matrix calculation with pynumero

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
