### PR TITLE
Fix reduced costs dropped by legacy results when load_solutions=False

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -1626,7 +1626,9 @@ class LegacySolverInterface:
                         legacy_soln.constraint[symbol]['Slack'] = val
             if hasattr(model, 'rc') and model.rc.import_enabled():
                 for v, val in results.solution_loader.get_reduced_costs().items():
-                    legacy_soln.variable['Rc'] = val
+                    symbol = symbol_map.getSymbol(v)
+                    if symbol in legacy_soln.variable:
+                        legacy_soln.variable[symbol]['Rc'] = val
 
             legacy_results.solution.insert(legacy_soln)
             legacy_results._smap = symbol_map

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -1410,16 +1410,22 @@ class TestLegacySolverInterface(unittest.TestCase):
             raise unittest.SkipTest
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
-        m.obj = pyo.Objective(expr=m.x)
+        m.y = pyo.Var(bounds=(0, None))
+        m.obj = pyo.Objective(expr=m.x + m.y)
         m.c = pyo.Constraint(expr=(-1, m.x, 1))
         if opt_class != MAiNGO:
             m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+            m.rc = pyo.Suffix(direction=pyo.Suffix.IMPORT)
         res = opt.solve(m, load_solutions=False)
         pyo.assert_optimal_termination(res)
         self.assertIsNone(m.x.value)
+        self.assertIsNone(m.y.value)
         if opt_class != MAiNGO:
             self.assertNotIn(m.c, m.dual)
+            self.assertNotIn(m.y, m.rc)
         m.solutions.load_from(res)
         self.assertAlmostEqual(m.x.value, -1)
+        self.assertAlmostEqual(m.y.value, 0)
         if opt_class != MAiNGO:
             self.assertAlmostEqual(m.dual[m.c], 1)
+            self.assertAlmostEqual(m.rc[m.y], 1)

--- a/pyomo/contrib/solver/common/base.py
+++ b/pyomo/contrib/solver/common/base.py
@@ -571,7 +571,9 @@ class LegacySolverWrapper:
                     legacy_soln.constraint[symbol_map.getSymbol(con)] = {'Dual': val}
             if hasattr(model, 'rc') and model.rc.import_enabled():
                 for var, val in results.solution_loader.get_reduced_costs().items():
-                    legacy_soln.variable['Rc'] = val
+                    symbol = symbol_map.getSymbol(var)
+                    if symbol in legacy_soln.variable:
+                        legacy_soln.variable[symbol]['Rc'] = val
 
             legacy_results.solution.insert(legacy_soln)
             legacy_results._smap_id = id(symbol_map)

--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -2497,16 +2497,22 @@ class TestLegacySolverInterface(unittest.TestCase):
             raise unittest.SkipTest(f'Solver {opt.name} not available.')
         m = pyo.ConcreteModel()
         m.x = pyo.Var()
-        m.obj = pyo.Objective(expr=m.x)
+        m.y = pyo.Var(bounds=(0, None))
+        m.obj = pyo.Objective(expr=m.x + m.y)
         m.c = pyo.Constraint(expr=(-1, m.x, 1))
         if (name, opt_class) in dual_solvers:
             m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+            m.rc = pyo.Suffix(direction=pyo.Suffix.IMPORT)
         res = opt.solve(m, load_solutions=False)
         pyo.assert_optimal_termination(res)
         self.assertIsNone(m.x.value)
+        self.assertIsNone(m.y.value)
         if (name, opt_class) in dual_solvers:
             self.assertNotIn(m.c, m.dual)
+            self.assertNotIn(m.y, m.rc)
         m.solutions.load_from(res)
         self.assertAlmostEqual(m.x.value, -1)
+        self.assertAlmostEqual(m.y.value, 0)
         if (name, opt_class) in dual_solvers:
             self.assertAlmostEqual(m.dual[m.c], 1)
+            self.assertAlmostEqual(m.rc[m.y], 1)


### PR DESCRIPTION
## Fixes #

No existing Pyomo issue. This bug was discovered while investigating [Pyomo/mpi-sppy#762](https://github.com/Pyomo/mpi-sppy/issues/762).

## Summary/Motivation:

Both legacy solver wrappers — APPSI (`pyomo/contrib/appsi/base.py`) and the new interface (`pyomo/contrib/solver/common/base.py`) — drop reduced costs when a model is solved with `solve(..., load_solutions=False)` and the solution is later applied via `model.solutions.load_from(results)`.

Instead of attaching each variable's reduced cost to that variable's entry in `legacy_soln.variable` (as is done for primal values, and analogous to the per-constraint dual/slack handling), the code assigned every reduced cost to a single literal `'Rc'` key:

```python
legacy_soln.variable['Rc'] = val
```

so `load_from` never routed the values into the model's `rc` Suffix, which was left empty. Primal values, duals, and slacks were unaffected; the bug is specific to reduced costs and is not solver-specific (it affects any solver used through these wrappers, e.g. `highs`, `gurobi`).

Reproducer:

```python
import pyomo.environ as pyo
m = pyo.ConcreteModel()
m.x = pyo.Var(bounds=(-1, 1))
m.obj = pyo.Objective(expr=m.x)
m.rc = pyo.Suffix(direction=pyo.Suffix.IMPORT)
opt = pyo.SolverFactory('appsi_highs')   # or 'highs'
res = opt.solve(m, load_solutions=False)
m.solutions.load_from(res)
print(len(m.rc))      # 0 before this fix; 1 after  (m.rc[m.x] == 1)
```

(With the default `load_solutions=True`, reduced costs load correctly — that path assigns `model.rc[v] = val` directly.)

## Changes proposed in this PR:
- Attach `'Rc'` to each variable's own entry in `legacy_soln.variable` (mirroring the existing slack handling) in both `pyomo/contrib/appsi/base.py` and `pyomo/contrib/solver/common/base.py`.
- Extend the legacy-interface `test_load_solutions` tests in both interfaces to load and assert a nonzero reduced cost (these tests fail without the source change).

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [x] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [x] AI tools generated tests (baselines, examples, and/or code)
    - [x] AI tools generated code (apart from tests)

    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [x] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository

 **Notes for reviewers (optional):** The fix mirrors the adjacent per-constraint slack handling. Verified locally with `highs` and `gurobi` through both the APPSI and new interfaces (`rc` now loads via `load_from`; the extended tests fail without the source change). The APPSI compiled extensions were not built in the dev environment, so those parameterized solver tests were exercised by running the test body directly; `black --check` is clean on all changed files.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
