### PR TITLE
Fix typos in PyROS `CardinalitySet` documentation

### DIFF
--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -1498,7 +1498,8 @@ class CardinalitySet(UncertaintySet):
              \\,\\exists\\, \\xi^+, \\xi^- \\in [0, 1]^n \\,:\\,
              \\left[
                  \\begin{array}{l}
-                    q = q^0 + \\hat{q}^+ \\circ \\xi^+ - \\hat{q}^-\\xi^- \\\\
+                    q = q^0 + \\hat{q}^+ \\circ \\xi^+
+                        - \\hat{q}^- \\circ \\xi^- \\\\
                     \\displaystyle \\sum_{i=1}^n (\\xi_i^+ + \\xi_i^-)
                         \\leq \\Gamma \\\\
                     \\xi_i^+ = 0 \\quad\\forall\\,i :
@@ -1871,7 +1872,7 @@ class CardinalitySet(UncertaintySet):
             is_entry_of_arg=False,
         )
 
-        # check deviations are positive
+        # check deviations are nonnegative
         for dev_pair in zip(self.positive_deviation, self.negative_deviation):
             for dev_name, dev in zip(("positive", "negative"), dev_pair):
                 if dev < 0:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:

Following up on #3969, this PR fixes typos in the PyROS `CardinalitySet` documentation.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [x] **AI tools were NOT used during the preparation of this PR**

    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
