### PR TITLE
Fix IIS interface for current CPLEX releases

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -320,14 +320,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            # Disallow cplex 22.1.2.1 because it errors fatally when
-            #  computing IIS on python 3.13 and 3.14
-            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex!=22.1.2.1'
-            else
-                CPLEX='cplex'
-            fi
-            python -m pip install --cache-dir cache/pip "$CPLEX" docplex \
+            python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"
@@ -410,14 +403,8 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 and 22.1.2.1, as they error fatally when
-            #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
-            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2|>22.1.2.1'
-            else
-                CPLEX='cplex>=12.10'
-            fi
+            CPLEX='cplex>=12.10'
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -373,14 +373,7 @@ jobs:
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
-            # Disallow cplex 22.1.2.1 because it errors fatally when
-            #  computing IIS on python 3.13 and 3.14
-            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex!=22.1.2.1'
-            else
-                CPLEX='cplex'
-            fi
-            python -m pip install --cache-dir cache/pip "$CPLEX" docplex \
+            python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip gurobipy \
                 || echo "WARNING: Gurobi is not available"
@@ -463,14 +456,8 @@ jobs:
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
             #
-            # Disallow cplex 22.1.2 and 22.1.2.1, as they error fatally when
-            #   computing IIS on Python 3.13 and 3.14
             # Disallow cplex 12.9 (caused segfaults in tests)
-            if [[ ${{matrix.python}} =~ 3.1[34] ]]; then
-                CPLEX='cplex>=12.10,<22.1.2|>22.1.2.1'
-            else
-                CPLEX='cplex>=12.10'
-            fi
+            CPLEX='cplex>=12.10'
             # xpress.init() (xpress 9.5.1 from conda) hangs indefinitely
             # on GHA/Windows under Python 3.10 and 3.11.  Exclude that
             # release on that platform.

--- a/pyomo/contrib/iis/iis.py
+++ b/pyomo/contrib/iis/iis.py
@@ -104,7 +104,8 @@ class _IISBase(abc.ABC):
 
 class CplexConflict(_IISBase):
     def compute(self):
-        self._solver._solver_model.conflict.refine()
+        _conflict = self._solver._solver_model.conflict
+        _conflict.refine(_conflict.all_constraints())
 
     def write(self, file_name):
         self._solver._solver_model.conflict.write(file_name)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This PR fixes the interface for computing the IIS through CPLEX.  Apparently, current versions of CPLEX (starting in 22.1.2.1) require passing the list of constraints to consider when calling `conflict.refine()` [this interface is poorly documented, and the examples that the documentation references apparently are not available unless you install CPLEX studio].  Based on the `refine()` docstring, adding `conflict.all_constraints()` as the sole argument appears to work (tested back through cplex 22.1.1.0).

## Changes proposed in this PR:
- Pass `conflict.all_constraints()` as the sole argument for `conflict.refine()`
- Remove restriction disallowing recent CPLEX versions in the GHA test driver

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [X] **AI tools were NOT used during the preparation of this PR**

or

- [ ] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
