### PR TITLE
Fix GDPopt LBB time-limit results

### DIFF
--- a/pyomo/contrib/gdpopt/branch_and_bound.py
+++ b/pyomo/contrib/gdpopt/branch_and_bound.py
@@ -236,7 +236,7 @@ class GDP_LBB_Solver(_GDPoptAlgorithm):
                 config.logger.info(
                     'Final bound values: LB: {}  UB: {}'.format(self.LB, self.UB)
                 )
-                return self._get_final_results_object()
+                return self._get_final_pyomo_results_object()
 
             # Handle current node
             if not node_data.is_screened:

--- a/pyomo/contrib/gdpopt/tests/test_LBB.py
+++ b/pyomo/contrib/gdpopt/tests/test_LBB.py
@@ -20,8 +20,17 @@ from pyomo.common.fileutils import import_file
 from pyomo.common.log import LoggingIntercept
 import pyomo.contrib.gdpopt.tests.common_tests as ct
 from pyomo.contrib.satsolver.satsolver import z3_available
-from pyomo.environ import SolverFactory, value, ConcreteModel, Var, Objective, maximize
-from pyomo.gdp import Disjunction
+from pyomo.contrib.gdpopt.branch_and_bound import GDP_LBB_Solver
+from pyomo.environ import (
+    SolverFactory,
+    value,
+    ConcreteModel,
+    Constraint,
+    Var,
+    Objective,
+    maximize,
+)
+from pyomo.gdp import Disjunct, Disjunction
 from pyomo.opt import TerminationCondition
 
 currdir = dirname(abspath(__file__))
@@ -33,6 +42,40 @@ solver_available = SolverFactory(minlp_solver).available()
 license_available = (
     SolverFactory(minlp_solver).license_is_valid() if solver_available else False
 )
+
+
+class TestGDPopt_LBB_TimeLimit(unittest.TestCase):
+    """Tests for solver-independent LBB termination paths."""
+
+    def test_time_limit_returns_pyomo_results_object(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(0, 2))
+        m.d1 = Disjunct()
+        m.d2 = Disjunct()
+        m.d1.c = Constraint(expr=m.x <= 0.5)
+        m.d2.c = Constraint(expr=m.x >= 1.5)
+        m.disj = Disjunction(expr=[m.d1, m.d2])
+        m.obj = Objective(expr=m.x)
+
+        orig_reached_time_limit = GDP_LBB_Solver.reached_time_limit
+
+        def force_time_limit(solver, config):
+            solver.pyomo_results.solver.termination_condition = (
+                TerminationCondition.maxTimeLimit
+            )
+            return True
+
+        GDP_LBB_Solver.reached_time_limit = force_time_limit
+        try:
+            results = SolverFactory('gdpopt.lbb').solve(m, time_limit=1, tee=False)
+        finally:
+            GDP_LBB_Solver.reached_time_limit = orig_reached_time_limit
+
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.maxTimeLimit
+        )
+        self.assertEqual(results.problem.lower_bound, float('-inf'))
+        self.assertEqual(results.problem.upper_bound, float('inf'))
 
 
 @unittest.skipUnless(

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py
@@ -11,6 +11,7 @@
 from unittest.mock import MagicMock, patch
 
 from pyomo.common import timing
+from pyomo.contrib.mindtpy.global_outer_approximation import MindtPy_GOA_Solver
 from pyomo.opt import TerminationCondition as tc, SolverStatus, SolverResults
 import pyomo.common.unittest as unittest
 
@@ -458,8 +459,6 @@ class TestMirrorDirectSolveResults(unittest.TestCase):
 
 class TestMindtPyGOATimeLimit(unittest.TestCase):
     def test_goa_time_limit_sets_solver_results_condition(self):
-        from pyomo.contrib.mindtpy.global_outer_approximation import MindtPy_GOA_Solver
-
         solver = MindtPy_GOA_Solver()
         solver.config = _SimpleNamespace(
             logger=MagicMock(), single_tree=False, time_limit=1

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py
@@ -10,7 +10,8 @@
 
 from unittest.mock import MagicMock, patch
 
-from pyomo.opt import TerminationCondition as tc, SolverStatus
+from pyomo.common import timing
+from pyomo.opt import TerminationCondition as tc, SolverStatus, SolverResults
 import pyomo.common.unittest as unittest
 
 from pyomo.environ import (
@@ -453,6 +454,25 @@ class TestMirrorDirectSolveResults(unittest.TestCase):
         self.assertEqual(algo.results.solver.status, SolverStatus.ok)
         self.assertEqual(algo.results.solver.termination_condition, tc.optimal)
         self.assertEqual(algo.results.solver.message, "All good")
+
+
+class TestMindtPyGOATimeLimit(unittest.TestCase):
+    def test_goa_time_limit_sets_solver_results_condition(self):
+        from pyomo.contrib.mindtpy.global_outer_approximation import MindtPy_GOA_Solver
+
+        solver = MindtPy_GOA_Solver()
+        solver.config = _SimpleNamespace(
+            logger=MagicMock(), single_tree=False, time_limit=1
+        )
+        solver.results = SolverResults()
+        solver.timing = _SimpleNamespace(
+            main_timer_start_time=timing.default_timer() - 2
+        )
+        solver.primal_bound = float('inf')
+        solver.dual_bound = float('-inf')
+
+        self.assertTrue(solver.reached_time_limit())
+        self.assertEqual(solver.results.solver.termination_condition, tc.maxTimeLimit)
 
 
 class _FakeLegacyMIPSolver:


### PR DESCRIPTION
Summary
- Replace GDPopt LBB's stale `_get_final_results_object()` call on the time-limit path with `_get_final_pyomo_results_object()`.
- Add a solver-independent LBB regression test that forces the time-limit branch and verifies `maxTimeLimit` results.
- Add MindtPy GOA time-limit coverage to verify its inherited GOA path sets `maxTimeLimit` on `SolverResults`.

Tests run
- `pytest -q pyomo/contrib/gdpopt/tests/test_LBB.py::TestGDPopt_LBB_TimeLimit::test_time_limit_returns_pyomo_results_object pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py::TestMindtPyGOATimeLimit::test_goa_time_limit_sets_solver_results_condition` - passed, 2 passed in 0.52s
- `pytest -q pyomo/contrib/gdpopt/tests/test_LBB.py pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py` - passed, 32 passed, 9 skipped, 2 deselected in 1.86s
- `python -m black --check --diff pyomo/contrib/gdpopt/branch_and_bound.py pyomo/contrib/gdpopt/tests/test_LBB.py pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py` - passed, 3 files would be left unchanged
- `git diff --check -- pyomo/contrib/gdpopt/branch_and_bound.py pyomo/contrib/gdpopt/tests/test_LBB.py pyomo/contrib/mindtpy/tests/test_mindtpy_no_discrete.py` - passed

Notes about tests not run
- Full repository pytest and full-repository Black were not run locally because the targeted change is narrow and the full CI matrix covers multiple Python versions, platforms, optional solver installs, documentation, and coverage jobs.

Closes #3941
