### PR TITLE
Add a new template for tracking tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,10 +1,10 @@
 ---
-name: "Task"
-about: Track a new task to be completed.
+name: "Developer Task"
+about: Track a new developer task to be completed.
 labels: "Task"
 ---
 
-<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+<!-- ONLY FOR USE BY CORE DEVELOPERS. This template is only intended for use by core developers. If you are reporting a bug or requesting a new feature, please use the appropriate template. -->
 
 ## Summary
 <!-- Brief description of this task -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: "Task"
+about: Track a new task to be completed.
+labels: "Task"
+---
+
+<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+
+## Summary
+<!-- Brief description of this task -->
+
+## Goal / Purpose
+<!-- Why is this task needed? -->
+
+## Additional Info Needed
+<!-- Are there any discussion items that still need to be addressed, maybe with other developer? -->
+


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes N/A

## Summary/Motivation:
There is a gap in our Issue templates - we don't have a template for recording "something we want to work on that we are already discussing" / "a general task that we want to keep track of."

## Changes proposed in this PR:
- New "Task" template

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
