### PR TITLE
Testing: add missing Ipopt guards (parmest); add GHA nosolvers test

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -169,7 +169,7 @@ jobs:
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
         EXTRAS=tests
-        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" -eq 1; then
+        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" = 1; then
             EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
@@ -195,7 +195,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v5
-      if: ${{ ! matrix.slim || matrix.slim == 1 }}
+      if: ${{ ! matrix.slim }}
       id: download-cache
       with:
         path: cache/download

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -150,9 +150,10 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           other: /slim
-          slim: 1
+          slim: 2
           TARGET: linux
           PYENV: pip
+
 
     steps:
     - name: Checkout Pyomo source
@@ -168,7 +169,7 @@ jobs:
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
         EXTRAS=tests
-        if test -z "${{matrix.slim}}"; then
+        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" -eq 1; then
             EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
@@ -194,7 +195,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v5
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim || matrix.slim == 1 }}
       id: download-cache
       with:
         path: cache/download

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -161,6 +161,13 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           other: /slim
+          slim: 2
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: 3.13
+          other: /nosolvers
           slim: 1
           TARGET: linux
           PYENV: pip
@@ -215,7 +222,7 @@ jobs:
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
         EXTRAS=tests
-        if test -z "${{matrix.slim}}"; then
+        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" -eq 1; then
             EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
@@ -241,7 +248,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v5
-      if: ${{ ! matrix.slim }}
+      if: ${{ ! matrix.slim || matrix.slim == 1 }}
       id: download-cache
       with:
         path: cache/download

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -222,7 +222,7 @@ jobs:
             echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
         fi
         EXTRAS=tests
-        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" -eq 1; then
+        if test -z "${{matrix.slim}}" -o "${{matrix.slim}}" = 1; then
             EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
@@ -248,7 +248,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v5
-      if: ${{ ! matrix.slim || matrix.slim == 1 }}
+      if: ${{ ! matrix.slim }}
       id: download-cache
       with:
         path: cache/download

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -1539,6 +1539,7 @@ class TestRegularizationCore(unittest.TestCase):
 
         self.assertAlmostEqual(pyo.value(expr), expected)
 
+    @unittest.skipUnless(ipopt_available, "Test requires ipopt")
     def test_l2_penalty_not_double_counted_across_scenarios(self):
         # Confirms regularization is applied once at the estimator level,
         # not once per scenario.
@@ -1591,6 +1592,7 @@ class TestRegularizationCore(unittest.TestCase):
                 exp_list, obj_function="SSE", regularization=lambda m: m.theta0**2
             )
 
+    @unittest.skipUnless(ipopt_available, "Test requires ipopt")
     def test_l2_lambda_zero_matches_unregularized_objective(self):
         exp_list = [self.LinearExperiment(1.0, 1.0), self.LinearExperiment(2.0, 2.0)]
         prior_fim = pd.DataFrame(
@@ -1615,6 +1617,7 @@ class TestRegularizationCore(unittest.TestCase):
             obj_l2_zero = self._obj_at_theta(pest_l2_zero, theta0, theta1)
             self.assertAlmostEqual(obj_l2_zero, obj_base)
 
+    @unittest.skipUnless(ipopt_available, "Test requires ipopt")
     def test_prior_subset_penalizes_only_selected_parameter(self):
         # Prior indexed only by theta1 should leave theta0 unpenalized.
         exp_list = [self.LinearExperiment(1.0, 1.0)]
@@ -1976,6 +1979,7 @@ class TestRegularizationCore(unittest.TestCase):
 
         self.assertAlmostEqual(pyo.value(expr), expected)
 
+    @unittest.skipUnless(ipopt_available, "Test requires ipopt")
     def test_indexed_unknown_parameters_regularization_uses_scalar_theta_names(self):
         exp_list = [IndexedThetaExperiment(2.0, 5.0)]
         prior_fim = pd.DataFrame(


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
#3550 snuck in some tests that were improperly guarded for missing Ipopt solvers (this was caught by a Jenkins job that is not in the main PR workflow).  This PR:
- adds the missing guards
- adds a `linux/3.13/nosolvers` GHA to catch this during the normal PR workflow.

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
