### PR TITLE
Clip and scale calculate_variable_from_constraint

### DIFF
--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -11,6 +11,7 @@ from pyomo.common.errors import IterationLimitError
 from pyomo.common.numeric_types import native_numeric_types, native_complex_types, value
 from pyomo.core.expr.calculus.derivatives import differentiate
 from pyomo.core.base.constraint import Constraint
+from pyomo.core.base.suffix import SuffixFinder
 
 import logging
 
@@ -24,6 +25,53 @@ _symbolic_modes = {
 }
 
 
+def _clip_variable_to_bounds(variable, expr, eps):
+    """
+    Function to try to clip a variable back within its bounds.
+    If the expression residual is less than eps, then the new
+    value of the variable is retained. If the value is greater
+    than eps, then the original, bound-violating value of
+    variable is retained.
+
+    Parameters:
+    -----------
+    variable: :py:class:`VarData`
+        The variable to clip to within its bounds
+    expr: :py:class:`NumericExpression`
+        The expression to evaluate the constraint residual
+    eps: `float`
+        The tolerance to use to determine constraint feasibility.
+
+    Returns:
+    --------
+    None
+
+    """
+    # Should we check against variable domain here as well?
+    variable_value = value(variable)
+    if (
+        variable.lb is not None
+        and variable.ub is not None
+        and variable.lb > variable.ub
+    ):
+        raise ValueError(
+            f"Variable {variable} has inconsistent bounds. "
+            f"It has a lower bound of {variable.lb} and an "
+            f"upper bound of {variable.ub}."
+        )
+    elif variable.lb is not None and variable_value < variable.lb:
+        variable.set_value(variable.lb)
+        if abs(value(expr)) < eps:
+            return
+        # Else proceed to set the variable to its old value
+    elif variable.ub is not None and variable_value > variable.ub:
+        variable.set_value(variable.ub)
+        if abs(value(expr)) < eps:
+            return
+        # Else proceed to set the variable to its old value
+    variable.set_value(variable_value)
+
+
 def calculate_variable_from_constraint(
     variable,
     constraint,
@@ -32,6 +80,8 @@ def calculate_variable_from_constraint(
     linesearch=True,
     alpha_min=1e-8,
     diff_mode=None,
+    scale_problem=False,
+    clip_to_bounds=False,
 ):
     """Calculate the variable value given a specified equality constraint
 
@@ -72,6 +122,16 @@ def calculate_variable_from_constraint(
     diff_mode: :py:enum:`pyomo.core.expr.calculus.derivatives.Modes`
         The mode to use to differentiate the expression.  If
         unspecified, defaults to `Modes.sympy`
+    scale_problem: `bool`
+        Whether to take variable and constraint scaling into account
+        when calculating if the constraint residual tolerance is
+        satisfied or if the initial derivative is zero.
+    clip_to_bounds: `bool`
+        If terminating at a point outside a variable's bounds, set the
+        variable to its closest bound and see whether the constraint
+        residual termination condition is satisfied. This method is
+        applied only to constraints that are not solved by the shortcut
+        methods used to quickly solve linear constraints.
 
     Returns:
     --------
@@ -96,6 +156,16 @@ def calculate_variable_from_constraint(
 
     if lower != upper:
         raise ValueError(f"Constraint '{constraint}' must be an equality constraint")
+
+    if scale_problem:
+        finder = SuffixFinder('scaling_factor', 1.0, constraint.model())
+
+        sf_variable = finder.find(variable)
+        sf_constraint = finder.find(constraint)
+        eps /= sf_constraint
+    else:
+        sf_variable = 1
+        sf_constraint = 1
 
     _invalid_types = set(native_complex_types)
     _invalid_types.add(type(None))
@@ -219,7 +289,7 @@ def calculate_variable_from_constraint(
     else:
         fp0 = value(expr_deriv)
 
-    if abs(value(fp0)) < 1e-12:
+    if abs(value(fp0) * sf_constraint / sf_variable) < 1e-12:
         raise ValueError(
             f"Initial value for variable '{variable}' results in a derivative "
             f"value for constraint '{constraint}' that is very close to zero.\n"
@@ -258,7 +328,7 @@ def calculate_variable_from_constraint(
         else:
             fpk = value(expr_deriv)
 
-        if abs(fpk) < 1e-12:
+        if abs(fpk * sf_constraint / sf_variable) < 1e-12:
             # TODO: should this raise a ValueError or a new
             # DerivativeError (subclassing ArithmeticError)?
             raise RuntimeError(
@@ -310,7 +380,9 @@ def calculate_variable_from_constraint(
                     f"variable '{variable}' using constraint '{constraint}'; "
                     f"remaining residual = {residual}."
                 )
-    #
-    # Re-set the variable value to trigger any warnings WRT the final
-    # variable state
-    variable.set_value(variable.value)
+    if clip_to_bounds:
+        _clip_variable_to_bounds(variable, expr, eps)
+    else:
+        # Re-set the variable value to trigger any warnings WRT the final
+        # variable state
+        variable.set_value(variable.value)

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -301,11 +301,18 @@ def calculate_variable_from_constraint(
     while abs(fk) > eps and iter_left:
         iter_left -= 1
         if not iter_left:
-            raise IterationLimitError(
-                f"Iteration limit (%s) reached solving for variable '{variable}' "
-                f"using constraint '{constraint}'; remaining residual = %s"
-                % (iterlim, value(expr))
-            )
+            if scale_problem:
+                raise IterationLimitError(
+                    f"Iteration limit (%s) reached solving for variable '{variable}' "
+                    f"using constraint '{constraint}'; remaining (scaled) residual = %s"
+                    % (iterlim, sf_constraint * value(expr))
+                )
+            else:
+                raise IterationLimitError(
+                    f"Iteration limit (%s) reached solving for variable '{variable}' "
+                    f"using constraint '{constraint}'; remaining residual = %s"
+                    % (iterlim, value(expr))
+                )
 
         # compute step
         xk = value(variable)
@@ -356,7 +363,11 @@ def calculate_variable_from_constraint(
                     if fkp1.__class__ in _invalid_types:
                         # We cannot perform computations on complex numbers
                         fkp1 = None
-                    if fkp1 is not None and fkp1**2 < c1 * fk**2:
+                    if (
+                        fkp1 is not None
+                        and (fkp1 * sf_constraint / sf_variable) ** 2
+                        < c1 * (fk * sf_constraint / sf_variable) ** 2
+                    ):
                         # found an alpha value with sufficient reduction
                         # continue to the next step
                         fk = fkp1

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -363,10 +363,10 @@ def calculate_variable_from_constraint(
                     if fkp1.__class__ in _invalid_types:
                         # We cannot perform computations on complex numbers
                         fkp1 = None
+                    # Why isn't this the Armijo condition?
                     if (
                         fkp1 is not None
-                        and (fkp1 * sf_constraint / sf_variable) ** 2
-                        < c1 * (fk * sf_constraint / sf_variable) ** 2
+                        and (fkp1 * sf_constraint) ** 2 < c1 * (fk * sf_constraint) ** 2
                     ):
                         # found an alpha value with sufficient reduction
                         # continue to the next step

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -319,7 +319,7 @@ class Test_calc_var(unittest.TestCase):
                     "constraint 'g'; remaining residual = "
                     + SCIENTIFIC_NOTATION_REGEX
                     + r"\.",
-                    err.message,
+                    str(err),
                 )
                 assert out is not None
 

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -8,6 +8,7 @@
 # ____________________________________________________________________________________
 
 import logging
+import re
 from io import StringIO
 
 import pyomo.common.unittest as unittest
@@ -300,23 +301,27 @@ class Test_calc_var(unittest.TestCase):
                     m.x, m.g, diff_mode=mode, scale_problem=True
                 )
         # Here, because both the variable and constraint are scaled, we don't terminate due to
-        # a zero derivative. It still raises an error, however, because we're asking for an
-        # unreasonable amount of precision
+        # a zero derivative. It still raises an error on some platforms, however, because we're
+        # asking for an unreasonable amount of precision
         m.scaling_factor[m.x] = 1e16
         m.scaling_factor[m.g] = 1e16
         m.rhs.set_value(3)
         for mode in all_diff_modes:
             m.x.set_value(1)
-            with self.assertRaisesRegex(
-                IterationLimitError,
-                "Linesearch iteration limit reached solving for variable 'x' using "
-                "constraint 'g'; remaining residual = "
-                + SCIENTIFIC_NOTATION_REGEX
-                + r"\.",
-            ):
+
+            try:
                 calculate_variable_from_constraint(
                     m.x, m.g, diff_mode=mode, scale_problem=True
                 )
+            except IterationLimitError as err:
+                out = re.match(
+                    "Linesearch iteration limit reached solving for variable 'x' using "
+                    "constraint 'g'; remaining residual = "
+                    + SCIENTIFIC_NOTATION_REGEX
+                    + r"\.",
+                    err.message,
+                )
+                assert out is not None
 
         # Calculate the bubble point of Benzene.  The first step
         # computed by calculate_variable_from_constraint will make the

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -24,6 +24,7 @@ from pyomo.environ import (
     exp,
     NonNegativeReals,
     Binary,
+    Suffix,
 )
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core.expr.calculus.diff_with_sympy import differentiate_available
@@ -240,7 +241,26 @@ class Test_calc_var(unittest.TestCase):
                     m.x, m.f, linesearch=False, diff_mode=mode
                 )
 
-        # Calculate the bubble point of Benzene.  THe first step
+        # Test whether scaling is being correctly applied
+        m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        m.scaling_factor[m.e] = 1e4
+        for mode in all_diff_modes:
+            m.x.set_value(3.1)
+            calculate_variable_from_constraint(
+                m.x, m.e, eps=1e-4, diff_mode=mode, scale_problem=False
+            )
+            # Without scaling, we should stop at x = 3 + 1.028e-5
+            assert value(m.x) - 3 > 1e-5
+
+        for mode in all_diff_modes:
+            m.x.set_value(3.1)
+            calculate_variable_from_constraint(
+                m.x, m.e, eps=1e-6, diff_mode=mode, scale_problem=True
+            )
+            # With scaling, we should stop at x = 3 + 5.288-11
+            self.assertAlmostEqual(value(m.x), 3, places=9)
+
+        # Calculate the bubble point of Benzene.  The first step
         # computed by calculate_variable_from_constraint will make the
         # second term become complex, and the evaluation will fail.
         # This tests that the algorithm cleanly continues
@@ -414,6 +434,34 @@ class Test_calc_var(unittest.TestCase):
         self.assertAlmostEqual(value(m.x), 3.5, 3)
 
     @unittest.skipUnless(differentiate_available, "this test requires sympy")
+    def test_clip_bounds_nonlinear(self):
+        # This test was written with the assistance of Google Gemini 3.5 Flash
+        # (in order to generate the regex to match the value in the log).
+        m = ConcreteModel()
+        # The first step of Newton's method will overshoot the root
+        # and subsequent steps will be negative.
+        m.x = Var(initialize=1, bounds=(0, None))
+        m.c = Constraint(expr=-1.5 * m.x**2 + 3.5 * m.x == 0)
+
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(m.x, m.c, eps=1e-6, linesearch=False)
+        self.assertRegex(
+            LOG.getvalue().strip(),
+            r"Setting Var 'x' to a numeric value `-?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+` outside the "
+            r"bounds \(0, None\).",
+        )
+        self.assertAlmostEqual(value(m.x), 0)
+        assert value(m.x) < 0
+
+        m.x.set_value(1)
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(
+                m.x, m.c, eps=1e-6, linesearch=False, clip_to_bounds=True
+            )
+        assert len(LOG.getvalue().strip()) == 0
+        assert value(m.x) == 0
+
+    @unittest.skipUnless(differentiate_available, "this test requires sympy")
     def test_nonlinear_overflow(self):
         # Regression check to make sure calculate_variable_from_constraint
         # can handle extreme non-linear cases where assuming linear behaviour
@@ -466,3 +514,7 @@ class Test_calc_var(unittest.TestCase):
 
         calculate_variable_from_constraint(m.x, m.con)
         self.assertAlmostEqual(value(m.x), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -37,6 +37,10 @@ all_diff_modes = [
     differentiate.Modes.reverse_numeric,
 ]
 
+# This regex was written with Google Gemini 3.5 to match an arbitrary
+# floating point number in scientific notation
+SCIENTIFIC_NOTATION_REGEX = r"[+-]?(?:\d+(?:\.\d*)?)[eE][+-]?\d+"
+
 
 def sum_sq(args, fixed, fgh):
     f = sum(arg**2 for arg in args)
@@ -260,6 +264,60 @@ class Test_calc_var(unittest.TestCase):
             # With scaling, we should stop at x = 3 + 5.288-11
             self.assertAlmostEqual(value(m.x), 3, places=9)
 
+        # Check whether scaling factors are being used when calculating
+        # problem derivatives
+        # Here, the variable scaling causes a failure because the scaled
+        # derivative is near-zero
+        m.rhs = Param(initialize=3, mutable=True)
+        m.g = Constraint(expr=m.x**2 + m.x == m.rhs)
+        m.scaling_factor[m.x] = 1e16
+        for mode in all_diff_modes:
+            m.x.set_value(1)
+            with self.assertRaisesRegex(
+                ValueError,
+                "Initial value for variable 'x' results in a "
+                "derivative value for constraint 'g' that is very close to zero.",
+            ):
+                calculate_variable_from_constraint(
+                    m.x, m.g, diff_mode=mode, scale_problem=True
+                )
+
+        # Here, the constraint scaling factor causes a failure because the
+        # scaled derivative is near-zero
+        del m.scaling_factor[m.x]
+        # Set rhs to large value to make sure we don't terminate due to a small
+        # constraint residual in any of the shortcut steps
+        m.rhs.set_value(1e16)
+        m.scaling_factor[m.g] = 1e-16
+        for mode in all_diff_modes:
+            m.x.set_value(1)
+            with self.assertRaisesRegex(
+                ValueError,
+                "Initial value for variable 'x' results in a "
+                "derivative value for constraint 'g' that is very close to zero.",
+            ):
+                calculate_variable_from_constraint(
+                    m.x, m.g, diff_mode=mode, scale_problem=True
+                )
+        # Here, because both the variable and constraint are scaled, we don't terminate due to
+        # a zero derivative. It still raises an error, however, because we're asking for an
+        # unreasonable amount of precision
+        m.scaling_factor[m.x] = 1e16
+        m.scaling_factor[m.g] = 1e16
+        m.rhs.set_value(3)
+        for mode in all_diff_modes:
+            m.x.set_value(1)
+            with self.assertRaisesRegex(
+                IterationLimitError,
+                "Linesearch iteration limit reached solving for variable 'x' using "
+                "constraint 'g'; remaining residual = "
+                + SCIENTIFIC_NOTATION_REGEX
+                + r"\.",
+            ):
+                calculate_variable_from_constraint(
+                    m.x, m.g, diff_mode=mode, scale_problem=True
+                )
+
         # Calculate the bubble point of Benzene.  The first step
         # computed by calculate_variable_from_constraint will make the
         # second term become complex, and the evaluation will fail.
@@ -435,8 +493,7 @@ class Test_calc_var(unittest.TestCase):
 
     @unittest.skipUnless(differentiate_available, "this test requires sympy")
     def test_clip_bounds_nonlinear(self):
-        # This test was written with the assistance of Google Gemini 3.5 Flash
-        # (in order to generate the regex to match the value in the log).
+
         m = ConcreteModel()
         # The first step of Newton's method will overshoot the root
         # and subsequent steps will be negative.
@@ -447,7 +504,9 @@ class Test_calc_var(unittest.TestCase):
             calculate_variable_from_constraint(m.x, m.c, eps=1e-6, linesearch=False)
         self.assertRegex(
             LOG.getvalue().strip(),
-            r"Setting Var 'x' to a numeric value `-?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+` outside the "
+            r"Setting Var 'x' to a numeric value `"
+            + SCIENTIFIC_NOTATION_REGEX
+            + "` outside the "
             r"bounds \(0, None\).",
         )
         self.assertAlmostEqual(value(m.x), 0)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -573,7 +573,3 @@ class Test_calc_var(unittest.TestCase):
 
         calculate_variable_from_constraint(m.x, m.con)
         self.assertAlmostEqual(value(m.x), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # #3985, part of #3785, and point 4 of #3571

## Summary/Motivation:
Projects like PrOMMiS are increasingly relying on IDAES's `BlockTriangularizationInitializer`, which in turn relies on `solve_strongly_connected_components`.  However, in models that need significant amounts of scaling, the initialization raises an error that the constraint residuals are not small. That's because `BlockTriangularizationInitializer` takes constraint scaling into account but `solve_strongly_connected_components` does not.

This PR begins addressing this issue by adding an option to scale the variable and constraint in `calculate_variable_from_constraint`. Additionally, it adds an option to clip variable values that fall outside their bounds back inside those bounds, because we have a ton of log spam from Pyomo warning about variables getting set to values barely outside their bounds.

## Changes proposed in this PR:
- Add option to allow scaling of variable and constraint in `calculate_variable_from_constraint
- Add option to clip variables back to their bounds

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [x] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** I set the default values of these new options to `False` in order to avoid anything breaking from using the new options. However, I think users will usually want to set those options to `True`. On the IDAES side, I can set those options in the configuration of `BlockTriangularizationInitializer`, but consider what the default behavior in Pyomo should be.

Additionally, when clipping the values back to their bounds, I check the residual to see whether to accept the clipping or not. If the clipped value does not satisfy the convergence condition, it gets set to the unclipped value. What should the default behavior be?

Finally, I noticed the line search done here doesn't use the Armijo sufficient decrease condition. Is that intended behavior?

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
