### PR TITLE
Add logger warning for non-PSD covariance matrix

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -525,6 +525,11 @@ def compute_covariance_matrix(
         cov = np.linalg.pinv(FIM)
         logger.warning("The FIM is singular. Using pseudo-inverse instead.")
 
+    # check if the covariance matrix is positive semi-definite
+    eigen_values = np.linalg.eigvalsh(cov)
+    if any(eig_val < -1e-10 for eig_val in eigen_values):
+        logger.warning("The covariance matrix is not positive semi-definite.")
+
     cov = pd.DataFrame(cov, index=theta_vals.keys(), columns=theta_vals.keys())
 
     return cov
@@ -1479,6 +1484,17 @@ class Estimator:
                             solver=solver,
                             tee=self.tee,
                         )
+                else:
+                    raise ValueError(
+                        'One or more values are missing from "measurement_error". All values of '
+                        'the measurement errors are required for the "SSE_weighted" objective.'
+                    )
+            else:
+                raise AttributeError(
+                    'Experiment model does not have suffix "measurement_error". '
+                    '"measurement_error" is a required suffix for the "SSE_weighted" '
+                    'objective.'
+                )
         else:
             raise ValueError(
                 f"Invalid objective function for covariance calculation. "


### PR DESCRIPTION
## Fixes # .
Added a logging warning for the case when the computed covariance matrix is not positive semi-definite (PSD).

## Summary/Motivation:
When a model is not structurally identifiable, the computed covariance matrix may not be PSD. This PR adds a warning message to the logging output when such a case is encountered.

## Changes proposed in this PR:
- Add an if statement that checks if the covariance matrix is PSD
- Add a logging warning if the covariance matrix is not PSD

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
