### PR TITLE
Revert PyPy pin in GHA workflow

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -187,7 +187,7 @@ jobs:
           PACKAGES: pyutilib
 
         - os: ubuntu-latest
-          python: 'pypy-3.11-v7.3.20'  #FIXME: Temporary version pin to avoid PyPy 7.3.21
+          python: 'pypy-3.11'
           TARGET: linux
           PYENV: pip
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:
In #3899 we added a temporary pin to the PyPy version we use for testing to work around issues in the 7.3.21 release. PyPy 7.3.22 is out now so this PR reverts the pin.

## Changes proposed in this PR:
- Remove PyPy pin to make sure we're testing the latest version

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
