### PR TITLE
Fixed bugs in ParmEst cov_est function and Estimator class

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -1700,7 +1700,11 @@ class Estimator:
 
                 # fix the value of the unknown parameters to the estimated values
                 for param in model.unknown_parameters:
-                    param.fix(self.estimated_theta[param.name])
+                    if param.is_indexed():
+                        for idx in param:
+                            param[idx].fix(self.estimated_theta[param[idx].name])
+                    else:
+                        param.fix(self.estimated_theta[param.name])
 
                 # re-solve the model with the estimated parameters
                 results = pyo.SolverFactory(solver).solve(model, tee=self.tee)

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -1074,16 +1074,13 @@ class Estimator:
         assert isinstance(experiment_list, list)
         self.exp_list = experiment_list
 
-        # get the number of experiments
-        self.number_exp = _count_total_experiments(self.exp_list)
-
         # check if the experiment has a ``get_labeled_model`` function
         model = _get_labeled_model(self.exp_list[0])
 
         # check if the model has all the required suffixes
         _check_model_labels(model)
 
-        # populate keyword argument options
+        # check if the objective function is supplied correctly
         if isinstance(obj_function, str):
             try:
                 self.obj_function = ObjectiveType(obj_function)
@@ -1112,6 +1109,15 @@ class Estimator:
                 "regularization must be None or one of "
                 f"{[e.value for e in RegularizationType]}."
             )
+
+        # get the number of data points
+        # this is used to compute the covariance matrix for the case
+        # when the measurement errors are not supplied by the user
+        all_unknown_errors = all(
+            model.measurement_error[y_hat] is None for y_hat in model.experiment_outputs
+        )
+        if self.obj_function == ObjectiveType.SSE and all_unknown_errors:
+            self.number_exp = _count_total_experiments(self.exp_list)
 
         self.tee = tee
         self.diagnostic_mode = diagnostic_mode
@@ -1720,12 +1726,6 @@ class Estimator:
                 f"The sum of squared errors at the estimated parameter(s) is: {sse}"
             )
 
-        # Number of data points considered
-        n = self.number_exp
-
-        # Extract the number of fitted parameters
-        l = len(self.estimated_theta)
-
         """Calculate covariance assuming experimental observation errors are
         independent and follow a Gaussian distribution with constant variance.
 
@@ -1763,6 +1763,17 @@ class Estimator:
 
                 # check if the user supplied the values of the measurement errors
                 if all(item is None for item in meas_error):
+                    # Number of data points considered
+                    n = self.number_exp
+
+                    # Extract the number of fitted parameters
+                    l = len(self.estimated_theta)
+
+                    assert n > l, (
+                        "The number of datapoints must be greater than the "
+                        "number of parameters to estimate."
+                    )
+
                     if cov_method == CovarianceMethod.reduced_hessian:
                         # in the "reduced_hessian" method, use the objective value
                         # to calculate the measurement error variance because this
@@ -2026,18 +2037,6 @@ class Estimator:
         # check if the step input is a float
         if not isinstance(step, float):
             raise TypeError("Expected a float for the step, e.g., 1e-2")
-
-        # number of unknown parameters
-        num_unknowns = max(
-            [
-                len(_expanded_unknown_parameter_info(experiment.get_labeled_model())[0])
-                for experiment in self.exp_list
-            ]
-        )
-        assert self.number_exp > num_unknowns, (
-            "The number of datapoints must be greater than the "
-            "number of parameters to estimate."
-        )
 
         return self._cov_at_theta(method=method, solver=solver, step=step)
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -1113,9 +1113,12 @@ class Estimator:
         # get the number of data points
         # this is used to compute the covariance matrix for the case
         # when the measurement errors are not supplied by the user
-        all_unknown_errors = all(
+        get_measurement_error = getattr(model, "measurement_error", None)
+
+        all_unknown_errors = get_measurement_error is None or all(
             model.measurement_error[y_hat] is None for y_hat in model.experiment_outputs
         )
+
         if self.obj_function == ObjectiveType.SSE and all_unknown_errors:
             self.number_exp = _count_total_experiments(self.exp_list)
 

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -2272,10 +2272,11 @@ class TestParmestBlockEF(unittest.TestCase):
 
         self.assertEqual(pest._return_theta_names(), ["theta[a]", "theta[b]"])
 
+    @unittest.skipUnless(ipopt_available, "Test requires ipopt")
     def test_cov_est_counts_expanded_indexed_unknown_parameters(self):
         pest = _build_indexed_theta_estimator([(1.0, 2.0), (2.0, 4.0)])
 
-        pest.estimated_theta = {"theta[a]": 1.0, "theta[b]": 2.0}
+        obj, theta = pest.theta_est()
 
         with self.assertRaisesRegex(
             AssertionError,

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -2275,7 +2275,7 @@ class TestParmestBlockEF(unittest.TestCase):
     def test_cov_est_counts_expanded_indexed_unknown_parameters(self):
         pest = _build_indexed_theta_estimator([(1.0, 2.0), (2.0, 4.0)])
 
-        obj, theta = pest.theta_est()
+        obj, theta = pest._Q_opt()
 
         with self.assertRaisesRegex(
             AssertionError,

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -2275,7 +2275,7 @@ class TestParmestBlockEF(unittest.TestCase):
     def test_cov_est_counts_expanded_indexed_unknown_parameters(self):
         pest = _build_indexed_theta_estimator([(1.0, 2.0), (2.0, 4.0)])
 
-        obj, theta = pest._Q_opt()
+        pest.estimated_theta = {"theta[a]": 1.0, "theta[b]": 2.0}
 
         with self.assertRaisesRegex(
             AssertionError,

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -2275,6 +2275,8 @@ class TestParmestBlockEF(unittest.TestCase):
     def test_cov_est_counts_expanded_indexed_unknown_parameters(self):
         pest = _build_indexed_theta_estimator([(1.0, 2.0), (2.0, 4.0)])
 
+        obj, theta = pest.theta_est()
+
         with self.assertRaisesRegex(
             AssertionError,
             "The number of datapoints must be greater than the number of parameters to estimate.",


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
This PR fixes bugs in the Estimator class, `cov_est`, and `_cov_at_theta` functions of ParmEst

## Summary/Motivation:
1. The number of data points should only be counted in the case where the measurement error is not supplied by the user
2. The check that ensures that the number of data points is greater than the number of unknown parameters should be carried out in `_cov_at_theta` and not in `cov_est`, as this is only needed when measurement error is not supplied by the user


## Changes proposed in this PR:
- Ensure that the number of data points is only calculated for the SSE-with-unsupplied-measurement-error case
- Ensure that the check that compares the number of data points and the number of unknown parameters lives in `_cov_at_theta`

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [x] **AI tools were NOT used during the preparation of this PR**

or

- [ ] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
3. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
