### PR TITLE
Update osx installers and urlchecker environment

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -50,8 +50,15 @@ jobs:
         black . --check --diff
     - name: Spell Check
       uses: crate-ci/typos@master
-      with: 
+      with:
         config: ./.github/workflows/typos.toml
+    - name: Set DNS server
+      run: |
+        # This will hopefully resolve intermittent DNS resolution errors
+        echo "Reset DNS servers to use cloudfare"
+        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        sudo resolvectl flush-caches
+        sudo resolvectl status
     - name: URL Checker
       if: env.PYOMO_WORKFLOW == 'branch'
       uses: urlstechie/urlchecker-action@0.0.34
@@ -700,7 +707,7 @@ jobs:
         echo ""
         echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
 
-    # this has to be done after Pyomo is installed because highspy 
+    # this has to be done after Pyomo is installed because highspy
     # depends on pyomo's find_library function
     - name: Install HiGHS
       if: ${{ ! matrix.slim }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -214,7 +214,7 @@ jobs:
         #  - install glpk
         #  - pyodbc needs: gcc pkg-config unixodbc freetds
         for pkg in bash pkg-config unixodbc freetds glpk ginac; do
-            brew list $pkg || brew install $pkg
+            brew list $pkg 2>/dev/null || brew install $pkg
         done
 
     - name: Update Linux

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -56,8 +56,10 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
+        sudo resolvectl query github.com
         sudo resolvectl status
     - name: URL Checker
       if: env.PYOMO_WORKFLOW == 'branch'

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        LINK=`resolvectl query github.com | grep link: | sed -r 's/.*link://'`
         sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
         sudo resolvectl query github.com

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -266,7 +266,7 @@ jobs:
         #  - install glpk
         #  - pyodbc needs: gcc pkg-config unixodbc freetds
         for pkg in bash pkg-config unixodbc freetds glpk ginac; do
-            brew list $pkg || brew install $pkg
+            brew list $pkg 2>/dev/null || brew install $pkg
         done
 
     - name: Update Linux

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -61,8 +61,15 @@ jobs:
         black . --check --diff
     - name: Spell Check
       uses: crate-ci/typos@master
-      with: 
+      with:
         config: ./.github/workflows/typos.toml
+    - name: Set DNS server
+      run: |
+        # This will hopefully resolve intermittent DNS resolution errors
+        echo "Reset DNS servers to use cloudfare"
+        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        sudo resolvectl flush-caches
+        sudo resolvectl status
     - name: URL Checker
       if: env.PYOMO_WORKFLOW == 'branch'
       uses: urlstechie/urlchecker-action@0.0.34
@@ -752,7 +759,7 @@ jobs:
         echo ""
         echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
 
-    # this has to be done after Pyomo is installed because highspy 
+    # this has to be done after Pyomo is installed because highspy
     # depends on pyomo's find_library function
     - name: Install HiGHS
       if: ${{ ! matrix.slim }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -67,8 +67,10 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
+        sudo resolvectl query github.com
         sudo resolvectl status
     - name: URL Checker
       if: env.PYOMO_WORKFLOW == 'branch'

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        LINK=`resolvectl query github.com | grep link: | sed -r 's/.*link://'`
         sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
         sudo resolvectl query github.com

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -19,8 +19,10 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
+        sudo resolvectl query github.com
         sudo resolvectl status
     - name: URL Checker
       uses: urlstechie/urlchecker-action@0.0.34

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v6
+    - name: Set DNS server
+      run: |
+        # This will hopefully resolve intermittent DNS resolution errors
+        echo "Reset DNS servers to use cloudfare"
+        sudo resolvectl dns eth0 1.1.1.1 1.0.0.1
+        sudo resolvectl flush-caches
+        sudo resolvectl status
     - name: URL Checker
       uses: urlstechie/urlchecker-action@0.0.34
       with:

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         # This will hopefully resolve intermittent DNS resolution errors
         echo "Reset DNS servers to use cloudfare"
-        LINK=`resolvectl query github.com | grep link: | sed -r '.*link://'`
+        LINK=`resolvectl query github.com | grep link: | sed -r 's/.*link://'`
         sudo resolvectl dns $LINK 1.1.1.1 1.0.0.1
         sudo resolvectl flush-caches
         sudo resolvectl query github.com


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves a pair of longstanding irritations:
- the OSX environment setup logged errors (looking for packages that were not installed) that were picked up by GHA and included in the job summary.  This PR suppresses those messages
- the urlchecker was having intermittent errors (particularly with servers like egon.cheme.cmu.edu).  @jdawber223 suggested that it might be an intermittent issue with Google DNS lookups for CMU machines.  This PR sets the DNS servers to CloudFare before running the urlchecker (which might resolve the problem)

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
