### PR TITLE
Disallow cplex 22.1.2.1 from conda, too

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -386,7 +386,7 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 and 22.1.2.1, as they errors fatally when
+            # Disallow cplex 22.1.2 and 22.1.2.1, as they error fatally when
             #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -386,12 +386,11 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 because 22.1.2.1 errors fatally when
-            #   computing IIS on Python 3.13 and 3.14, and conda does
-            #   not appear to distinguish between 22.1.2 and 22.1.2.1
+            # Disallow cplex 22.1.2 and 22.1.2.1, as they errors fatally when
+            #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2|>22.1.2'
+                CPLEX='cplex>=12.10,<22.1.2|>22.1.2.1'
             else
                 CPLEX='cplex>=12.10'
             fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -304,7 +304,14 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip 'cplex!=22.1.2.1' docplex \
+            # Disallow cplex 22.1.2.1 because it errors fatally when
+            #  computing IIS on python 3.13 and 3.14
+            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
+                CPLEX='cplex!=22.1.2.1'
+            else
+                CPLEX='cplex'
+            fi
+            python -m pip install --cache-dir cache/pip "$CPLEX" docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"
@@ -375,6 +382,18 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            TIMEOUT_MSG="TIMEOUT: killing conda install process"
+            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
+            echo "Installing for $PYVER"
+            #
+            # Disallow cplex 22.1.2.1 because it errors fatally when
+            #   computing IIS on Python 3.13 and 3.14
+            # Disallow cplex 12.9 (caused segfaults in tests)
+            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
+                CPLEX='cplex>=12.10,<22.1.2.1|>22.1.2.1'
+            else
+                CPLEX='cplex>=12.10'
+            fi
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.
@@ -387,10 +406,7 @@ jobs:
             else
                 XPRESS='xpress'
             fi
-            TIMEOUT_MSG="TIMEOUT: killing conda install process"
-            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
-            echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in "$CPLEX" docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -386,11 +386,12 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2.1 because it errors fatally when
-            #   computing IIS on Python 3.13 and 3.14
+            # Disallow cplex 22.1.2 because 22.1.2.1 errors fatally when
+            #   computing IIS on Python 3.13 and 3.14, and conda does
+            #   not appear to distinguish between 22.1.2 and 22.1.2.1
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2.1|>22.1.2.1'
+                CPLEX='cplex>=12.10,<22.1.2|>22.1.2'
             else
                 CPLEX='cplex>=12.10'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -438,11 +438,12 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2.1 because it errors fatally when
-            #   computing IIS on Python 3.13 and 3.14
+            # Disallow cplex 22.1.2 because 22.1.2.1 errors fatally when
+            #   computing IIS on Python 3.13 and 3.14, and conda does
+            #   not appear to distinguish between 22.1.2 and 22.1.2.1
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2.1|>22.1.2.1'
+                CPLEX='cplex>=12.10,<22.1.2|>22.1.2'
             else
                 CPLEX='cplex>=12.10'
             fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -438,7 +438,7 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 and 22.1.2.1, as they errors fatally when
+            # Disallow cplex 22.1.2 and 22.1.2.1, as they error fatally when
             #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -356,7 +356,14 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            python -m pip install --cache-dir cache/pip 'cplex!=22.1.2.1' docplex \
+            # Disallow cplex 22.1.2.1 because it errors fatally when
+            #  computing IIS on python 3.13 and 3.14
+            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
+                CPLEX='cplex!=22.1.2.1'
+            else
+                CPLEX='cplex'
+            fi
+            python -m pip install --cache-dir cache/pip "$CPLEX" docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"
@@ -427,6 +434,18 @@ jobs:
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y python="${{matrix.python}}" $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            TIMEOUT_MSG="TIMEOUT: killing conda install process"
+            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
+            echo "Installing for $PYVER"
+            #
+            # Disallow cplex 22.1.2.1 because it errors fatally when
+            #   computing IIS on Python 3.13 and 3.14
+            # Disallow cplex 12.9 (caused segfaults in tests)
+            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
+                CPLEX='cplex>=12.10,<22.1.2.1|>22.1.2.1'
+            else
+                CPLEX='cplex>=12.10'
+            fi
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.
@@ -439,10 +458,7 @@ jobs:
             else
                 XPRESS='xpress'
             fi
-            TIMEOUT_MSG="TIMEOUT: killing conda install process"
-            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
-            echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex gurobi "$XPRESS" cyipopt pymumps scip; do
+            for PKG in "$CPLEX" docplex gurobi "$XPRESS" cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -438,12 +438,11 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 because 22.1.2.1 errors fatally when
-            #   computing IIS on Python 3.13 and 3.14, and conda does
-            #   not appear to distinguish between 22.1.2 and 22.1.2.1
+            # Disallow cplex 22.1.2 and 22.1.2.1, as they errors fatally when
+            #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
             if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2|>22.1.2'
+                CPLEX='cplex>=12.10,<22.1.2|>22.1.2.1'
             else
                 CPLEX='cplex>=12.10'
             fi


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
We have previously disallowed cplex 22.1.2.1 from pip because of internal CPEX errors when computing an IIS.  They recently (4 days ago) released both 22.1.2 and 22.1.2.1 to conda, where they fail, too.  This PR extends the exclusion to the conda environments:
- exclude cplex 22.1.2 and 22.1.2.1 from conda builds for python 3.13 and 3.14
  - note that this is different from pip where we don't exclude 22.1.2, as those releases appear to work.
- relax the cplex restriction on PIP toonly Python 3.13 and 3.14

## Changes proposed in this PR:
- disallow cplex 22.1.2 and 22.1.2.1 from conda
- only disallow 22.1.2.1 from PIP for Python 3.13 and 3.14

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
