### PR TITLE
Update URL for cyipopt documentation

### DIFF
--- a/doc/OnlineDocs/getting_started/solvers.rst
+++ b/doc/OnlineDocs/getting_started/solvers.rst
@@ -44,8 +44,8 @@ the license requirements for their desired solver.
    * - cyipopt
      - ``pip install cyipopt``
      - ``conda install ‑c conda‑forge cyipopt``
-     - `License <https://cyipopt.readthedocs.io/en/stable/#copyright>`__
-       `Docs <https://cyipopt.readthedocs.io/en/stable/install.html>`__
+     - `License <https://cyipopt.readthedocs.io/stable/#copyright>`__
+       `Docs <https://cyipopt.readthedocs.io/stable/install.html>`__
    * - glpk
      - N/A
      - ``conda install ‑c conda‑forge glpk``


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The Cyipopt documentation appears to have dropped the `/en/` from the RTD documentation pages.  This tracks that change.

## Changes proposed in this PR:
- Update cyipopt RTD URLs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
