### PR TITLE
Handle cuOpt UnboundedOrInfeasible termination status (11)

### DIFF
--- a/pyomo/solvers/plugins/solvers/cuopt_direct.py
+++ b/pyomo/solvers/plugins/solvers/cuopt_direct.py
@@ -249,16 +249,18 @@ class CUOPTDirect(DirectSolver):
         is_mip = solution.get_problem_category()
 
         # Termination Status
-        # 0 - CUOPT_TERIMINATION_STATUS_NO_TERMINATION
-        # 1 - CUOPT_TERIMINATION_STATUS_OPTIMAL
-        # 2 - CUOPT_TERIMINATION_STATUS_INFEASIBLE
-        # 3 - CUOPT_TERIMINATION_STATUS_UNBOUNDED
-        # 4 - CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT
-        # 5 - CUOPT_TERIMINATION_STATUS_TIME_LIMIT
-        # 6 - CUOPT_TERIMINATION_STATUS_NUMERICAL_ERROR
-        # 7 - CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE
-        # 8 - CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND
-        # 9 - CUOPT_TERIMINATION_STATUS_CONCURRENT_LIMIT
+        #  0 - CUOPT_TERIMINATION_STATUS_NO_TERMINATION
+        #  1 - CUOPT_TERIMINATION_STATUS_OPTIMAL
+        #  2 - CUOPT_TERIMINATION_STATUS_INFEASIBLE
+        #  3 - CUOPT_TERIMINATION_STATUS_UNBOUNDED
+        #  4 - CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT
+        #  5 - CUOPT_TERIMINATION_STATUS_TIME_LIMIT
+        #  6 - CUOPT_TERIMINATION_STATUS_NUMERICAL_ERROR
+        #  7 - CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE
+        #  8 - CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND
+        #  9 - CUOPT_TERIMINATION_STATUS_CONCURRENT_LIMIT
+        # 10 - CUOPT_TERIMINATION_STATUS_WORK_LIMIT
+        # 11 - CUOPT_TERIMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE
 
         if status == 1:
             self.results.solver.status = SolverStatus.ok
@@ -292,6 +294,12 @@ class CUOPTDirect(DirectSolver):
             self.results.solver.status = SolverStatus.ok
             self.results.solver.termination_condition = TerminationCondition.other
             soln.status = SolutionStatus.other
+        elif status == 11:
+            self.results.solver.status = SolverStatus.warning
+            self.results.solver.termination_condition = (
+                TerminationCondition.infeasibleOrUnbounded
+            )
+            soln.status = SolutionStatus.unsure
         else:
             self.results.solver.status = SolverStatus.error
             self.results.solver.termination_condition = TerminationCondition.error

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -29,7 +29,18 @@ from pyomo.opt import check_available_solvers
 from pyomo.common.tee import capture_output
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.common.unittest as unittest
-from pyomo.solvers.plugins.solvers.cuopt_direct import cuopt_available
+from pyomo.solvers.plugins.solvers.cuopt_direct import cuopt_available, CUOPTDirect
+
+
+def _cuopt_at_least(*required):
+    """True iff cuOpt is available and at least the given (major, minor[, patch]) version."""
+    if not cuopt_available:
+        return False
+    try:
+        version = tuple(int(p) for p in CUOPTDirect._version[: len(required)])
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return version >= required
 
 
 @unittest.pytest.mark.solver("cuopt")
@@ -125,7 +136,10 @@ class CUOPTTests(unittest.TestCase):
         with pytest.raises(ValueError, match=r"Trivial constraint.*infeasible"):
             opt.solve(m, skip_trivial_constraints=True)
 
-    @unittest.skipIf(not cuopt_available, "The CuOpt solver is not available")
+    @unittest.skipUnless(
+        _cuopt_at_least(26, 4),
+        "cuOpt UnboundedOrInfeasible status (11) requires cuOpt 26.04 or later",
+    )
     def test_unbounded_or_infeasible_status(self):
         # An LP with no variable bounds and an unbounded objective triggers
         # cuOpt's presolver to return UnboundedOrInfeasible (status 11), which

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -138,9 +138,7 @@ class CUOPTTests(unittest.TestCase):
         opt = SolverFactory('cuopt')
         res = opt.solve(m, load_solutions=False)
 
-        self.assertEqual(
-            res.solver.termination_condition, "infeasibleOrUnbounded"
-        )
+        self.assertEqual(res.solver.termination_condition, "infeasibleOrUnbounded")
         self.assertEqual(res.solver.status, "warning")
         self.assertEqual(res.solution[0].status, "unsure")
 

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -126,6 +126,25 @@ class CUOPTTests(unittest.TestCase):
             opt.solve(m, skip_trivial_constraints=True)
 
     @unittest.skipIf(not cuopt_available, "The CuOpt solver is not available")
+    def test_unbounded_or_infeasible_status(self):
+        # An LP with no variable bounds and an unbounded objective triggers
+        # cuOpt's presolver to return UnboundedOrInfeasible (status 11), which
+        # the plugin maps to TerminationCondition.infeasibleOrUnbounded.
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.obj = Objective(expr=m.x + m.y, sense=minimize)
+
+        opt = SolverFactory('cuopt')
+        res = opt.solve(m, load_solutions=False)
+
+        self.assertEqual(
+            res.solver.termination_condition, "infeasibleOrUnbounded"
+        )
+        self.assertEqual(res.solver.status, "warning")
+        self.assertEqual(res.solution[0].status, "unsure")
+
+    @unittest.skipIf(not cuopt_available, "The CuOpt solver is not available")
     def test_nonlinear_constraint_rejected(self):
         m = ConcreteModel()
         m.x = Var(domain=NonNegativeReals)


### PR DESCRIPTION
## Summary

cuOpt added a new termination status (value 11, \`UnboundedOrInfeasible\`) that its presolver returns when it cannot disambiguate infeasibility from unboundedness. The \`cuopt_direct\` plugin's status cascade does not recognize it, so it falls through to \`TerminationCondition.error\` and fails the \`LP_unbounded\` test variants (\`test_cuopt_python\`, \`test_cuopt_python_nonsymbolic_labels\`, \`test_cuopt_python_symbolic_labels\`).

Adds an \`elif status == 11\` branch mapping to \`TerminationCondition.infeasibleOrUnbounded\` (with \`SolverStatus.warning\` / \`SolutionStatus.unsure\`). Also extends the status-code comment block to include status 10 (WorkLimit) and 11 (UnboundedOrInfeasible).

Tracked upstream in NVIDIA/cuopt#1114.