### PR TITLE
KNITROAMPL: use \$KNITRODIR/knitroampl/knitroampl for executable

### DIFF
--- a/pyomo/solvers/plugins/solvers/KNITROAMPL.py
+++ b/pyomo/solvers/plugins/solvers/KNITROAMPL.py
@@ -7,6 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 import logging
+import os
 
 from pyomo.common import Executable
 from pyomo.common.collections import Bunch
@@ -64,17 +65,27 @@ class KNITROAMPL(ASL):
         self._capabilities.sos2 = False
 
     def _default_executable(self):
-        try:
-            # If knitro Python package is available, use the executable it contains
-            import knitro
-
-            package_knitroampl_path = (
-                pathlib.Path(knitro.__file__).resolve().parent
-                / 'knitroampl'
-                / 'knitroampl'
+        executable = None
+        knitrodir = os.environ.get('KNITRODIR')
+        if knitrodir:
+            knitroampl_path = (
+                pathlib.Path(knitrodir) / 'knitroampl' / 'knitroampl'
             )
-            executable = Executable(str(package_knitroampl_path))
-        except ModuleNotFoundError:
+            executable = Executable(str(knitroampl_path))
+        if not executable:
+            try:
+                # If knitro Python package is available, use the executable it contains
+                import knitro
+
+                package_knitroampl_path = (
+                    pathlib.Path(knitro.__file__).resolve().parent
+                    / 'knitroampl'
+                    / 'knitroampl'
+                )
+                executable = Executable(str(package_knitroampl_path))
+            except ModuleNotFoundError:
+                pass
+        if not executable:
             # Otherwise, search usual path list
             executable = Executable('knitroampl')
         if not executable:

--- a/pyomo/solvers/plugins/solvers/KNITROAMPL.py
+++ b/pyomo/solvers/plugins/solvers/KNITROAMPL.py
@@ -68,9 +68,7 @@ class KNITROAMPL(ASL):
         executable = None
         knitrodir = os.environ.get('KNITRODIR')
         if knitrodir:
-            knitroampl_path = (
-                pathlib.Path(knitrodir) / 'knitroampl' / 'knitroampl'
-            )
+            knitroampl_path = pathlib.Path(knitrodir) / 'knitroampl' / 'knitroampl'
             executable = Executable(str(knitroampl_path))
         if not executable:
             try:

--- a/pyomo/solvers/tests/checks/test_KNITROAMPL.py
+++ b/pyomo/solvers/tests/checks/test_KNITROAMPL.py
@@ -7,7 +7,10 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
+import os
+
 from pyomo.common import unittest
+from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (
     ConcreteModel,
     Var,
@@ -21,6 +24,32 @@ from pyomo.environ import (
 from pyomo.opt import SolverFactory, TerminationCondition
 
 knitroampl_available = SolverFactory('knitroampl').available(False)
+
+
+class TestKNITROAMPLDefaultExecutable(unittest.TestCase):
+    def test_default_executable_from_KNITRODIR(self):
+        with TempfileManager.new_context() as tempfile:
+            knitrodir = tempfile.create_tempdir()
+            exe = os.path.join(knitrodir, 'knitroampl', 'knitroampl')
+            # This makes a fake executable with the correct permissions
+            # so KNITRO actually recognizes it
+            os.mkdir(os.path.dirname(exe))
+            with open(exe, 'w'):
+                pass
+            os.chmod(exe, 0o755)
+
+            orig = os.environ.get('KNITRODIR')
+            os.environ['KNITRODIR'] = knitrodir
+            try:
+                opt = SolverFactory('knitroampl')
+                self.assertEqual(
+                    os.path.realpath(opt._default_executable()), os.path.realpath(exe)
+                )
+            finally:
+                if orig is None:
+                    del os.environ['KNITRODIR']
+                else:
+                    os.environ['KNITRODIR'] = orig
 
 
 @unittest.skipIf(not knitroampl_available, "The 'knitroampl' command is not available")


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

NA

## Summary/Motivation:

Some `KNITRO` users install it as a standalone package (not via the Python knitro module) and rely on the `KNITRODIR` environment variable to locate their installation. Previously, `_default_executable()` only checked the knitro Python package path first, then fell back to a plain PATH search, meaning users with a `KNITRODIR`-based installation but no Python package would only succeed if `knitroampl` happened to be on their PATH.

This PR adds an explicit lookup for `$KNITRODIR/knitroampl/knitroampl` as the highest-priority candidate, reflecting the standard layout of a standalone KNITRO installation.

## Changes proposed in this PR:
-
-

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

AI was used only for generating the commit message.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
