### PR TITLE
Fix extremely slow sparse_keys() call for unsorted sparse params

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -515,6 +515,8 @@ You can silence this warning by one of three ways:
             # IndexedComponent): we might as well just sort the sparse
             # _data keys instead of iterating over the whole index.
             return iter(sorted_robust(self._data))
+        elif SortComponents.UNSORTED in sort:
+            return iter(self._data)
         else:
             #
             # Test each element of a sparse _data with an ordered

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -434,13 +434,22 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
 
     def sparse_keys(self, sort=SortComponents.UNSORTED):
         """Return a list of keys in the defined parameters"""
+        sort = SortComponents(sort)
+        if sort is SortComponents.UNSORTED:
+            # Fast path: bypass keys() entirely when no ordering is
+            # requested to avoid unnecessary refiltering of entire
+            # index cross product. Return in dict insertion order.
+            return list(self._data.keys())
         try:
             # Temporarily remove the default value so that len(self) ==
-            # len(self._dict).  This will cause the base class
-            # implementation of keys() to only return values from
+            # len(self._data).  This will cause the base class
+            # implementation of keys() to only return sparse values from
             # self._data:
             tmp = self._default_val
             self._default_val = Param.NoValue
+            # For SORTED_INDICES, keys() sorts sparse _data keys directly.
+            # For ORDERED_INDICES, keys() walks the full index set and
+            # filters, returning sparse indices in index-set order (slow).
             return self.keys(sort)
         finally:
             self._default_val = tmp


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
Fix a very slow call from sparse_keys() to keys() for unsorted params.

## Summary/Motivation:
The sparse_keys() function was updated to return ordered/sorted sparse indices when sorting was specified, going via the keys() function. The change, however, also routed unsorted parameters through the keys() function, collapsing to the final block where filtering was performed over the entire index cross product, keeping only sparse keys, but in index-insertion order. For very large but sparsely indexed params, this dramatically increased (by many orders of magnitude) the time to return the sparse keys set. For unsorted parameters, it makes sense to default back to old behaviour of just returning the unordered sparse keys immediately.

## Changes proposed in this PR:
- When the sort argument is not set (defaults to UNSORTED) or explicitly set to UNSORTED, just return the unordered sparse keys set as in previous pyomo versions.
- When set to SORTED_INDICES, this will go via keys() to an explicit sorting of the sparse keys as was established in 6.10
- When set to ORDERED_INDICES, collapses to the final block in keys() where the sparse keys set is slowly returned in index insertion order.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [X] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [X] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [X] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->
Does this correctly cover the different cases of sorting?
(This is my first PR to the pyomo codebase, forgive me if I am missing something)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
