### PR TITLE
GHA: run tests on draft PRs

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -866,7 +866,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled
-    if: ${{ success() || failure()) }}
+    if: ${{ success() || failure() }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -31,7 +31,8 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    if: ${{ env.PYOMO_WORKFLOW != 'wip' }}
+    # Note: 'env' is not available in ght jobs.<job_id>.if context.
+    if: ${{ ! contains(github.event.pull_request.title, '[WIP]') }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
@@ -864,8 +865,8 @@ jobs:
   cover:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
-    # run even if a build job fails, but not if canceled (except for branches)
-    if: ${{ env.PYOMO_WORKFLOW != 'branch' && (success() || failure()) }}
+    # run even if a build job fails, but not if canceled
+    if: ${{ success() || failure()) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -974,7 +975,9 @@ jobs:
         fi
 
     - name: Upload codecov reports
-      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
+      if: |
+        env.PYOMO_WORKFLOW != 'branch' &&
+        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v6
       with:
         files: coverage.xml
@@ -985,6 +988,7 @@ jobs:
 
     - name: Upload other coverage reports
       if: |
+        env.PYOMO_WORKFLOW != 'branch' &&
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v6

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -31,9 +31,7 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    if: |
-      ${{ ! ( contains(github.event.pull_request.title, '[WIP]') ||
-            github.event.pull_request.draft ) }}
+    if: env.PYOMO_WORKFLOW != 'wip'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    # Note: 'env' is not available in ght jobs.<job_id>.if context.
+    # Note: 'env' is not available in GHA jobs.<job_id>.if context.
     if: ${{ ! contains(github.event.pull_request.title, '[WIP]') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -865,7 +865,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled (except for branches)
-    if: ${{ false }}
+    if: env.PYOMO_WORKFLOW != 'branch' && (success() || failure())
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    if: env.PYOMO_WORKFLOW != 'wip'
+    if: ${{ env.PYOMO_WORKFLOW != 'wip' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
@@ -60,7 +60,7 @@ jobs:
         sudo resolvectl query github.com
         sudo resolvectl status
     - name: URL Checker
-      if: env.PYOMO_WORKFLOW == 'branch'
+      if: ${{ env.PYOMO_WORKFLOW == 'branch' }}
       uses: urlstechie/urlchecker-action@0.0.34
       with:
         # A comma-separated list of file types to cover in the URL checks
@@ -865,7 +865,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled (except for branches)
-    if: env.PYOMO_WORKFLOW != 'branch' && (success() || failure())
+    if: ${{ env.PYOMO_WORKFLOW != 'branch' && (success() || failure()) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    if: env.PYOMO_WORKFLOW != 'wip'
+    if: ${{ env.PYOMO_WORKFLOW != 'wip' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
@@ -72,7 +72,7 @@ jobs:
         sudo resolvectl query github.com
         sudo resolvectl status
     - name: URL Checker
-      if: env.PYOMO_WORKFLOW == 'branch'
+      if: ${{ env.PYOMO_WORKFLOW == 'branch' }}
       uses: urlstechie/urlchecker-action@0.0.34
       with:
         # A comma-separated list of file types to cover in the URL checks
@@ -919,7 +919,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled (except for branches)
-    if: env.PYOMO_WORKFLOW != 'branch' && (success() || failure())
+    if: ${{ env.PYOMO_WORKFLOW != 'branch' && (success() || failure()) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -919,7 +919,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled (except for branches)
-    if: success() || failure()
+    if: env.PYOMO_WORKFLOW != 'branch' && (success() || failure())
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -36,7 +36,7 @@ env:
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |
     ${{ contains(github.event.pull_request.title, '[WIP]') && 'wip'
-        || github.event.pull_request.draft ) && 'draft_pr'
+        || github.event.pull_request.draft && 'draft_pr'
         || github.event.pull_request.number && 'pr'
         || 'main' }}
 

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -43,7 +43,8 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    if: ${{ env.PYOMO_WORKFLOW != 'wip' }}
+    # Note: 'env' is not available in ght jobs.<job_id>.if context.
+    if: ${{ ! contains(github.event.pull_request.title, '[WIP]') }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source
@@ -918,8 +919,8 @@ jobs:
   cover:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
-    # run even if a build job fails, but not if canceled (except for branches)
-    if: ${{ env.PYOMO_WORKFLOW != 'branch' && (success() || failure()) }}
+    # run even if a build job fails, but not if canceled
+    if: ${{ success() || failure()) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -1028,7 +1029,9 @@ jobs:
         fi
 
     - name: Upload codecov reports
-      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
+      if: |
+        env.PYOMO_WORKFLOW != 'branch' &&
+        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v6
       with:
         files: coverage.xml
@@ -1039,6 +1042,7 @@ jobs:
 
     - name: Upload other coverage reports
       if: |
+        env.PYOMO_WORKFLOW != 'branch' &&
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v6

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -35,16 +35,15 @@ env:
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |
-    ${{ ( contains(github.event.pull_request.title, '[WIP]') ||
-          github.event.pull_request.draft ) && 'draft_pr'
-        || github.event.pull_request.number && 'pr' || 'main' }}
+    ${{ contains(github.event.pull_request.title, '[WIP]') && 'wip'
+        || github.event.pull_request.draft ) && 'draft_pr'
+        || github.event.pull_request.number && 'pr'
+        || 'main' }}
 
 jobs:
   lint:
     name: lint/style-and-typos
-    if: |
-      ${{ ! ( contains(github.event.pull_request.title, '[WIP]') ||
-            github.event.pull_request.draft ) }}
+    if: env.PYOMO_WORKFLOW != 'wip'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pyomo source

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   lint:
     name: lint/style-and-typos
-    # Note: 'env' is not available in ght jobs.<job_id>.if context.
+    # Note: 'env' is not available in GHA jobs.<job_id>.if context.
     if: ${{ ! contains(github.event.pull_request.title, '[WIP]') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -920,7 +920,7 @@ jobs:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     # run even if a build job fails, but not if canceled
-    if: ${{ success() || failure()) }}
+    if: ${{ success() || failure() }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
We moved to more actively using "Draft" PRs to communicate PR status between PR authors and the Review team.  Unfortunately, we previously had GHA skip all tests when the PR was marked either "draft" or "WIP", which beans developers aren't getting build/test information.  This PR updates the GHA runners so that tests are run for draft PRs, but not for tests marked "WIP".

As a bonus, this reworks the logic around code coverage: the runners are more standardized now, which also means that branches will get coverage computed on their jobs - but not uploaded to codecov.

## Changes proposed in this PR:
- Only skip GHA tests for "`[WIP]`" PRs (and run tests for draft PRs)
- Standardize logic for running coverage

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
