### PR TITLE
Fix GDPopt LOA maximization objective sense

### DIFF
--- a/pyomo/contrib/gdpopt/loa.py
+++ b/pyomo/contrib/gdpopt/loa.py
@@ -147,9 +147,8 @@ class GDP_LOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
         # Set up augmented penalty objective
         discrete_objective.deactivate()
         # placeholder for OA objective
-        discrete_problem_util_block.oa_obj = Objective(
-            expr=0, sense=discrete_objective.sense
-        )
+        discrete_problem_util_block.oa_obj = Objective()
+        discrete_problem_util_block.oa_obj.sense = discrete_objective.sense
 
         return discrete_objective
 

--- a/pyomo/contrib/gdpopt/loa.py
+++ b/pyomo/contrib/gdpopt/loa.py
@@ -147,7 +147,9 @@ class GDP_LOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
         # Set up augmented penalty objective
         discrete_objective.deactivate()
         # placeholder for OA objective
-        discrete_problem_util_block.oa_obj = Objective(sense=minimize)
+        discrete_problem_util_block.oa_obj = Objective(
+            expr=0, sense=discrete_objective.sense
+        )
 
         return discrete_objective
 

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -40,6 +40,7 @@ from pyomo.environ import (
     Integers,
     LogicalConstraint,
     maximize,
+    minimize,
     Objective,
     RangeSet,
     TransformationFactory,
@@ -321,6 +322,48 @@ class TestGDPoptUnit(unittest.TestCase):
             "algorithm-specific solver.",
         ):
             SolverFactory('gdpopt').solve(m)
+
+    def test_loa_augmented_penalty_objective_preserves_objective_sense(self):
+        for sense in (minimize, maximize):
+            m = ConcreteModel()
+            m.GDPopt_utils = Block()
+            m.x = Var(bounds=(0, 1))
+            m.obj = Objective(expr=m.x, sense=sense)
+
+            solver = SolverFactory('gdpopt.loa')
+            original_obj = solver._setup_augmented_penalty_objective(m.GDPopt_utils)
+
+            self.assertIs(original_obj, m.obj)
+            self.assertFalse(m.obj.active)
+            self.assertEqual(m.GDPopt_utils.oa_obj.sense, sense)
+
+    @unittest.skipUnless(
+        SolverFactory(mip_solver).available(), "MIP solver not available"
+    )
+    def test_LOA_maximize_matches_minimize_negated_objective(self):
+        def build_model(maximize_objective):
+            m = ConcreteModel()
+            m.x = Var(bounds=(0, 10))
+            m.disjunction = Disjunction(expr=[[m.x == 1], [m.x == 9]])
+            if maximize_objective:
+                m.obj = Objective(expr=m.x, sense=maximize)
+            else:
+                m.obj = Objective(expr=-m.x)
+            return m
+
+        for maximize_objective in (False, True):
+            m = build_model(maximize_objective)
+            results = SolverFactory('gdpopt.loa').solve(
+                m,
+                mip_solver=mip_solver,
+                nlp_solver=nlp_solver,
+                init_algorithm='no_init',
+            )
+
+            self.assertEqual(
+                results.solver.termination_condition, TerminationCondition.optimal
+            )
+            self.assertAlmostEqual(value(m.x), 9)
 
     @unittest.skipIf(
         not LOA_solvers_available,


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3937.

## Summary/Motivation:

GDPopt LOA currently creates the augmented OA master objective with minimization sense even when the original GDP objective is a maximization objective. For maximization GDPs, this can make the discrete OA master pursue the wrong objective direction.

This was observed while validating the GDPLib methanol benchmark:

- SECQUOIA/gdplib#114 tracks the downstream methanol LOA mismatch.
- SECQUOIA/gdplib#113 documents and preserves the downstream sign-convention workaround.

In the methanol reproducer, the algebraically equivalent formulations `minimize(-profit)` and `maximize(profit)` selected different disjuncts before this fix. With this branch, both formulations return the same profit and active disjuncts.

## Changes proposed in this PR:

- Preserve the original objective sense when GDPopt LOA creates the augmented OA master objective.
- Keep the placeholder OA objective expressionless until the augmented expression is assigned.
- Add regression coverage for a small GDP where `minimize(-x)` and `maximize(x)` should select the same disjunct.

## Tests run:

- `python -m pytest -q pyomo/contrib/gdpopt/tests/test_gdpopt.py::TestGDPoptUnit::test_loa_augmented_penalty_objective_preserves_objective_sense pyomo/contrib/gdpopt/tests/test_gdpopt.py::TestGDPoptUnit::test_LOA_maximize_matches_minimize_negated_objective`
  - Result: `2 passed in 1.40s`
- `python -m pytest -q pyomo/contrib/gdpopt/tests/test_gdpopt.py`
  - Result: `60 passed, 21 skipped, 3 deselected in 16.46s`
- `python -m black --check --diff pyomo/contrib/gdpopt/loa.py pyomo/contrib/gdpopt/tests/test_gdpopt.py`
  - Result: passed, `2 files would be left unchanged`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
