### PR TITLE
Unpin GAMS release; rebuild GHA package cache

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -142,7 +142,7 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: '3.11'
+          python: '3.10'
           other: /pip
           TARGET: win
           PYENV: pip

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -677,7 +677,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz --no-check-certificate |" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz --insecure |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -677,7 +677,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz --no-check-certificate |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -566,7 +566,7 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/latest"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -142,9 +142,16 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: '3.10'
+          python: '3.11'
           other: /pip
           TARGET: win
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: '3.10'
+          other: /slim
+          slim: 1
+          TARGET: linux
           PYENV: pip
 
     steps:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.1
+  CACHE_VER: v260512.2
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -552,9 +552,12 @@ jobs:
         $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -363,6 +363,8 @@ jobs:
         python --version
         # We need setuptools so we can run Pyomo's setup.py
         conda install setuptools
+        # Make sure pip is installed for dependencies not available through conda
+        conda install pip
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -677,9 +677,9 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz --insecure |" get.ASL
-            cat get.ASL
-            ./get.ASL
+            sed "s|wget |curl -o solvers.tgz |" get.ASL > get.ASL.patched
+            cat get.ASL.patched
+            bash ./get.ASL.patched
             cd ..
             make
             mv bin "$INSTALL_DIR/bin"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -545,12 +545,9 @@ jobs:
         $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      if: ${{ ! matrix.slim }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
-      # - We no longer install on OSX because GAMS no longer distributes
-      #   self extracting ZIP for OSX and the package is difficult [for JDS]
-      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260304.0
+  CACHE_VER: v260512.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.0
+  CACHE_VER: v260512.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.2
+  CACHE_VER: v260512.3
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: branch

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -730,7 +730,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz |" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz --no-check-certificate |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -151,7 +151,7 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
-        # [13 May 26] Disabled until we cna sort out the seg fault issue
+        # [13 May 26] Disabled until we can sort out the seg fault issue
         #- os: windows-latest
         #  python: '3.10'
         #  other: /pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260304.0
+  CACHE_VER: v260512.0
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.0
+  CACHE_VER: v260512.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -151,11 +151,12 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
-        - os: windows-latest
-          python: '3.11'
-          other: /pip
-          TARGET: win
-          PYENV: pip
+        # [13 May 26] Disabled until we cna sort out the seg fault issue
+        #- os: windows-latest
+        #  python: '3.10'
+        #  other: /pip
+        #  TARGET: win
+        #  PYENV: pip
 
         - os: ubuntu-latest
           python: '3.10'

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -598,9 +598,12 @@ jobs:
         $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
+      # - We no longer install on OSX because GAMS no longer distributes
+      #   self extracting ZIP for OSX and the package is difficult [for JDS]
+      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -152,22 +152,22 @@ jobs:
           PACKAGES: cython
 
         - os: windows-latest
-          python: '3.10'
+          python: '3.11'
           other: /pip
           TARGET: win
-          PYENV: pip
-
-        - os: ubuntu-latest
-          python: 3.11
-          other: /singletest
-          category: "-m 'neos or importtest'"
-          TARGET: linux
           PYENV: pip
 
         - os: ubuntu-latest
           python: '3.10'
           other: /slim
           slim: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: 3.11
+          other: /singletest
+          category: "-m 'neos or importtest'"
           TARGET: linux
           PYENV: pip
 

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -619,7 +619,7 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
         # Demo licenses are included for 5mo from the newest release
-        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/52.5.0"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/latest"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.2
+  CACHE_VER: v260512.3
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -598,12 +598,9 @@ jobs:
         $IPOPT_DIR/ipopt -v
 
     - name: Install GAMS
-      if: ${{ ! matrix.slim && matrix.TARGET != 'osx' }}
+      if: ${{ ! matrix.slim }}
       # - We install using Powershell because the GAMS installer hangs
       #   when launched from bash on Windows
-      # - We no longer install on OSX because GAMS no longer distributes
-      #   self extracting ZIP for OSX and the package is difficult [for JDS]
-      #   to install in GHA
       shell: pwsh
       run: |
         $GAMS_DIR = "${env:TPL_DIR}/gams"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -730,9 +730,9 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz --insecure |" get.ASL
-            cat get.ASL
-            ./get.ASL
+            sed "s|wget |curl -o solvers.tgz |" get.ASL > get.ASL.patched
+            cat get.ASL.patched
+            bash ./get.ASL.patched
             cd ..
             make
             mv bin "$INSTALL_DIR/bin"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -410,6 +410,8 @@ jobs:
         python --version
         # We need setuptools so we can run Pyomo's setup.py
         conda install setuptools
+        # Make sure pip is installed for dependencies not available through conda
+        conda install pip
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -31,7 +31,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver linear-tree
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels linear-tree
-  CACHE_VER: v260512.1
+  CACHE_VER: v260512.2
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   PYOMO_WORKFLOW: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -730,7 +730,7 @@ jobs:
             cd gjh_asl_json-master/Thirdparty
             # Patch get.ASL to use curl
             URL="http://www.ampl.com/netlib/ampl/solvers.tgz"
-            sed -i "s|wget |curl -o solvers.tgz --no-check-certificate |" get.ASL
+            sed -i "s|wget |curl -o solvers.tgz --insecure |" get.ASL
             cat get.ASL
             ./get.ASL
             cd ..

--- a/pyomo/neos/__init__.py
+++ b/pyomo/neos/__init__.py
@@ -16,6 +16,7 @@ doc = {
     'bonmin': 'Deterministic local MINLP solver',
     'cbc': 'MILP solver',
     'conopt': 'Feasible path NLP solver',
+    'copt': 'MILP solver',
     'couenne': 'Deterministic global MINLP solver',
     'cplex': 'MILP solver',
     'fico-xpress': 'MILP solver',

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -223,6 +223,9 @@ class RunAllNEOSSolvers:
     def test_conopt(self):
         self._run('conopt')
 
+    def test_copt(self):
+        self._run('copt')
+
     def test_couenne(self):
         self._run('couenne')
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
The Demo license for the pinned GAMS version in GHA has expired, leading to test failures on `main`.  This releases the pin on the GAMS version and rebuilds the GHA package cache.

## Changes proposed in this PR:
- Unpin GAMS release version
- Rebuild package caches

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
