### PR TITLE
Enable More Complex Error Structures in ParmEst and Pyomo.DoE

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -450,12 +450,13 @@ class DesignOfExperiments:
         self.results["Unknown Parameters"] = self.get_unknown_parameter_values()
         self.results["Unknown Parameter Names"] = [
             str(pyo.ComponentUID(k, context=model.scenario_blocks[0]))
-            for k in model.scenario_blocks[0].unknown_parameters
+            for k in self._get_param_data_objects(model.scenario_blocks[0])
         ]
         self.results["Measurement Error"] = self.get_measurement_error_values()
         self.results["Measurement Error Names"] = [
             str(pyo.ComponentUID(k, context=model.scenario_blocks[0]))
             for k in model.scenario_blocks[0].measurement_error
+            if hasattr(k, "name")
         ]
 
         self.results["Prior FIM"] = [list(row) for row in list(self.prior_FIM)]
@@ -604,11 +605,12 @@ class DesignOfExperiments:
             Full measurement-error covariance matrix
         """
         # get the output variables
-        outputs_name = [y.name for y in model.experiment_outputs]
-        output_index = {y: i for i, y in enumerate(outputs_name)}
+        outputs = list(model.experiment_outputs.keys())
+        outputs_name = [y_hat.name for y_hat in outputs]
+        outputs_index = {y_hat_name: i for i, y_hat_name in enumerate(outputs_name)}
 
         # get the number of output variables
-        number_outputs = len(outputs_name)
+        number_outputs = len(outputs)
 
         # define the measurement-error covariance matrix
         Sigma_y = np.zeros((number_outputs, number_outputs))
@@ -630,9 +632,12 @@ class DesignOfExperiments:
 
         # fill the leading-diagonal elements from the standard deviation of
         # the measurement errors
-        for y_name, i in output_index.items():
+        for y_hat in outputs:
+            # get the index of y_hat
+            i = outputs_index[y_hat.name]
+
             if all_known_errors:
-                standard_dev = model.measurement_error[model.find_component(y_name)]
+                standard_dev = model.measurement_error[y_hat]
                 Sigma_y[i, i] = standard_dev**2
             else:
                 raise ValueError(
@@ -653,8 +658,8 @@ class DesignOfExperiments:
                     )
 
                 # get the indices of yi and yj
-                i = output_index[yi.name]
-                j = output_index[yj.name]
+                i = outputs_index[yi.name]
+                j = outputs_index[yj.name]
 
                 # update the measurement-error covariance matrix which
                 # is a symmetric matrix
@@ -698,6 +703,32 @@ class DesignOfExperiments:
 
         return Sigma_y_inv
 
+    def _get_param_data_objects(self, model):
+        """
+        Creates a list of scalar parameter data objects
+        for indexed or scalar parameters
+
+        Parameters
+        ----------
+        model : ConcreteModel
+            Annotated Pyomo model
+
+        Returns
+        -------
+        params: list
+            List of scalar parameter data objects
+        """
+        params = []
+        for param in model.unknown_parameters:
+            # check if the parameter is indexed
+            if param.is_indexed():
+                # get the parameter data objects
+                params.extend(param.values())
+            else:
+                params.append(param)
+
+        return params
+
     # Compute FIM for the DoE object
     def compute_FIM(self, model=None, method="sequential"):
         """
@@ -732,7 +763,7 @@ class DesignOfExperiments:
         self.check_model_labels(model=model)
 
         # Set length values for the model features
-        self.n_parameters = len(model.unknown_parameters)
+        self.n_parameters = len(self._get_param_data_objects(model))
         self.n_measurement_error = len(
             [k for k in model.measurement_error if hasattr(k, "name")]
         )
@@ -741,9 +772,7 @@ class DesignOfExperiments:
 
         # Check FIM input, if it exists. Otherwise, set the prior_FIM attribute
         if self.prior_FIM is None:
-            self.prior_FIM = np.zeros(
-                (len(model.unknown_parameters), len(model.unknown_parameters))
-            )
+            self.prior_FIM = np.zeros((self.n_parameters, self.n_parameters))
         else:
             self.check_model_FIM(FIM=self.prior_FIM)
 
@@ -787,25 +816,28 @@ class DesignOfExperiments:
             model.del_component(model.parameter_scenarios)
         model.parameter_scenarios = pyo.Suffix(direction=pyo.Suffix.LOCAL)
 
+        # get the parameter data objects
+        unknown_params = self._get_param_data_objects(model)
+        unknown_params_val = {p.name: p.value for p in unknown_params}
+
         # Populate parameter scenarios, and scenario
         # inds based on finite difference scheme
         if self.fd_formula == FiniteDifferenceStep.central:
             model.parameter_scenarios.update(
-                (2 * ind, k) for ind, k in enumerate(model.unknown_parameters.keys())
+                (2 * ind, k) for ind, k in enumerate(unknown_params)
             )
             model.parameter_scenarios.update(
-                (2 * ind + 1, k)
-                for ind, k in enumerate(model.unknown_parameters.keys())
+                (2 * ind + 1, k) for ind, k in enumerate(unknown_params)
             )
-            model.scenarios = range(len(model.unknown_parameters) * 2)
+            model.scenarios = range(self.n_parameters * 2)
         elif self.fd_formula in [
             FiniteDifferenceStep.forward,
             FiniteDifferenceStep.backward,
         ]:
             model.parameter_scenarios.update(
-                (ind + 1, k) for ind, k in enumerate(model.unknown_parameters.keys())
+                (ind + 1, k) for ind, k in enumerate(unknown_params)
             )
-            model.scenarios = range(len(model.unknown_parameters) + 1)
+            model.scenarios = range(self.n_parameters + 1)
         else:
             raise DeveloperError(
                 "Finite difference option not recognized. Please "
@@ -840,7 +872,7 @@ class DesignOfExperiments:
             if not skip_param_update:
                 param = model.parameter_scenarios[s]
                 # Update parameter values for the given finite difference scenario
-                param.set_value(model.unknown_parameters[param] * (1 + diff))
+                param.set_value(unknown_params_val[param.name] * (1 + diff))
             else:
                 continue
 
@@ -860,7 +892,7 @@ class DesignOfExperiments:
 
             # Reset value of parameter to default value
             # before computing finite difference perturbation
-            param.set_value(model.unknown_parameters[param])
+            param.set_value(unknown_params_val[param.name])
 
             # Extract the measurement values for the scenario and append
             measurement_vals.append(
@@ -870,12 +902,7 @@ class DesignOfExperiments:
         # Use the measurement outputs to make the Q matrix
         measurement_vals_np = np.array(measurement_vals).T
 
-        self.seq_jac = np.zeros(
-            (
-                len(model.experiment_outputs.items()),
-                len(model.unknown_parameters.items()),
-            )
-        )
+        self.seq_jac = np.zeros((self.n_experiment_outputs, self.n_parameters))
 
         # Counting variable for loop
         i = 0
@@ -883,7 +910,8 @@ class DesignOfExperiments:
         # Loop over parameter values and grab correct
         # columns for finite difference calculation
 
-        for k, v in model.unknown_parameters.items():
+        for k in unknown_params:
+            v = pyo.value(k)
             curr_step = v * self.step
 
             if self.fd_formula == FiniteDifferenceStep.central:
@@ -946,8 +974,11 @@ class DesignOfExperiments:
 
         self.solver.solve(model, tee=self.tee)
 
+        # get the parameter data objects
+        unknown_params = self._get_param_data_objects(model)
+
         # Probe the solved model for dsdp results (sensitivities s.t. parameters)
-        params_dict = {k.name: v for k, v in model.unknown_parameters.items()}
+        params_dict = {p.name: p.value for p in unknown_params}
         params_names = list(params_dict.keys())
 
         dsdp_re, col = get_dsdp(model, params_names, params_dict, tee=self.tee)
@@ -980,12 +1011,12 @@ class DesignOfExperiments:
         jac = [[] for k in params_names]
 
         for d in range(len(dsdp_extract)):
-            for k, v in model.unknown_parameters.items():
+            for k in unknown_params:
                 p = params_names.index(k.name)  # Index of parameter in np array
                 # if scaled by parameter value or constant value
                 sensi = dsdp_extract[d][p] * self.scale_constant_value
                 if self.scale_nominal_param_value:
-                    sensi *= v
+                    sensi *= pyo.value(k)
                 jac[p].append(sensi)
 
         # record kaug jacobian
@@ -993,7 +1024,7 @@ class DesignOfExperiments:
 
         # Compute FIM
         if self.prior_FIM is None:
-            self.prior_FIM = np.zeros((len(params_names), len(params_names)))
+            self.prior_FIM = np.zeros(self.n_parameters, self.n_parameters)
         else:
             self.check_model_FIM(FIM=self.prior_FIM)
 
@@ -1051,13 +1082,13 @@ class DesignOfExperiments:
         scen_block_ind = min(
             [
                 k.name.split(".").index("scenario_blocks[0]")
-                for k in model.scenario_blocks[0].unknown_parameters.keys()
+                for k in self._get_param_data_objects(model.scenario_blocks[0])
             ]
         )
         model.parameter_names = pyo.Set(
             initialize=[
                 ".".join(k.name.split(".")[(scen_block_ind + 1) :])
-                for k in model.scenario_blocks[0].unknown_parameters.keys()
+                for k in self._get_param_data_objects(model.scenario_blocks[0])
             ]
         )
         model.output_names = pyo.Set(
@@ -1203,8 +1234,7 @@ class DesignOfExperiments:
             var_lo = cuid.find_component_on(m.scenario_blocks[s2])
 
             param = m.parameter_scenarios[max(s1, s2)]
-            param_loc = pyo.ComponentUID(param).find_component_on(m.scenario_blocks[0])
-            param_val = m.scenario_blocks[0].unknown_parameters[param_loc]
+            param_val = pyo.value(param)
             param_diff = param_val * fd_step_mult * self.step
 
             if self.scale_nominal_param_value:
@@ -1257,20 +1287,23 @@ class DesignOfExperiments:
                 else:
                     return m.fim[p, q] == m.fim[q, p]
             else:
-                return (
-                    m.fim[p, q]
-                    == sum(
-                        1
-                        / m.scenario_blocks[0].measurement_error[
-                            pyo.ComponentUID(n).find_component_on(m.scenario_blocks[0])
-                        ]
-                        ** 2
-                        * m.sensitivity_jacobian[n, p]
-                        * m.sensitivity_jacobian[n, q]
-                        for n in m.output_names
-                    )
-                    + m.prior_FIM[p, q]
+                # create a numpy array for the sensitivity Jacobian
+                sens_jac = np.array(
+                    [
+                        [m.sensitivity_jacobian[y, p] for p in m.parameter_names]
+                        for y in m.output_names
+                    ],
+                    dtype=object,
                 )
+
+                # get the inverse of the measurement-error covariance matrix
+                Sigma_y_inv = self.get_meas_error_covariance_matrix_inv(
+                    m.scenario_blocks[0]
+                )
+
+                fim_expr = sens_jac.T @ Sigma_y_inv @ sens_jac
+
+                return m.fim[p, q] == fim_expr[p_ind, q_ind] + m.prior_FIM[p, q]
 
         model.jacobian_constraint = pyo.Constraint(
             model.output_names, model.parameter_names, rule=jacobian_rule
@@ -1319,7 +1352,7 @@ class DesignOfExperiments:
         self.check_model_labels(model=model.base_model)
 
         # Gather lengths of label structures for later use in the model build process
-        self.n_parameters = len(model.base_model.unknown_parameters)
+        self.n_parameters = len(self._get_param_data_objects(model.base_model))
         self.n_measurement_error = len(
             [k for k in model.base_model.measurement_error if hasattr(k, "name")]
         )
@@ -1354,27 +1387,28 @@ class DesignOfExperiments:
         # are associated with parameters
         model.parameter_scenarios = pyo.Suffix(direction=pyo.Suffix.LOCAL)
 
+        # get the parameter data objects
+        unknown_params = self._get_param_data_objects(model.base_model)
+        unknown_params_val = {p.name: p.value for p in unknown_params}
+
         # Populate parameter scenarios, and scenario
         # inds based on finite difference scheme
         if self.fd_formula == FiniteDifferenceStep.central:
             model.parameter_scenarios.update(
-                (2 * ind, k)
-                for ind, k in enumerate(model.base_model.unknown_parameters.keys())
+                (2 * ind, k) for ind, k in enumerate(unknown_params)
             )
             model.parameter_scenarios.update(
-                (2 * ind + 1, k)
-                for ind, k in enumerate(model.base_model.unknown_parameters.keys())
+                (2 * ind + 1, k) for ind, k in enumerate(unknown_params)
             )
-            model.scenarios = range(len(model.base_model.unknown_parameters) * 2)
+            model.scenarios = range(self.n_parameters * 2)
         elif self.fd_formula in [
             FiniteDifferenceStep.forward,
             FiniteDifferenceStep.backward,
         ]:
             model.parameter_scenarios.update(
-                (ind + 1, k)
-                for ind, k in enumerate(model.base_model.unknown_parameters.keys())
+                (ind + 1, k) for ind, k in enumerate(unknown_params)
             )
-            model.scenarios = range(len(model.base_model.unknown_parameters) + 1)
+            model.scenarios = range(self.n_parameters + 1)
         else:
             raise DeveloperError(
                 "Finite difference option not recognized. Please contact "
@@ -1432,7 +1466,7 @@ class DesignOfExperiments:
             # Update parameter values for the given finite difference scenario
             pyo.ComponentUID(param, context=m.base_model).find_component_on(
                 b
-            ).set_value(m.base_model.unknown_parameters[param] * (1 + diff))
+            ).set_value(unknown_params_val[param.name] * (1 + diff))
 
             # Fix experiment inputs before solve (enforce square solve)
             for comp in b.experiment_inputs:
@@ -1841,7 +1875,7 @@ class DesignOfExperiments:
 
         # Check that unknown parameters exist
         try:
-            unknown_params = [k.name for k, v in model.unknown_parameters.items()]
+            unknown_params = self._get_param_data_objects(model)
         except:
             raise RuntimeError(
                 "Experiment model does not have suffix " + '"unknown_parameters".'
@@ -2819,12 +2853,11 @@ class DesignOfExperiments:
                     "`get_unknown_parameter_values`"
                 )
 
-            theta_vals = [
-                pyo.value(k)
-                for k, v in model.scenario_blocks[0].unknown_parameters.items()
-            ]
+            unknown_params = self._get_param_data_objects(model.scenario_blocks[0])
+            theta_vals = [pyo.value(k) for k in unknown_params]
         else:
-            theta_vals = [pyo.value(k) for k, v in model.unknown_parameters.items()]
+            unknown_params = self._get_param_data_objects(model)
+            theta_vals = [pyo.value(k) for k in unknown_params]
 
         return theta_vals
 
@@ -2893,12 +2926,17 @@ class DesignOfExperiments:
                     "`get_measurement_error_values`"
                 )
 
-            sigma_vals = [
-                pyo.value(k)
-                for k, v in model.scenario_blocks[0].measurement_error.items()
-            ]
+            # get the measurement-error covariance matrix
+            Sigma_matrix = self._build_meas_error_covariance_matrix(
+                model.scenario_blocks[0]
+            )
+
+            # get the measurement-error standard deviation
+            sigma_vals = np.sqrt(np.diag(Sigma_matrix))
+
         else:
-            sigma_vals = [pyo.value(k) for k, v in model.measurement_error.items()]
+            Sigma_matrix = self._build_meas_error_covariance_matrix(model)
+            sigma_vals = np.sqrt(np.diag(Sigma_matrix))
 
         return sigma_vals
 

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -450,7 +450,7 @@ class DesignOfExperiments:
         self.results["Unknown Parameters"] = self.get_unknown_parameter_values()
         self.results["Unknown Parameter Names"] = [
             str(pyo.ComponentUID(k, context=model.scenario_blocks[0]))
-            for k in self._get_param_data_objects(model.scenario_blocks[0])
+            for k in self._expanded_unknown_parameters(model.scenario_blocks[0])
         ]
         self.results["Measurement Error"] = self.get_measurement_error_values()
         self.results["Measurement Error Names"] = [
@@ -703,10 +703,13 @@ class DesignOfExperiments:
 
         return Sigma_y_inv
 
-    def _get_param_data_objects(self, model):
+    def _expanded_unknown_parameters(self, model):
         """
-        Creates a list of scalar parameter data objects
-        for indexed or scalar parameters
+        Creates a list of scalar unknown parameter components
+
+        The unknown_parameters suffix may contain either scalar ComponentData
+        objects or indexed components. Indexed components are expanded to
+        their scalar data objects.
 
         Parameters
         ----------
@@ -715,19 +718,19 @@ class DesignOfExperiments:
 
         Returns
         -------
-        params: list
+        params_data_object: list
             List of scalar parameter data objects
         """
-        params = []
-        for param in model.unknown_parameters:
-            # check if the parameter is indexed
-            if param.is_indexed():
+        params_data_object = []
+        for component in model.unknown_parameters:
+            # check if it is indexed
+            if component.is_indexed():
                 # get the parameter data objects
-                params.extend(param.values())
+                params_data_object.extend(component.values())
             else:
-                params.append(param)
+                params_data_object.append(component)
 
-        return params
+        return params_data_object
 
     # Compute FIM for the DoE object
     def compute_FIM(self, model=None, method="sequential"):
@@ -763,7 +766,7 @@ class DesignOfExperiments:
         self.check_model_labels(model=model)
 
         # Set length values for the model features
-        self.n_parameters = len(self._get_param_data_objects(model))
+        self.n_parameters = len(self._expanded_unknown_parameters(model))
         self.n_measurement_error = len(
             [k for k in model.measurement_error if hasattr(k, "name")]
         )
@@ -817,7 +820,7 @@ class DesignOfExperiments:
         model.parameter_scenarios = pyo.Suffix(direction=pyo.Suffix.LOCAL)
 
         # get the parameter data objects
-        unknown_params = self._get_param_data_objects(model)
+        unknown_params = self._expanded_unknown_parameters(model)
         unknown_params_val = {p.name: p.value for p in unknown_params}
 
         # Populate parameter scenarios, and scenario
@@ -975,7 +978,7 @@ class DesignOfExperiments:
         self.solver.solve(model, tee=self.tee)
 
         # get the parameter data objects
-        unknown_params = self._get_param_data_objects(model)
+        unknown_params = self._expanded_unknown_parameters(model)
 
         # Probe the solved model for dsdp results (sensitivities s.t. parameters)
         params_dict = {p.name: p.value for p in unknown_params}
@@ -1082,13 +1085,13 @@ class DesignOfExperiments:
         scen_block_ind = min(
             [
                 k.name.split(".").index("scenario_blocks[0]")
-                for k in self._get_param_data_objects(model.scenario_blocks[0])
+                for k in self._expanded_unknown_parameters(model.scenario_blocks[0])
             ]
         )
         model.parameter_names = pyo.Set(
             initialize=[
                 ".".join(k.name.split(".")[(scen_block_ind + 1) :])
-                for k in self._get_param_data_objects(model.scenario_blocks[0])
+                for k in self._expanded_unknown_parameters(model.scenario_blocks[0])
             ]
         )
         model.output_names = pyo.Set(
@@ -1352,7 +1355,7 @@ class DesignOfExperiments:
         self.check_model_labels(model=model.base_model)
 
         # Gather lengths of label structures for later use in the model build process
-        self.n_parameters = len(self._get_param_data_objects(model.base_model))
+        self.n_parameters = len(self._expanded_unknown_parameters(model.base_model))
         self.n_measurement_error = len(
             [k for k in model.base_model.measurement_error if hasattr(k, "name")]
         )
@@ -1388,7 +1391,7 @@ class DesignOfExperiments:
         model.parameter_scenarios = pyo.Suffix(direction=pyo.Suffix.LOCAL)
 
         # get the parameter data objects
-        unknown_params = self._get_param_data_objects(model.base_model)
+        unknown_params = self._expanded_unknown_parameters(model.base_model)
         unknown_params_val = {p.name: p.value for p in unknown_params}
 
         # Populate parameter scenarios, and scenario
@@ -1875,7 +1878,7 @@ class DesignOfExperiments:
 
         # Check that unknown parameters exist
         try:
-            unknown_params = self._get_param_data_objects(model)
+            unknown_params = self._expanded_unknown_parameters(model)
         except:
             raise RuntimeError(
                 "Experiment model does not have suffix " + '"unknown_parameters".'
@@ -2853,10 +2856,10 @@ class DesignOfExperiments:
                     "`get_unknown_parameter_values`"
                 )
 
-            unknown_params = self._get_param_data_objects(model.scenario_blocks[0])
+            unknown_params = self._expanded_unknown_parameters(model.scenario_blocks[0])
             theta_vals = [pyo.value(k) for k in unknown_params]
         else:
-            unknown_params = self._get_param_data_objects(model)
+            unknown_params = self._expanded_unknown_parameters(model)
             theta_vals = [pyo.value(k) for k in unknown_params]
 
         return theta_vals

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -648,7 +648,7 @@ class DesignOfExperiments:
 
         # fill the off-diagonal elements from covariance entries
         # supplied by the user
-        for key, entry in model.measurement_error.items():
+        for key, err_cov in model.measurement_error.items():
             if isinstance(key, tuple) and len(key) == 2:
                 yi, yj = key
                 if yi.name not in outputs_name or yj.name not in outputs_name:
@@ -663,8 +663,8 @@ class DesignOfExperiments:
 
                 # update the measurement-error covariance matrix which
                 # is a symmetric matrix
-                Sigma_y[i, j] = entry
-                Sigma_y[j, i] = entry
+                Sigma_y[i, j] = err_cov
+                Sigma_y[j, i] = err_cov
             elif not isinstance(key, tuple) and not hasattr(key, "name"):
                 raise TypeError(
                     "Expected a tuple of two measured variables when specifying a "

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -581,6 +581,123 @@ class DesignOfExperiments:
     def run_multi_doe_simultaneous(self, N_exp=1):
         raise NotImplementedError("Multiple experiment optimization not yet supported.")
 
+    def _build_meas_error_covariance_matrix(self, model):
+        """
+        Builds the full measurement-error covariance matrix
+
+        Note: The code does not automatically build the full covariance matrix
+        It only places whatever standard deviation and covariances the user
+        explicitly supplies
+        Therefore, for correlation in time, shared timepoints, or other types of
+        correlation, the user must provide all the desired covariance terms
+        They standard deviations may be constant or depend on the value (i.e.,
+        data) of the measured or input variables (e.g., be proportional to them)
+
+        Parameters
+        ----------
+        model : ConcreteModel
+            Annotated Pyomo model
+
+        Returns
+        -------
+        Sigma_y: numpy.ndarray
+            Full measurement-error covariance matrix
+        """
+        # get the output variables
+        outputs_name = [y.name for y in model.experiment_outputs]
+        output_index = {y: i for i, y in enumerate(outputs_name)}
+
+        # get the number of output variables
+        number_outputs = len(outputs_name)
+
+        # define the measurement-error covariance matrix
+        Sigma_y = np.zeros((number_outputs, number_outputs))
+
+        # check if all the values of the measurement-error standard deviation
+        # have been supplied
+        try:
+            all_known_errors = all(
+                model.measurement_error[y_hat] is not None
+                for y_hat in model.experiment_outputs
+            )
+        except KeyError:
+            raise KeyError(
+                'One or more experiment outputs are not defined in the '
+                '"measurement_error" attribute. All the variables defined '
+                'in "experiment_outputs" must be defined as keys in '
+                '"measurement_error".'
+            )
+
+        # fill the leading-diagonal elements from the standard deviation of
+        # the measurement errors
+        for y_name, i in output_index.items():
+            if all_known_errors:
+                standard_dev = model.measurement_error[model.find_component(y_name)]
+                Sigma_y[i, i] = standard_dev**2
+            else:
+                raise ValueError(
+                    'One or more values are missing from "measurement_error". All '
+                    'values of the measurement errors are required to compute the '
+                    'Fisher information matrix.'
+                )
+
+        # fill the off-diagonal elements from covariance entries
+        # supplied by the user
+        for key, entry in model.measurement_error.items():
+            if isinstance(key, tuple) and len(key) == 2:
+                yi, yj = key
+                if yi.name not in outputs_name or yj.name not in outputs_name:
+                    raise ValueError(
+                        "Measurement-error covariance must be defined only between "
+                        "experiment output variables."
+                    )
+
+                # get the indices of yi and yj
+                i = output_index[yi.name]
+                j = output_index[yj.name]
+
+                # update the measurement-error covariance matrix which
+                # is a symmetric matrix
+                Sigma_y[i, j] = entry
+                Sigma_y[j, i] = entry
+            elif not isinstance(key, tuple) and not hasattr(key, "name"):
+                raise TypeError(
+                    "Expected a tuple of two measured variables when specifying a "
+                    "measurement-error covariance, e.g., "
+                    "measurement_error[(y1, y2)] = covariance."
+                )
+
+        return Sigma_y
+
+    def get_meas_error_covariance_matrix_inv(self, model):
+        """
+        Computes the inverse of the measurement-error covariance matrix
+
+        Parameters
+        ----------
+        model : ConcreteModel
+            Annotated Pyomo model
+
+        Returns
+        -------
+        Sigma_y_inv: numpy.ndarray
+            Inverse of the measurement-error covariance matrix
+        """
+        # get the measurement-error covariance matrix
+        Sigma_y = self._build_meas_error_covariance_matrix(model)
+
+        # compute the inverse of the measurement-error covariance matrix
+        try:
+            Sigma_y_inv = np.linalg.inv(Sigma_y)
+        except np.linalg.LinAlgError:
+            Sigma_y_inv = np.linalg.pinv(Sigma_y)
+            logger.warning(
+                "The measurement-error covariance matrix is singular. "
+                "Using pseudo-inverse instead."
+            )
+
+        return Sigma_y_inv
+
     # Compute FIM for the DoE object
     def compute_FIM(self, model=None, method="sequential"):
         """
@@ -616,7 +733,9 @@ class DesignOfExperiments:
 
         # Set length values for the model features
         self.n_parameters = len(model.unknown_parameters)
-        self.n_measurement_error = len(model.measurement_error)
+        self.n_measurement_error = len(
+            [k for k in model.measurement_error if hasattr(k, "name")]
+        )
         self.n_experiment_inputs = len(model.experiment_inputs)
         self.n_experiment_outputs = len(model.experiment_outputs)
 
@@ -792,18 +911,11 @@ class DesignOfExperiments:
             # Increment the count
             i += 1
 
-        # TODO: As more complex measurement error schemes
-        #       are put in place, this needs to change
-        # Add independent (non-correlated) measurement
-        # error for FIM calculation
-        cov_y = np.zeros((len(model.measurement_error), len(model.measurement_error)))
-        count = 0
-        for k, v in model.measurement_error.items():
-            cov_y[count, count] = 1 / v**2
-            count += 1
+        # get the inverse of the measurement-error covariance matrix
+        Sigma_y_inv = self.get_meas_error_covariance_matrix_inv(model)
 
         # Compute and record FIM
-        self.seq_FIM = self.seq_jac.T @ cov_y @ self.seq_jac + self.prior_FIM
+        self.seq_FIM = self.seq_jac.T @ Sigma_y_inv @ self.seq_jac + self.prior_FIM
 
     # Use kaug to get FIM
     def _kaug_FIM(self, model=None):
@@ -885,19 +997,10 @@ class DesignOfExperiments:
         else:
             self.check_model_FIM(FIM=self.prior_FIM)
 
-        # Constructing the Covariance of the measurements for the FIM calculation
-        # The following assumes independent measurement error.
-        cov_y = np.zeros((len(model.measurement_error), len(model.measurement_error)))
-        count = 0
-        for k, v in model.measurement_error.items():
-            cov_y[count, count] = 1 / v**2
-            count += 1
+        # get the inverse of the measurement-error covariance matrix
+        Sigma_y_inv = self.get_meas_error_covariance_matrix_inv(model)
 
-        # TODO: need to add a covariance matrix for measurements (sigma inverse)
-        # i.e., cov_y = self.cov_y or model.cov_y
-        # Still deciding where this would be best.
-
-        self.kaug_FIM = self.kaug_jac.T @ cov_y @ self.kaug_jac + self.prior_FIM
+        self.kaug_FIM = self.kaug_jac.T @ Sigma_y_inv @ self.kaug_jac + self.prior_FIM
 
     # Create the DoE model (with ``scenarios`` from finite differencing scheme)
     def create_doe_model(self, model=None):
@@ -1217,7 +1320,9 @@ class DesignOfExperiments:
 
         # Gather lengths of label structures for later use in the model build process
         self.n_parameters = len(model.base_model.unknown_parameters)
-        self.n_measurement_error = len(model.base_model.measurement_error)
+        self.n_measurement_error = len(
+            [k for k in model.base_model.measurement_error if hasattr(k, "name")]
+        )
         self.n_experiment_inputs = len(model.base_model.experiment_inputs)
         self.n_experiment_outputs = len(model.base_model.experiment_outputs)
 
@@ -1728,7 +1833,7 @@ class DesignOfExperiments:
 
         # Check that experimental inputs exist
         try:
-            outputs = [k.name for k, v in model.experiment_inputs.items()]
+            exp_inputs = [k.name for k, v in model.experiment_inputs.items()]
         except:
             raise RuntimeError(
                 "Experiment model does not have suffix " + '"experiment_inputs".'
@@ -1736,7 +1841,7 @@ class DesignOfExperiments:
 
         # Check that unknown parameters exist
         try:
-            outputs = [k.name for k, v in model.unknown_parameters.items()]
+            unknown_params = [k.name for k, v in model.unknown_parameters.items()]
         except:
             raise RuntimeError(
                 "Experiment model does not have suffix " + '"unknown_parameters".'
@@ -1744,7 +1849,7 @@ class DesignOfExperiments:
 
         # Check that measurement errors exist
         try:
-            outputs = [k.name for k, v in model.measurement_error.items()]
+            meas_error = [k.name for k in model.measurement_error if hasattr(k, "name")]
         except:
             raise RuntimeError(
                 "Experiment model does not have suffix " + '"measurement_error".'

--- a/pyomo/contrib/doe/tests/test_doe_build.py
+++ b/pyomo/contrib/doe/tests/test_doe_build.py
@@ -462,7 +462,7 @@ class TestDoeBuild(unittest.TestCase):
 
         count = 0
         for k, v in doe_obj.compute_FIM_model.measurement_error.items():
-            self.assertEqual(pyo.value(k), stuff[count])
+            self.assertEqual(v, stuff[count])
             count += 1
 
     def test_get_unknown_parameters_without_blocks(self):

--- a/pyomo/contrib/doe/tests/test_doe_solve.py
+++ b/pyomo/contrib/doe/tests/test_doe_solve.py
@@ -70,17 +70,79 @@ def get_rooney_biegler_data():
     return data.iloc[0]
 
 
-def get_rooney_biegler_experiment():
+def get_rooney_biegler_experiment(index_vars=False):
     """Get a fresh RooneyBieglerExperiment instance for testing.
 
     Creates a new experiment instance to ensure test isolation.
     Each test gets its own instance to avoid state sharing.
+
+    Parameters
+    ----------
+    index_vars : Boolean
+        Specifies if the Rooney-Biegler model with indexed
+        parameters is used
     """
-    return RooneyBieglerExperiment(
-        data=get_rooney_biegler_data(),
-        theta={'asymptote': 15, 'rate_constant': 0.5},
-        measure_error=0.1,
-    )
+
+    if index_vars:
+
+        class RooneyBieglerExperimentIndexed(RooneyBieglerExperiment):
+            def create_model(self):
+                data = self.data.to_frame().transpose()
+
+                model = pyo.ConcreteModel()
+
+                model.var_names = pyo.Set(initialize=["asymptote", "rate_constant"])
+                model.theta = pyo.Var(model.var_names, initialize=self.theta)
+                model.theta["asymptote"].fix()
+                model.theta["rate_constant"].fix()
+
+                # Add the experiment inputs
+                model.hour = pyo.Var(initialize=data["hour"].iloc[0], bounds=(0, 10))
+
+                # Fix the experiment inputs
+                model.hour.fix()
+
+                # Add experiment outputs
+                model.y = pyo.Var(
+                    initialize=data['y'].iloc[0], within=pyo.PositiveReals
+                )
+
+                # Define the model equations
+                def response_rule(m):
+                    return m.y == m.theta["asymptote"] * (
+                        1 - pyo.exp(-m.theta["rate_constant"] * m.hour)
+                    )
+
+                model.response_con = pyo.Constraint(rule=response_rule)
+
+                self.model = model
+
+            def label_model(self):
+                m = self.model
+
+                m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_outputs.update([(m.y, self.data["y"])])
+
+                m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.unknown_parameters.update((k, pyo.ComponentUID(k)) for k in [m.theta])
+
+                m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.measurement_error.update([(m.y, self.measure_error)])
+
+                m.experiment_inputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_inputs.update([(m.hour, self.data['hour'])])
+
+        return RooneyBieglerExperimentIndexed(
+            data=get_rooney_biegler_data(),
+            theta={'asymptote': 15, 'rate_constant': 0.5},
+            measure_error=0.1,
+        )
+    else:
+        return RooneyBieglerExperiment(
+            data=get_rooney_biegler_data(),
+            theta={'asymptote': 15, 'rate_constant': 0.5},
+            measure_error=0.1,
+        )
 
 
 def get_FIM_Q_L(doe_obj=None):
@@ -111,9 +173,8 @@ def get_FIM_Q_L(doe_obj=None):
         for i in model.output_names
         for j in model.parameter_names
     ]
-    sigma_inv = [
-        1 / v**2 for k, v in model.scenario_blocks[0].measurement_error.items()
-    ]
+    sigma_inv = doe_obj.get_meas_error_covariance_matrix_inv(model.scenario_blocks[0])
+
     FIM_vals_np = np.array(FIM_vals).reshape((n_param, n_param))
 
     for i in range(n_param):
@@ -124,12 +185,7 @@ def get_FIM_Q_L(doe_obj=None):
     L_vals_np = np.array(L_vals).reshape((n_param, n_param))
     Q_vals_np = np.array(Q_vals).reshape((n_y, n_param))
 
-    sigma_inv_np = np.zeros((n_y, n_y))
-
-    for ind, v in enumerate(sigma_inv):
-        sigma_inv_np[ind, ind] = v
-
-    return FIM_vals_np, Q_vals_np, L_vals_np, sigma_inv_np
+    return FIM_vals_np, Q_vals_np, L_vals_np, sigma_inv
 
 
 def get_standard_args(experiment, fd_method, obj_used):
@@ -168,23 +224,36 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         doe_obj.run_doe()
+        indx_param_doe_obj.run_doe()
 
         # assert model solves
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
+        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
+            doe_obj=indx_param_doe_obj
+        )
 
         # Since Trace is used, no comparison for FIM and L.T @ L
 
         # Make sure FIM and Q.T @ sigma_inv @ Q are close (alternate definition of FIM)
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q)))
+        self.assertTrue(
+            np.all(np.isclose(FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx))
+        )
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_fd_forward_solve(self):
@@ -230,22 +299,35 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         doe_obj.run_doe()
+        indx_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
+        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
+            doe_obj=indx_param_doe_obj
+        )
 
         # Since Trace is used, no comparison for FIM and L.T @ L
 
         # Make sure FIM and Q.T @ sigma_inv @ Q are close (alternate definition of FIM)
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q)))
+        self.assertTrue(
+            np.all(np.isclose(FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx))
+        )
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_obj_det_solve(self):
@@ -254,27 +336,43 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
+
         DoE_args["scale_nominal_param_value"] = (
             False  # Vanilla determinant solve needs this
         )
         DoE_args["_Cholesky_option"] = False
         DoE_args["_only_compute_fim_lower"] = False
 
+        indx_param_DoE_args["scale_nominal_param_value"] = False
+        indx_param_DoE_args["_Cholesky_option"] = False
+        indx_param_DoE_args["_only_compute_fim_lower"] = False
+
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         # Increase numerical performance by adding a prior
         prior_FIM = doe_obj.compute_FIM()
+        prior_FIM_indx = indx_param_doe_obj.compute_FIM()
         doe_obj.prior_FIM = prior_FIM
+        indx_param_doe_obj.prior_FIM = prior_FIM_indx
 
         doe_obj.run_doe()
+        indx_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
 
         expected_design = 9.999213890476453
         actual_design = doe_obj.results["Experiment Design"][0]
+        actual_design_indx = indx_param_doe_obj.results["Experiment Design"][0]
         self.assertAlmostEqual(actual_design, expected_design, places=3)
+        self.assertAlmostEqual(actual_design_indx, expected_design, places=3)
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_obj_cholesky_solve(self):
@@ -283,29 +381,50 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         # Add prior FIM for better numerical conditioning
         # This follows the pattern in rooney_biegler_doe_example.py
         doe_obj_prior = DesignOfExperiments(**DoE_args)
+        indx_doe_obj_prior = DesignOfExperiments(**indx_param_DoE_args)
         prior_FIM = doe_obj_prior.compute_FIM()
+        prior_FIM_indx = indx_doe_obj_prior.compute_FIM()
         DoE_args['prior_FIM'] = prior_FIM
+        indx_param_DoE_args['prior_FIM'] = prior_FIM_indx
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         doe_obj.run_doe()
+        indx_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
+        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
+            doe_obj=indx_param_doe_obj
+        )
 
         # Since Cholesky is used, there is comparison for FIM and L.T @ L
         self.assertTrue(np.all(np.isclose(FIM, L @ L.T)))
+        self.assertTrue(np.all(np.isclose(FIM_indx, L_indx @ L_indx.T)))
 
         # Note: When using prior_FIM, the relationship FIM = Q.T @ sigma_inv @ Q + prior_FIM
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q + prior_FIM)))
+        self.assertTrue(
+            np.all(
+                np.isclose(
+                    FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx + prior_FIM_indx
+                )
+            )
+        )
 
     def DISABLE_test_reactor_obj_cholesky_solve_bad_prior(self):
         # [10/2025] This test has been disabled because it frequently
@@ -349,10 +468,15 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         expected_FIM = np.array(
             [[18957.7788694, 4238.27606876], [4238.27606876, 947.52577076]]
@@ -360,6 +484,13 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         self.assertTrue(
             np.all(np.isclose(doe_obj.compute_FIM(method="sequential"), expected_FIM))
+        )
+        self.assertTrue(
+            np.all(
+                np.isclose(
+                    indx_param_doe_obj.compute_FIM(method="sequential"), expected_FIM
+                )
+            )
         )
 
     # This test ensure that compute FIM runs without error using the
@@ -371,12 +502,18 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         doe_obj.compute_FIM(method="sequential")
+        indx_param_doe_obj.compute_FIM(method="sequential")
 
     # This test ensure that compute FIM runs without error using the
     # `kaug` option. kaug computes the FIM directly so no finite difference
@@ -390,10 +527,15 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
         obj_used = "determinant"
 
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         expected_FIM = np.array(
             [[18957.7788694, 4238.27606876], [4238.27606876, 947.52577076]]
@@ -401,6 +543,11 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         self.assertTrue(
             np.all(np.isclose(doe_obj.compute_FIM(method="kaug"), expected_FIM))
+        )
+        self.assertTrue(
+            np.all(
+                np.isclose(indx_param_doe_obj.compute_FIM(method="kaug"), expected_FIM)
+            )
         )
 
     # This test ensure that compute FIM runs without error using the
@@ -412,12 +559,18 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
+        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
+        indx_param_DoE_args = get_standard_args(
+            indx_param_experiment, fd_method, obj_used
+        )
 
         doe_obj = DesignOfExperiments(**DoE_args)
+        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
 
         doe_obj.compute_FIM(method="sequential")
+        indx_param_doe_obj.compute_FIM(method="sequential")
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_reactor_grid_search(self):

--- a/pyomo/contrib/doe/tests/test_doe_solve.py
+++ b/pyomo/contrib/doe/tests/test_doe_solve.py
@@ -224,36 +224,32 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         doe_obj.run_doe()
-        indx_param_doe_obj.run_doe()
+        ind_param_doe_obj.run_doe()
 
         # assert model solves
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
-        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(ind_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
-        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
-            doe_obj=indx_param_doe_obj
-        )
+        FIM_ind, Q_ind, L_ind, sigma_inv_ind = get_FIM_Q_L(doe_obj=ind_param_doe_obj)
 
         # Since Trace is used, no comparison for FIM and L.T @ L
 
         # Make sure FIM and Q.T @ sigma_inv @ Q are close (alternate definition of FIM)
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q)))
-        self.assertTrue(
-            np.all(np.isclose(FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx))
-        )
+        self.assertTrue(np.all(np.isclose(FIM_ind, Q_ind.T @ sigma_inv_ind @ Q_ind)))
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_fd_forward_solve(self):
@@ -299,35 +295,31 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         doe_obj.run_doe()
-        indx_param_doe_obj.run_doe()
+        ind_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
-        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(ind_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
-        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
-            doe_obj=indx_param_doe_obj
-        )
+        FIM_ind, Q_ind, L_ind, sigma_inv_ind = get_FIM_Q_L(doe_obj=ind_param_doe_obj)
 
         # Since Trace is used, no comparison for FIM and L.T @ L
 
         # Make sure FIM and Q.T @ sigma_inv @ Q are close (alternate definition of FIM)
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q)))
-        self.assertTrue(
-            np.all(np.isclose(FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx))
-        )
+        self.assertTrue(np.all(np.isclose(FIM_ind, Q_ind.T @ sigma_inv_ind @ Q_ind)))
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_obj_det_solve(self):
@@ -336,11 +328,11 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         DoE_args["scale_nominal_param_value"] = (
@@ -349,30 +341,30 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
         DoE_args["_Cholesky_option"] = False
         DoE_args["_only_compute_fim_lower"] = False
 
-        indx_param_DoE_args["scale_nominal_param_value"] = False
-        indx_param_DoE_args["_Cholesky_option"] = False
-        indx_param_DoE_args["_only_compute_fim_lower"] = False
+        ind_param_DoE_args["scale_nominal_param_value"] = False
+        ind_param_DoE_args["_Cholesky_option"] = False
+        ind_param_DoE_args["_only_compute_fim_lower"] = False
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         # Increase numerical performance by adding a prior
         prior_FIM = doe_obj.compute_FIM()
-        prior_FIM_indx = indx_param_doe_obj.compute_FIM()
+        prior_FIM_ind = ind_param_doe_obj.compute_FIM()
         doe_obj.prior_FIM = prior_FIM
-        indx_param_doe_obj.prior_FIM = prior_FIM_indx
+        ind_param_doe_obj.prior_FIM = prior_FIM_ind
 
         doe_obj.run_doe()
-        indx_param_doe_obj.run_doe()
+        ind_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
-        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(ind_param_doe_obj.results["Solver Status"], "ok")
 
         expected_design = 9.999213890476453
         actual_design = doe_obj.results["Experiment Design"][0]
-        actual_design_indx = indx_param_doe_obj.results["Experiment Design"][0]
+        actual_design_ind = ind_param_doe_obj.results["Experiment Design"][0]
         self.assertAlmostEqual(actual_design, expected_design, places=3)
-        self.assertAlmostEqual(actual_design_indx, expected_design, places=3)
+        self.assertAlmostEqual(actual_design_ind, expected_design, places=3)
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_rooney_biegler_obj_cholesky_solve(self):
@@ -381,49 +373,43 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         # Add prior FIM for better numerical conditioning
         # This follows the pattern in rooney_biegler_doe_example.py
         doe_obj_prior = DesignOfExperiments(**DoE_args)
-        indx_doe_obj_prior = DesignOfExperiments(**indx_param_DoE_args)
+        ind_doe_obj_prior = DesignOfExperiments(**ind_param_DoE_args)
         prior_FIM = doe_obj_prior.compute_FIM()
-        prior_FIM_indx = indx_doe_obj_prior.compute_FIM()
+        prior_FIM_ind = ind_doe_obj_prior.compute_FIM()
         DoE_args['prior_FIM'] = prior_FIM
-        indx_param_DoE_args['prior_FIM'] = prior_FIM_indx
+        ind_param_DoE_args['prior_FIM'] = prior_FIM_ind
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         doe_obj.run_doe()
-        indx_param_doe_obj.run_doe()
+        ind_param_doe_obj.run_doe()
 
         self.assertEqual(doe_obj.results["Solver Status"], "ok")
-        self.assertEqual(indx_param_doe_obj.results["Solver Status"], "ok")
+        self.assertEqual(ind_param_doe_obj.results["Solver Status"], "ok")
 
         # assert that Q, F, and L are the same.
         FIM, Q, L, sigma_inv = get_FIM_Q_L(doe_obj=doe_obj)
-        FIM_indx, Q_indx, L_indx, sigma_inv_indx = get_FIM_Q_L(
-            doe_obj=indx_param_doe_obj
-        )
+        FIM_ind, Q_ind, L_ind, sigma_inv_ind = get_FIM_Q_L(doe_obj=ind_param_doe_obj)
 
         # Since Cholesky is used, there is comparison for FIM and L.T @ L
         self.assertTrue(np.all(np.isclose(FIM, L @ L.T)))
-        self.assertTrue(np.all(np.isclose(FIM_indx, L_indx @ L_indx.T)))
+        self.assertTrue(np.all(np.isclose(FIM_ind, L_ind @ L_ind.T)))
 
         # Note: When using prior_FIM, the relationship FIM = Q.T @ sigma_inv @ Q + prior_FIM
         self.assertTrue(np.all(np.isclose(FIM, Q.T @ sigma_inv @ Q + prior_FIM)))
         self.assertTrue(
-            np.all(
-                np.isclose(
-                    FIM_indx, Q_indx.T @ sigma_inv_indx @ Q_indx + prior_FIM_indx
-                )
-            )
+            np.all(np.isclose(FIM_ind, Q_ind.T @ sigma_inv_ind @ Q_ind + prior_FIM_ind))
         )
 
     def DISABLE_test_reactor_obj_cholesky_solve_bad_prior(self):
@@ -468,15 +454,15 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         expected_FIM = np.array(
             [[18957.7788694, 4238.27606876], [4238.27606876, 947.52577076]]
@@ -488,7 +474,7 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
         self.assertTrue(
             np.all(
                 np.isclose(
-                    indx_param_doe_obj.compute_FIM(method="sequential"), expected_FIM
+                    ind_param_doe_obj.compute_FIM(method="sequential"), expected_FIM
                 )
             )
         )
@@ -502,18 +488,18 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         doe_obj.compute_FIM(method="sequential")
-        indx_param_doe_obj.compute_FIM(method="sequential")
+        ind_param_doe_obj.compute_FIM(method="sequential")
 
     # This test ensure that compute FIM runs without error using the
     # `kaug` option. kaug computes the FIM directly so no finite difference
@@ -527,15 +513,15 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
         obj_used = "determinant"
 
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         expected_FIM = np.array(
             [[18957.7788694, 4238.27606876], [4238.27606876, 947.52577076]]
@@ -546,7 +532,7 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
         )
         self.assertTrue(
             np.all(
-                np.isclose(indx_param_doe_obj.compute_FIM(method="kaug"), expected_FIM)
+                np.isclose(ind_param_doe_obj.compute_FIM(method="kaug"), expected_FIM)
             )
         )
 
@@ -559,18 +545,18 @@ class TestRooneyBieglerExampleSolving(unittest.TestCase):
 
         # Use RooneyBiegler for algorithm validation (faster)
         experiment = get_rooney_biegler_experiment()
-        indx_param_experiment = get_rooney_biegler_experiment(index_vars=True)
+        ind_param_experiment = get_rooney_biegler_experiment(index_vars=True)
 
         DoE_args = get_standard_args(experiment, fd_method, obj_used)
-        indx_param_DoE_args = get_standard_args(
-            indx_param_experiment, fd_method, obj_used
+        ind_param_DoE_args = get_standard_args(
+            ind_param_experiment, fd_method, obj_used
         )
 
         doe_obj = DesignOfExperiments(**DoE_args)
-        indx_param_doe_obj = DesignOfExperiments(**indx_param_DoE_args)
+        ind_param_doe_obj = DesignOfExperiments(**ind_param_DoE_args)
 
         doe_obj.compute_FIM(method="sequential")
-        indx_param_doe_obj.compute_FIM(method="sequential")
+        ind_param_doe_obj.compute_FIM(method="sequential")
 
     @unittest.skipIf(not pandas_available, "pandas is not available")
     def test_reactor_grid_search(self):

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -1781,13 +1781,12 @@ class Estimator:
             for experiment in self.exp_list:
                 model = _get_labeled_model(experiment)
 
+                # get the parameter data objects
+                param_data_objects = _get_param_data_objects(model)
+
                 # fix the value of the unknown parameters to the estimated values
-                for param in model.unknown_parameters:
-                    if param.is_indexed():
-                        for idx in param:
-                            param[idx].fix(self.estimated_theta[param[idx].name])
-                    else:
-                        param.fix(self.estimated_theta[param.name])
+                for param in param_data_objects:
+                    param.fix(self.estimated_theta[param.name])
 
                 # re-solve the model with the estimated parameters
                 results = pyo.SolverFactory(solver).solve(model, tee=self.tee)

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -166,7 +166,7 @@ def _build_meas_error_covariance(model, estimated_var=None):
     """
     # get the output variables
     outputs = list(model.experiment_outputs.keys())
-    output_index = {y: i for i, y in enumerate(outputs)}
+    output_index = {y.name: i for i, y in enumerate(outputs)}
 
     # get the number of output variables
     number_outputs = len(outputs)
@@ -181,11 +181,11 @@ def _build_meas_error_covariance(model, estimated_var=None):
             model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
         )
 
-        # get the measurement errors
-        meas_error = list(model.measurement_error.keys())
+        # get the measurement-error variables
+        meas_error_outputs = [y_hat.name for y_hat in model.measurement_error]
 
         # check if the dimension of meas_error is the same with that of outputs
-        if len(meas_error) != len(outputs):
+        if len(meas_error_outputs) != len(outputs):
             raise ValueError(
                 "Experiment outputs and measurement errors are not the same length."
             )
@@ -193,29 +193,34 @@ def _build_meas_error_covariance(model, estimated_var=None):
         # fill the diagonal elements from the standard deviation of
         # the measurement errors
         for y, i in output_index.items():
-            if y in meas_error and all_known_errors:
+            if y in meas_error_outputs and all_known_errors:
                 standard_dev = model.measurement_error[y]
                 Sigma_y[i, i] = standard_dev ** 2
-            elif y in meas_error and not all_known_errors:
+            elif y in meas_error_outputs and not all_known_errors:
                 Sigma_y[i, i] = estimated_var
 
         # fill the off-diagonal elements from covariance entries
         for key, entry in model.measurement_error.items():
             if isinstance(key, tuple) and len(key) == 2:
                 yi, yj = key
-                if yi not in output_index or yj not in output_index:
+                if yi.name not in output_index or yj.name not in output_index:
                     raise ValueError(
                         "One of the variables defined in the covariance of the "
                         "measurement errors is not an experiment output variable."
                     )
 
                 # get the indices of yi and yj
-                i = output_index[yi]
-                j = output_index[yj]
+                i = output_index[yi.name]
+                j = output_index[yj.name]
 
                 # update the covariance entries
                 Sigma_y[i, j] = entry
                 Sigma_y[j, i] = entry
+            else:
+                raise TypeError(
+                    "The covariance between two measured variables must be defined "
+                    "using a tuple."
+                )
 
     return Sigma_y
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -450,7 +450,8 @@ def _get_labeled_model(experiment):
 
 def _get_param_data_objects(model):
     """
-    Creates a list of indexed or scalar parameters
+    Creates a list of the data objects for indexed parameters
+    or scalar parameters
 
     Parameters
     ----------

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -148,6 +148,7 @@ def SSE_weighted(model):
             'the measurement errors are required for the "SSE_weighted" objective.'
         )
 
+
 def _build_meas_error_covariance(model, estimated_var=None):
     """
     Builds the full measurement-error covariance matrix
@@ -447,6 +448,32 @@ def _get_labeled_model(experiment):
         raise RuntimeError(f"Failed to clone labeled model: {exc}")
 
 
+def _get_param_data_objects(model):
+    """
+    Creates a list of indexed or scalar parameters
+
+    Parameters
+    ----------
+    model : ConcreteModel
+        Annotated Pyomo model
+
+    Returns
+    -------
+    params: list
+        List of indexed or scalar parameters
+    """
+    params = []
+    for param in model.unknown_parameters:
+        # check if the parameter is indexed
+        if param.is_indexed():
+            for idx in param:
+                # get the parameter data object
+                params.append(param[idx])
+        else:
+            params.append(param)
+    return params
+
+
 def _format_outputs_index_as_tuple(index):
     """
     Formats the indices of indexed experiment outputs
@@ -641,8 +668,11 @@ def _compute_jacobian(experiment, theta_vals, step, solver, tee, solver_options)
     # grab the model
     model = _get_labeled_model(experiment)
 
+    # get the parameter data objects
+    param_data_objects = _get_param_data_objects(model)
+
     # fix the value of the unknown parameters to the estimated values
-    for param in model.unknown_parameters:
+    for param in param_data_objects:
         param.fix(theta_vals[param.name])
 
     # re-solve the model with the estimated parameters
@@ -656,7 +686,7 @@ def _compute_jacobian(experiment, theta_vals, step, solver, tee, solver_options)
     assert_optimal_termination(results)
 
     # get the estimated parameter values
-    param_values = [p.value for p in model.unknown_parameters]
+    param_values = [p.value for p in param_data_objects]
 
     # get the number of parameters and measured variables
     n_params = len(param_values)
@@ -665,7 +695,7 @@ def _compute_jacobian(experiment, theta_vals, step, solver, tee, solver_options)
     # compute the sensitivity of the measured variables w.r.t the parameters
     J = np.zeros((n_outputs, n_params))
 
-    for i, param in enumerate(model.unknown_parameters):
+    for i, param in enumerate(param_data_objects):
         # store original value of the parameter
         orig_value = param_values[i]
 
@@ -955,8 +985,11 @@ def _kaug_FIM(
     # add the built-in objective function selected by the user
     model.objective = pyo.Objective(expr=obj_function, sense=pyo.minimize)
 
+    # get the parameter data objects
+    param_data_objects = _get_param_data_objects(model)
+
     # fix the parameter values to the estimated values
-    for param in model.unknown_parameters:
+    for param in param_data_objects:
         param.fix(theta_vals[param.name])
 
     solver = pyo.SolverFactory(solver)
@@ -967,7 +1000,7 @@ def _kaug_FIM(
     assert_optimal_termination(results)
 
     # Probe the solved model for dsdp results (sensitivities s.t. parameters)
-    params_dict = {k.name: v for k, v in model.unknown_parameters.items()}
+    params_dict = {k.name: theta_vals[k.name] for k in param_data_objects}
     params_names = list(params_dict.keys())
 
     dsdp_re, col = get_dsdp(model, params_names, params_dict, tee=tee)
@@ -1001,7 +1034,7 @@ def _kaug_FIM(
     jac = [[] for _ in params_names]
 
     for d in range(len(dsdp_extract)):
-        for k, v in model.unknown_parameters.items():
+        for k in param_data_objects:
             p = params_names.index(k.name)  # Index of parameter in np array
             sensi = dsdp_extract[d][p]
             jac[p].append(sensi)

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -126,7 +126,7 @@ def SSE_weighted(model):
             'objective.'
         )
 
-    # check if all the values of the measurement error standard deviation
+    # check if all the values of the measurement-error standard deviation
     # have been supplied
     try:
         all_known_errors = all(
@@ -147,18 +147,8 @@ def SSE_weighted(model):
             [y - y_hat for y_hat, y in model.experiment_outputs.items()]
         ).reshape(1, -1)
 
-        # build the measurement-error covariance matrix
-        Sigma_y = _build_meas_error_covariance_matrix(model)
-
-        # compute the inverse of the measurement-error covariance matrix
-        try:
-            Sigma_y_inv = np.linalg.inv(Sigma_y)
-        except np.linalg.LinAlgError:
-            Sigma_y_inv = np.linalg.pinv(Sigma_y)
-            logger.warning(
-                "The measurement-error covariance matrix is singular. "
-                "Using pseudo-inverse instead."
-            )
+        # get the inverse of the measurement-error covariance matrix
+        Sigma_y_inv = get_meas_error_covariance_matrix_inv(model)
 
         # calculate the weighted SSE between the prediction
         # and observation of the measured variables
@@ -179,9 +169,10 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
     It only places whatever covariances the user explicitly supplies
     Therefore, for correlation in time, shared timepoints, or other types of
     correlation, the user must provide all the desired covariance terms
-    The diagonal elements can be constructed automatically or specified by
-    the user. They may be constant or depend on the experiment outputs (e.g.,
-    be proportional to them)
+    The diagonal elements can be constructed automatically or the standard
+    deviations can be specified by the user. They standard deviations may be
+    constant or depend on the value (i.e., data) of the measured or input
+    variables (e.g., be proportional to them)
 
     Parameters
     ----------
@@ -249,6 +240,38 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
                 )
 
     return Sigma_y
+
+
+def get_meas_error_covariance_matrix_inv(model, estimated_var=None):
+    """
+    Computes the inverse of the measurement-error covariance matrix
+
+    Parameters
+    ----------
+    model : ConcreteModel
+        Annotated Pyomo model
+    estimated_var: float, optional
+        Value of the estimated variance of the measurement error
+
+    Returns
+    -------
+    Sigma_y_inv: numpy.ndarray
+        Inverse of the measurement-error covariance matrix
+    """
+    # get the measurement-error covariance matrix
+    Sigma_y = _build_meas_error_covariance_matrix(model, estimated_var)
+
+    # compute the inverse of the measurement-error covariance matrix
+    try:
+        Sigma_y_inv = np.linalg.inv(Sigma_y)
+    except np.linalg.LinAlgError:
+        Sigma_y_inv = np.linalg.pinv(Sigma_y)
+        logger.warning(
+            "The measurement-error covariance matrix is singular. "
+            "Using pseudo-inverse instead."
+        )
+
+    return Sigma_y_inv
 
 
 def _validate_prior_FIM(prior_FIM, require_psd=True):
@@ -944,18 +967,8 @@ def _finite_difference_FIM(
     # grab the model
     model = _get_labeled_model(experiment)
 
-    # compute the measurement-error covariance matrix
-    Sigma_y = _build_meas_error_covariance_matrix(model, estimated_var)
-
-    # compute the inverse of the measurement-error covariance matrix
-    try:
-        Sigma_y_inv = np.linalg.inv(Sigma_y)
-    except np.linalg.LinAlgError:
-        Sigma_y_inv = np.linalg.pinv(Sigma_y)
-        logger.warning(
-            "The measurement-error covariance matrix is singular. "
-            "Using pseudo-inverse instead."
-        )
+    # get the inverse of the measurement-error covariance matrix
+    Sigma_y_inv = get_meas_error_covariance_matrix_inv(model, estimated_var)
 
     # calculate the FIM using the formula in our future paper
     # Lilonfe and Dowling. (2026)
@@ -1074,18 +1087,8 @@ def _kaug_FIM(
     # record kaug jacobian
     kaug_jac = np.array(jac).T
 
-    # compute the measurement-error covariance matrix
-    Sigma_y = _build_meas_error_covariance_matrix(model, estimated_var)
-
-    # compute the inverse of the measurement-error covariance matrix
-    try:
-        Sigma_y_inv = np.linalg.inv(Sigma_y)
-    except np.linalg.LinAlgError:
-        Sigma_y_inv = np.linalg.pinv(Sigma_y)
-        logger.warning(
-            "The measurement-error covariance matrix is singular. "
-            "Using pseudo-inverse instead."
-        )
+    # get the inverse of the measurement-error covariance matrix
+    Sigma_y_inv = get_meas_error_covariance_matrix_inv(model, estimated_var)
 
     # compute the FIM
     FIM = kaug_jac.T @ Sigma_y_inv @ kaug_jac

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -148,6 +148,77 @@ def SSE_weighted(model):
             'the measurement errors are required for the "SSE_weighted" objective.'
         )
 
+def _build_meas_error_covariance(model, estimated_var=None):
+    """
+    Builds the full measurement-error covariance matrix
+
+    Parameters
+    ----------
+    model : ConcreteModel
+        Annotated Pyomo model
+    estimated_var: float, optional
+        Value of the estimated variance of the measurement error
+
+    Returns
+    -------
+    Sigma_y: numpy.ndarray
+        Full measurement-error covariance matrix
+    """
+    # get the output variables
+    outputs = list(model.experiment_outputs.keys())
+    output_index = {y: i for i, y in enumerate(outputs)}
+
+    # get the number of output variables
+    number_outputs = len(outputs)
+
+    # define the measurement-error covariance matrix
+    Sigma_y = np.zeros((number_outputs, number_outputs))
+
+    if hasattr(model, "measurement_error"):
+        # check if all the measurement-error standard deviation
+        # has been supplied
+        all_known_errors = all(
+            model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
+        )
+
+        # get the measurement errors
+        meas_error = list(model.measurement_error.keys())
+
+        # check if the dimension of meas_error is the same with that of outputs
+        if len(meas_error) != len(outputs):
+            raise ValueError(
+                "Experiment outputs and measurement errors are not the same length."
+            )
+
+        # fill the diagonal elements from the standard deviation of
+        # the measurement errors
+        for y, i in output_index.items():
+            if y in meas_error and all_known_errors:
+                standard_dev = model.measurement_error[y]
+                Sigma_y[i, i] = standard_dev ** 2
+            elif y in meas_error and not all_known_errors:
+                Sigma_y[i, i] = estimated_var
+
+        # fill the off-diagonal elements from covariance entries
+        for key, entry in model.measurement_error.items():
+            if isinstance(key, tuple) and len(key) == 2:
+                yi, yj = key
+                if yi not in output_index or yj not in output_index:
+                    raise ValueError(
+                        "One of the variables defined in the covariance of the "
+                        "measurement errors is not an experiment output variable."
+                    )
+
+                # get the indices of yi and yj
+                i = output_index[yi]
+                j = output_index[yj]
+
+                # update the covariance entries
+                Sigma_y[i, j] = entry
+                Sigma_y[j, i] = entry
+
+    return Sigma_y
+
 
 def _validate_prior_FIM(prior_FIM, require_psd=True):
     """
@@ -813,36 +884,20 @@ def _finite_difference_FIM(
     # grab the model
     model = _get_labeled_model(experiment)
 
-    # extract the measured variables and measurement errors
-    y_hat_list = [y_hat for y_hat, y in model.experiment_outputs.items()]
+    # compute the measurement-error covariance matrix
+    Sigma_y = _build_meas_error_covariance(model, estimated_var)
 
-    # check if the model has a 'measurement_error' attribute and
-    # the measurement error standard deviation has been supplied
-    all_known_errors = all(
-        model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
-    )
+    # compute the inverse of the measurement-error covariance matrix
+    try:
+        Sigma_y_inv = np.linalg.inv(Sigma_y)
+    except np.linalg.LinAlgError:
+        Sigma_y_inv = np.linalg.pinv(Sigma_y)
+        logger.warning("The measurement-error covariance matrix is singular. "
+                       "Using pseudo-inverse instead.")
 
-    if hasattr(model, "measurement_error") and all_known_errors:
-        error_list = [
-            model.measurement_error[y_hat] for y_hat in model.experiment_outputs
-        ]
-
-        # check if the dimension of error_list is the same with that of y_hat_list
-        if len(error_list) != len(y_hat_list):
-            raise ValueError(
-                "Experiment outputs and measurement errors are not the same length."
-            )
-
-        # compute the matrix of the inverse of the measurement error variance
-        # the following assumes independent and identically distributed
-        # measurement errors
-        W = np.diag([1 / (err**2) for err in error_list])
-
-        # calculate the FIM using the formula in our future paper
-        # Lilonfe et al. (2025)
-        FIM = J.T @ W @ J
-    else:
-        FIM = (1 / estimated_var) * (J.T @ J)
+    # calculate the FIM using the formula in our future paper
+    # Lilonfe and Dowling. (2026)
+    FIM = J.T @ Sigma_y @ J
 
     return FIM
 
@@ -954,24 +1009,19 @@ def _kaug_FIM(
     # record kaug jacobian
     kaug_jac = np.array(jac).T
 
-    # compute FIM
-    # compute the matrix of the inverse of the measurement error variance
-    # the following assumes independent and identically distributed
-    # measurement errors
-    W = np.zeros((len(model.measurement_error), len(model.measurement_error)))
-    all_known_errors = all(
-        model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
-    )
+    # compute the measurement-error covariance matrix
+    Sigma_y = _build_meas_error_covariance(model, estimated_var)
 
-    count = 0
-    for k, v in model.measurement_error.items():
-        if all_known_errors:
-            W[count, count] = 1 / (v**2)
-        else:
-            W[count, count] = 1 / estimated_var
-        count += 1
+    # compute the inverse of the measurement-error covariance matrix
+    try:
+        Sigma_y_inv = np.linalg.inv(Sigma_y)
+    except np.linalg.LinAlgError:
+        Sigma_y_inv = np.linalg.pinv(Sigma_y)
+        logger.warning("The measurement-error covariance matrix is singular. "
+                       "Using pseudo-inverse instead.")
 
-    FIM = kaug_jac.T @ W @ kaug_jac
+    # compute the FIM
+    FIM = kaug_jac.T @ Sigma_y_inv @ kaug_jac
 
     return FIM
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -161,6 +161,13 @@ def _build_meas_error_covariance(model, estimated_var=None):
     """
     Builds the full measurement-error covariance matrix
 
+    Note: The code does not automatically build the full covariance matrix
+    It only places whatever covariances the user explicitly supplies
+    The leading-diagonal elements can be constructed automatically or
+    from user-supplied values
+    Therefore, for correlation in time, shared timepoints, or other types of
+    correlation, the user must provide all the desired covariance terms
+
     Parameters
     ----------
     model : ConcreteModel

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -237,7 +237,8 @@ def _build_meas_error_covariance(model, estimated_var=None):
                 i = output_index[yi.name]
                 j = output_index[yj.name]
 
-                # update the measurement-error covariance matrix
+                # update the measurement-error covariance matrix which
+                # is a symmetric matrix
                 Sigma_y[i, j] = entry
                 Sigma_y[j, i] = entry
             elif not isinstance(key, tuple) and not hasattr(key, "name"):

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -126,7 +126,8 @@ def SSE_weighted(model):
     # have been supplied
     try:
         all_known_errors = all(
-            model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
+            model.measurement_error[y_hat] is not None
+            for y_hat in model.experiment_outputs
         )
     except KeyError:
         raise KeyError(
@@ -137,11 +138,9 @@ def SSE_weighted(model):
         )
 
     if all_known_errors:
-        # calculate the difference between the model predictions and data
-        prediction_diff = np.array(
-            [
-                y - y_hat for y_hat, y in model.experiment_outputs.items()
-            ]
+        # calculate the residuals between the model predictions and data
+        prediction_resid = np.array(
+            [y - y_hat for y_hat, y in model.experiment_outputs.items()]
         ).reshape(1, -1)
 
         # build the measurement-error covariance matrix
@@ -159,7 +158,7 @@ def SSE_weighted(model):
 
         # calculate the weighted SSE between the prediction
         # and observation of the measured variables
-        expr = (1 / 2) * prediction_diff @ Sigma_y_inv @ prediction_diff.T
+        expr = (1 / 2) * prediction_resid @ Sigma_y_inv @ prediction_resid.T
         return expr[0, 0]
     else:
         raise ValueError(

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -221,7 +221,7 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
 
         # fill the off-diagonal elements from covariance entries
         # supplied by the user
-        for key, entry in model.measurement_error.items():
+        for key, err_cov in model.measurement_error.items():
             if isinstance(key, tuple) and len(key) == 2:
                 yi, yj = key
                 if yi.name not in outputs_name or yj.name not in outputs_name:
@@ -236,8 +236,8 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
 
                 # update the measurement-error covariance matrix which
                 # is a symmetric matrix
-                Sigma_y[i, j] = entry
-                Sigma_y[j, i] = entry
+                Sigma_y[i, j] = err_cov
+                Sigma_y[j, i] = err_cov
             elif not isinstance(key, tuple) and not hasattr(key, "name"):
                 raise TypeError(
                     "Expected a tuple of two measured variables when specifying a "

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -106,6 +106,10 @@ def SSE_weighted(model):
     assuming Gaussian correlated or i.i.d. errors, with the standard deviation
     or covariance of the measurement errors defined in the annotated Pyomo model
 
+    This objective function is applicable to both homoscedastic
+    (constant-variance) and heteroskedastic (non-constant-variance, e.g.,
+    proportional-error) measurement-error models
+
     Parameters
     ----------
     model : ConcreteModel
@@ -173,10 +177,11 @@ def _build_meas_error_covariance(model, estimated_var=None):
 
     Note: The code does not automatically build the full covariance matrix
     It only places whatever covariances the user explicitly supplies
-    The leading-diagonal elements can be constructed automatically or
-    from user-supplied values
     Therefore, for correlation in time, shared timepoints, or other types of
     correlation, the user must provide all the desired covariance terms
+    The diagonal elements can be constructed automatically or specified by
+    the user. They may be constant or depend on the experiment outputs (e.g.,
+    be proportional to them)
 
     Parameters
     ----------

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -178,8 +178,10 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
     ----------
     model : ConcreteModel
         Annotated Pyomo model
-    estimated_var: float, optional
+    estimated_var: float or int, optional
         Value of the estimated variance of the measurement error
+        in cases where the user does not supply the
+        measurement-error standard deviation
 
     Returns
     -------
@@ -187,11 +189,12 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
         Full measurement-error covariance matrix
     """
     # get the output variables
-    outputs_name = [y.name for y in model.experiment_outputs]
-    output_index = {y: i for i, y in enumerate(outputs_name)}
+    outputs = list(model.experiment_outputs.keys())
+    outputs_name = [y_hat.name for y_hat in outputs]
+    outputs_index = {y_hat_name: i for i, y_hat_name in enumerate(outputs_name)}
 
     # get the number of output variables
-    number_outputs = len(outputs_name)
+    number_outputs = len(outputs)
 
     # define the measurement-error covariance matrix
     Sigma_y = np.zeros((number_outputs, number_outputs))
@@ -206,9 +209,12 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
 
         # fill the leading-diagonal elements from the standard deviation of
         # the measurement errors
-        for y_name, i in output_index.items():
+        for y_hat in outputs:
+            # get the index of y_hat
+            i = outputs_index[y_hat.name]
+
             if all_known_errors:
-                standard_dev = model.measurement_error[model.find_component(y_name)]
+                standard_dev = model.measurement_error[y_hat]
                 Sigma_y[i, i] = standard_dev**2
             else:
                 Sigma_y[i, i] = estimated_var
@@ -225,8 +231,8 @@ def _build_meas_error_covariance_matrix(model, estimated_var=None):
                     )
 
                 # get the indices of yi and yj
-                i = output_index[yi.name]
-                j = output_index[yj.name]
+                i = outputs_index[yi.name]
+                j = outputs_index[yj.name]
 
                 # update the measurement-error covariance matrix which
                 # is a symmetric matrix
@@ -250,8 +256,10 @@ def get_meas_error_covariance_matrix_inv(model, estimated_var=None):
     ----------
     model : ConcreteModel
         Annotated Pyomo model
-    estimated_var: float, optional
+    estimated_var: float or int, optional
         Value of the estimated variance of the measurement error
+        in cases where the user does not supply the
+        measurement-error standard deviation
 
     Returns
     -------
@@ -501,32 +509,6 @@ def _get_labeled_model(experiment):
         raise RuntimeError(f"Failed to clone labeled model: {exc}")
 
 
-def _get_param_data_objects(model):
-    """
-    Creates a list for the data objects of indexed or scalar parameters
-
-    Parameters
-    ----------
-    model : ConcreteModel
-        Annotated Pyomo model
-
-    Returns
-    -------
-    params: list
-        List of indexed or scalar parameters data object
-    """
-    params = []
-    for param in model.unknown_parameters:
-        # check if the parameter is indexed
-        if param.is_indexed():
-            for idx in param:
-                # get the parameter data object
-                params.append(param[idx])
-        else:
-            params.append(param)
-    return params
-
-
 def _format_outputs_index_as_tuple(index):
     """
     Formats the indices of indexed experiment outputs
@@ -722,7 +704,7 @@ def _compute_jacobian(experiment, theta_vals, step, solver, tee, solver_options)
     model = _get_labeled_model(experiment)
 
     # get the parameter data objects
-    param_data_objects = _get_param_data_objects(model)
+    param_data_objects, _, _ = _expanded_unknown_parameter_info(model)
 
     # fix the value of the unknown parameters to the estimated values
     for param in param_data_objects:
@@ -1031,7 +1013,7 @@ def _kaug_FIM(
     model.objective = pyo.Objective(expr=obj_function, sense=pyo.minimize)
 
     # get the parameter data objects
-    param_data_objects = _get_param_data_objects(model)
+    param_data_objects, _, _ = _expanded_unknown_parameter_info(model)
 
     # fix the parameter values to the estimated values
     for param in param_data_objects:
@@ -1819,7 +1801,7 @@ class Estimator:
                 model = _get_labeled_model(experiment)
 
                 # get the parameter data objects
-                param_data_objects = _get_param_data_objects(model)
+                param_data_objects, _, _ = _expanded_unknown_parameter_info(model)
 
                 # fix the value of the unknown parameters to the estimated values
                 for param in param_data_objects:

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -479,7 +479,7 @@ def _get_labeled_model(experiment):
 
 def _get_param_data_objects(model):
     """
-    Creates a list of the data objects for indexed or scalar parameters
+    Creates a list for the data objects of indexed or scalar parameters
 
     Parameters
     ----------
@@ -489,7 +489,7 @@ def _get_param_data_objects(model):
     Returns
     -------
     params: list
-        List of indexed or scalar parameters
+        List of indexed or scalar parameters data object
     """
     params = []
     for param in model.unknown_parameters:

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -202,7 +202,7 @@ def _build_meas_error_covariance(model, estimated_var=None):
 
         # fill the off-diagonal elements from covariance entries
         for key, entry in model.measurement_error.items():
-            if isinstance(key, tuple) and len(key) == 2:
+            if len(key) == 2 and isinstance(key, tuple):
                 yi, yj = key
                 if yi.name not in output_index or yj.name not in output_index:
                     raise ValueError(
@@ -217,6 +217,12 @@ def _build_meas_error_covariance(model, estimated_var=None):
                 # update the covariance entries
                 Sigma_y[i, j] = entry
                 Sigma_y[j, i] = entry
+            elif len(key) == 2 and not isinstance(key, tuple):
+                raise TypeError(
+                    "Expected a tuple of two measured variables when specifying a "
+                    "measurement-error covariance, e.g., "
+                    "measurement_error[(y1, y2)] = covariance."
+                )
 
     return Sigma_y
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -192,11 +192,11 @@ def _build_meas_error_covariance(model, estimated_var=None):
 
         # fill the diagonal elements from the standard deviation of
         # the measurement errors
-        for y, i in output_index.items():
-            if y in meas_error_outputs and all_known_errors:
-                standard_dev = model.measurement_error[y]
+        for y_name, i in output_index.items():
+            if y_name in meas_error_outputs and all_known_errors:
+                standard_dev = model.measurement_error[model.find_component(y_name)]
                 Sigma_y[i, i] = standard_dev ** 2
-            elif y in meas_error_outputs and not all_known_errors:
+            elif y_name in meas_error_outputs and not all_known_errors:
                 Sigma_y[i, i] = estimated_var
 
         # fill the off-diagonal elements from covariance entries
@@ -216,11 +216,6 @@ def _build_meas_error_covariance(model, estimated_var=None):
                 # update the covariance entries
                 Sigma_y[i, j] = entry
                 Sigma_y[j, i] = entry
-            else:
-                raise TypeError(
-                    "The covariance between two measured variables must be defined "
-                    "using a tuple."
-                )
 
     return Sigma_y
 
@@ -902,7 +897,7 @@ def _finite_difference_FIM(
 
     # calculate the FIM using the formula in our future paper
     # Lilonfe and Dowling. (2026)
-    FIM = J.T @ Sigma_y @ J
+    FIM = J.T @ Sigma_y_inv @ J
 
     return FIM
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -124,9 +124,17 @@ def SSE_weighted(model):
 
     # check if all the values of the measurement error standard deviation
     # have been supplied
-    all_known_errors = all(
-        model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
-    )
+    try:
+        all_known_errors = all(
+            model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
+        )
+    except KeyError:
+        raise KeyError(
+            'One or more experiment outputs are not defined in the '
+            '"measurement_error" attribute. All the variables defined '
+            'in "experiment_outputs" must be defined as keys in '
+            '"measurement_error".'
+        )
 
     if all_known_errors:
         # calculate the weighted SSE between the prediction
@@ -166,59 +174,51 @@ def _build_meas_error_covariance(model, estimated_var=None):
         Full measurement-error covariance matrix
     """
     # get the output variables
-    outputs = list(model.experiment_outputs.keys())
-    output_index = {y.name: i for i, y in enumerate(outputs)}
+    outputs_name = [y.name for y in model.experiment_outputs]
+    output_index = {y: i for i, y in enumerate(outputs_name)}
 
     # get the number of output variables
-    number_outputs = len(outputs)
+    number_outputs = len(outputs_name)
 
     # define the measurement-error covariance matrix
     Sigma_y = np.zeros((number_outputs, number_outputs))
 
     if hasattr(model, "measurement_error"):
-        # check if all the measurement-error standard deviation
-        # has been supplied
+        # check if all the measurement-error standard deviations
+        # have been supplied
         all_known_errors = all(
             model.measurement_error[y_hat] is not None
             for y_hat in model.experiment_outputs
         )
 
-        # get the variables defined in the "measurement_error" attribute
-        meas_error_outputs = [y_hat.name for y_hat in model.measurement_error]
-
-        # check if the dimension of meas_error is the same with that of outputs
-        if len(meas_error_outputs) != len(outputs):
-            raise ValueError(
-                "Experiment outputs and measurement errors are not the same length."
-            )
-
-        # fill the diagonal elements from the standard deviation of
+        # fill the leading-diagonal elements from the standard deviation of
         # the measurement errors
         for y_name, i in output_index.items():
-            if y_name in meas_error_outputs and all_known_errors:
+            if all_known_errors:
                 standard_dev = model.measurement_error[model.find_component(y_name)]
                 Sigma_y[i, i] = standard_dev**2
-            elif y_name in meas_error_outputs and not all_known_errors:
+            else:
                 Sigma_y[i, i] = estimated_var
 
         # fill the off-diagonal elements from covariance entries
+        # supplied by the user
         for key, entry in model.measurement_error.items():
-            if len(key) == 2 and isinstance(key, tuple):
+            if isinstance(key, tuple) and len(key) == 2:
                 yi, yj = key
-                if yi.name not in output_index or yj.name not in output_index:
+                if yi.name not in outputs_name or yj.name not in outputs_name:
                     raise ValueError(
-                        "One of the variables defined in the covariance of the "
-                        "measurement errors is not an experiment output variable."
+                        "Measurement-error covariance must be defined only between "
+                        "experiment output variables."
                     )
 
                 # get the indices of yi and yj
                 i = output_index[yi.name]
                 j = output_index[yj.name]
 
-                # update the covariance entries
+                # update the measurement-error covariance matrix
                 Sigma_y[i, j] = entry
                 Sigma_y[j, i] = entry
-            elif len(key) == 2 and not isinstance(key, tuple):
+            elif not isinstance(key, tuple) and not hasattr(key, "name"):
                 raise TypeError(
                     "Expected a tuple of two measured variables when specifying a "
                     "measurement-error covariance, e.g., "
@@ -1856,10 +1856,18 @@ class Estimator:
             # check if the user defined the 'measurement_error' attribute
             if hasattr(ref_model, "measurement_error"):
                 # get the measurement errors
-                meas_error = [
-                    ref_model.measurement_error[y_hat]
-                    for y_hat, y in ref_model.experiment_outputs.items()
-                ]
+                try:
+                    meas_error = [
+                        ref_model.measurement_error[y_hat]
+                        for y_hat, y in ref_model.experiment_outputs.items()
+                    ]
+                except KeyError:
+                    raise KeyError(
+                        'One or more experiment outputs are not defined in the '
+                        '"measurement_error" attribute. All the variables defined '
+                        'in "experiment_outputs" must be defined as keys in '
+                        '"measurement_error".'
+                    )
 
                 # check if the user supplied the values of the measurement errors
                 if all(item is None for item in meas_error):

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -181,7 +181,7 @@ def _build_meas_error_covariance(model, estimated_var=None):
             model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
         )
 
-        # get the measurement-error variables
+        # get the variables defined in the "measurement_error" attribute
         meas_error_outputs = [y_hat.name for y_hat in model.measurement_error]
 
         # check if the dimension of meas_error is the same with that of outputs

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -450,8 +450,7 @@ def _get_labeled_model(experiment):
 
 def _get_param_data_objects(model):
     """
-    Creates a list of the data objects for indexed parameters
-    or scalar parameters
+    Creates a list of the data objects for indexed or scalar parameters
 
     Parameters
     ----------

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -148,7 +148,7 @@ def SSE_weighted(model):
         ).reshape(1, -1)
 
         # build the measurement-error covariance matrix
-        Sigma_y = _build_meas_error_covariance(model)
+        Sigma_y = _build_meas_error_covariance_matrix(model)
 
         # compute the inverse of the measurement-error covariance matrix
         try:
@@ -171,7 +171,7 @@ def SSE_weighted(model):
         )
 
 
-def _build_meas_error_covariance(model, estimated_var=None):
+def _build_meas_error_covariance_matrix(model, estimated_var=None):
     """
     Builds the full measurement-error covariance matrix
 
@@ -945,7 +945,7 @@ def _finite_difference_FIM(
     model = _get_labeled_model(experiment)
 
     # compute the measurement-error covariance matrix
-    Sigma_y = _build_meas_error_covariance(model, estimated_var)
+    Sigma_y = _build_meas_error_covariance_matrix(model, estimated_var)
 
     # compute the inverse of the measurement-error covariance matrix
     try:
@@ -1075,7 +1075,7 @@ def _kaug_FIM(
     kaug_jac = np.array(jac).T
 
     # compute the measurement-error covariance matrix
-    Sigma_y = _build_meas_error_covariance(model, estimated_var)
+    Sigma_y = _build_meas_error_covariance_matrix(model, estimated_var)
 
     # compute the inverse of the measurement-error covariance matrix
     try:

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -179,7 +179,8 @@ def _build_meas_error_covariance(model, estimated_var=None):
         # check if all the measurement-error standard deviation
         # has been supplied
         all_known_errors = all(
-            model.measurement_error[y_hat] is not None for y_hat in model.experiment_outputs
+            model.measurement_error[y_hat] is not None
+            for y_hat in model.experiment_outputs
         )
 
         # get the variables defined in the "measurement_error" attribute
@@ -196,7 +197,7 @@ def _build_meas_error_covariance(model, estimated_var=None):
         for y_name, i in output_index.items():
             if y_name in meas_error_outputs and all_known_errors:
                 standard_dev = model.measurement_error[model.find_component(y_name)]
-                Sigma_y[i, i] = standard_dev ** 2
+                Sigma_y[i, i] = standard_dev**2
             elif y_name in meas_error_outputs and not all_known_errors:
                 Sigma_y[i, i] = estimated_var
 
@@ -928,8 +929,10 @@ def _finite_difference_FIM(
         Sigma_y_inv = np.linalg.inv(Sigma_y)
     except np.linalg.LinAlgError:
         Sigma_y_inv = np.linalg.pinv(Sigma_y)
-        logger.warning("The measurement-error covariance matrix is singular. "
-                       "Using pseudo-inverse instead.")
+        logger.warning(
+            "The measurement-error covariance matrix is singular. "
+            "Using pseudo-inverse instead."
+        )
 
     # calculate the FIM using the formula in our future paper
     # Lilonfe and Dowling. (2026)
@@ -1056,8 +1059,10 @@ def _kaug_FIM(
         Sigma_y_inv = np.linalg.inv(Sigma_y)
     except np.linalg.LinAlgError:
         Sigma_y_inv = np.linalg.pinv(Sigma_y)
-        logger.warning("The measurement-error covariance matrix is singular. "
-                       "Using pseudo-inverse instead.")
+        logger.warning(
+            "The measurement-error covariance matrix is singular. "
+            "Using pseudo-inverse instead."
+        )
 
     # compute the FIM
     FIM = kaug_jac.T @ Sigma_y_inv @ kaug_jac

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -103,8 +103,8 @@ def SSE(model):
 def SSE_weighted(model):
     """
     Returns an expression that is used to compute the 'SSE_weighted' objective,
-    assuming Gaussian i.i.d. errors, with measurement error standard deviation
-    defined in the annotated Pyomo model
+    assuming Gaussian correlated or i.i.d. errors, with the standard deviation
+    or covariance of the measurement errors defined in the annotated Pyomo model
 
     Parameters
     ----------
@@ -137,19 +137,30 @@ def SSE_weighted(model):
         )
 
     if all_known_errors:
+        # calculate the difference between the model predictions and data
+        prediction_diff = np.array(
+            [
+                y - y_hat for y_hat, y in model.experiment_outputs.items()
+            ]
+        ).reshape(1, -1)
+
+        # build the measurement-error covariance matrix
+        Sigma_y = _build_meas_error_covariance(model)
+
+        # compute the inverse of the measurement-error covariance matrix
+        try:
+            Sigma_y_inv = np.linalg.inv(Sigma_y)
+        except np.linalg.LinAlgError:
+            Sigma_y_inv = np.linalg.pinv(Sigma_y)
+            logger.warning(
+                "The measurement-error covariance matrix is singular. "
+                "Using pseudo-inverse instead."
+            )
+
         # calculate the weighted SSE between the prediction
         # and observation of the measured variables
-        try:
-            expr = (1 / 2) * sum(
-                ((y - y_hat) / model.measurement_error[y_hat]) ** 2
-                for y_hat, y in model.experiment_outputs.items()
-            )
-            return expr
-        except ZeroDivisionError:
-            raise ValueError(
-                'Division by zero encountered in the "SSE_weighted" objective. '
-                'One or more values of the measurement error are zero.'
-            )
+        expr = (1 / 2) * prediction_diff @ Sigma_y_inv @ prediction_diff.T
+        return expr[0, 0]
     else:
         raise ValueError(
             'One or more values are missing from "measurement_error". All values of '

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -146,10 +146,7 @@ class TestParmestCovEst(unittest.TestCase):
         ][0]
 
         if measurement_error is None and obj_function == "SSE":
-            if (
-                cov_method == "finite_difference"
-                or cov_method == "automatic_differentiation_kaug"
-            ):
+            if cov_method in ("finite_difference", "automatic_differentiation_kaug"):
                 self.assertAlmostEqual(
                     cov.iloc[asymptote_index, asymptote_index], 6.229612, places=2
                 )  # 6.22864 from paper
@@ -180,10 +177,7 @@ class TestParmestCovEst(unittest.TestCase):
                     places=2,
                 )  # 0.04124 from paper
         elif measurement_error is not None and obj_function in ("SSE", "SSE_weighted"):
-            if (
-                cov_method == "finite_difference"
-                or cov_method == "automatic_differentiation_kaug"
-            ):
+            if cov_method in ("finite_difference", "automatic_differentiation_kaug"):
                 self.assertAlmostEqual(
                     cov.iloc[asymptote_index, asymptote_index], 0.009588, places=4
                 )
@@ -845,9 +839,9 @@ class TestModelVariants(unittest.TestCase):
                 m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
                 m.measurement_error.update([(m.y, None)])
 
-        rooney_biegler_indexed_vars_exp_list = []
+        self.rooney_biegler_indexed_vars_exp_list = []
         for i in range(self.data.shape[0]):
-            rooney_biegler_indexed_vars_exp_list.append(
+            self.rooney_biegler_indexed_vars_exp_list.append(
                 RooneyBieglerExperimentIndexedVars(self.data.loc[i, :])
             )
 
@@ -875,24 +869,24 @@ class TestModelVariants(unittest.TestCase):
                 "theta_vals": theta_vals,
             },
             "vars_index": {
-                "exp_list": rooney_biegler_indexed_vars_exp_list,
+                "exp_list": self.rooney_biegler_indexed_vars_exp_list,
                 "theta_names": ["theta"],
                 "theta_vals": theta_vals_index,
             },
             "vars_quoted_index": {
-                "exp_list": rooney_biegler_indexed_vars_exp_list,
+                "exp_list": self.rooney_biegler_indexed_vars_exp_list,
                 "theta_names": ["theta['asymptote']", "theta['rate_constant']"],
                 "theta_vals": theta_vals_index,
             },
             "vars_str_index": {
-                "exp_list": rooney_biegler_indexed_vars_exp_list,
+                "exp_list": self.rooney_biegler_indexed_vars_exp_list,
                 "theta_names": ["theta[asymptote]", "theta[rate_constant]"],
                 "theta_vals": theta_vals_index,
             },
         }
 
     @unittest.skipIf(not pynumero_ASL_available, "pynumero_ASL is not available")
-    def check_rooney_biegler_results(self, objval, cov):
+    def check_rooney_biegler_results(self, objval, cov, cov_method="reduced_hessian"):
 
         # get indices in covariance matrix
         cov_cols = cov.columns.to_list()
@@ -902,18 +896,35 @@ class TestModelVariants(unittest.TestCase):
         ][0]
 
         self.assertAlmostEqual(objval, 4.3317112, places=2)
-        self.assertAlmostEqual(
-            cov.iloc[asymptote_index, asymptote_index], 6.155892, places=2
-        )  # 6.22864 from paper
-        self.assertAlmostEqual(
-            cov.iloc[asymptote_index, rate_constant_index], -0.425232, places=2
-        )  # -0.4322 from paper
-        self.assertAlmostEqual(
-            cov.iloc[rate_constant_index, asymptote_index], -0.425232, places=2
-        )  # -0.4322 from paper
-        self.assertAlmostEqual(
-            cov.iloc[rate_constant_index, rate_constant_index], 0.040571, places=2
-        )  # 0.04124 from paper
+
+        if cov_method in ("finite_difference", "automatic_differentiation_kaug"):
+            self.assertAlmostEqual(
+                cov.iloc[asymptote_index, asymptote_index], 6.229612, places=2
+            )  # 6.22864 from paper
+            self.assertAlmostEqual(
+                cov.iloc[asymptote_index, rate_constant_index], -0.432265, places=2
+            )  # -0.4322 from paper
+            self.assertAlmostEqual(
+                cov.iloc[rate_constant_index, asymptote_index], -0.432265, places=2
+            )  # -0.4322 from paper
+            self.assertAlmostEqual(
+                cov.iloc[rate_constant_index, rate_constant_index],
+                0.041242,
+                places=2,
+            )  # 0.04124 from paper
+        else:
+            self.assertAlmostEqual(
+                cov.iloc[asymptote_index, asymptote_index], 6.155892, places=2
+            )  # 6.22864 from paper
+            self.assertAlmostEqual(
+                cov.iloc[asymptote_index, rate_constant_index], -0.425232, places=2
+            )  # -0.4322 from paper
+            self.assertAlmostEqual(
+                cov.iloc[rate_constant_index, asymptote_index], -0.425232, places=2
+            )  # -0.4322 from paper
+            self.assertAlmostEqual(
+                cov.iloc[rate_constant_index, rate_constant_index], 0.040571, places=2
+            )  # 0.04124 from paper
 
     @unittest.skipUnless(pynumero_ASL_available, 'pynumero_ASL is not available')
     def test_parmest_basics(self):
@@ -984,6 +995,32 @@ class TestModelVariants(unittest.TestCase):
             objval, thetavals = pest.theta_est()
             cov = pest.cov_est(method="reduced_hessian")
             self.check_rooney_biegler_results(objval, cov)
+
+    @unittest.skipUnless(pynumero_ASL_available, 'pynumero_ASL is not available')
+    def test_parmest_indexed_vars_finite_difference_cov(self):
+
+        pest = parmest.Estimator(
+            self.rooney_biegler_indexed_vars_exp_list,
+            obj_function=self.objective_function
+        )
+
+        objval, thetavals = pest.theta_est()
+        cov_method = "finite_difference"
+        cov = pest.cov_est(method=cov_method)
+        self.check_rooney_biegler_results(objval, cov, cov_method)
+
+    @unittest.skipUnless(pynumero_ASL_available, 'pynumero_ASL is not available')
+    def test_parmest_indexed_vars_auto_differentiation_cov(self):
+
+        pest = parmest.Estimator(
+            self.rooney_biegler_indexed_vars_exp_list,
+            obj_function=self.objective_function
+        )
+
+        objval, thetavals = pest.theta_est()
+        cov_method = "automatic_differentiation_kaug"
+        cov = pest.cov_est(method=cov_method)
+        self.check_rooney_biegler_results(objval, cov, cov_method)
 
 
 @unittest.skipIf(

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -1286,7 +1286,7 @@ class TestReactorDesign_DAE(unittest.TestCase):
 
         # create an instance of the ReactorDesignExperimentDAE class
         # without the "unknown_parameters" attribute
-        class ReactorDesignExperimentException(ReactorDesignExperimentDAE):
+        class ReactorDesignParameterException(ReactorDesignExperimentDAE):
             def label_model(self):
 
                 m = self.model
@@ -1308,11 +1308,114 @@ class TestReactorDesign_DAE(unittest.TestCase):
                 )
 
         # create an experiment list without the "unknown_parameters" attribute
-        exp_list_df_no_params = [ReactorDesignExperimentException(data_df)]
-        exp_list_dict_no_params = [ReactorDesignExperimentException(data_dict)]
+        self.exp_list_df_no_params = [ReactorDesignParameterException(data_df)]
+        self.exp_list_dict_no_params = [ReactorDesignParameterException(data_dict)]
 
-        self.exp_list_df_no_params = exp_list_df_no_params
-        self.exp_list_dict_no_params = exp_list_dict_no_params
+        # create instances of the ReactorDesignExperimentDAE class
+        # with incorrect definition of the measurement-error covariance
+        class ReactorErrorCovarianceException1(ReactorDesignExperimentDAE):
+            def label_model(self):
+
+                m = self.model
+
+                if isinstance(self.data, pd.DataFrame):
+                    meas_time_points = self.data.index
+                else:
+                    meas_time_points = list(self.data["ca"].keys())
+
+                m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_outputs.update(
+                    (m.ca[t], self.data["ca"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cb[t], self.data["cb"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cc[t], self.data["cc"][t]) for t in meas_time_points
+                )
+
+                m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.unknown_parameters.update(
+                    (k, pyo.ComponentUID(k)) for k in [m.k1, m.k2]
+                )
+
+                m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.measurement_error.update((m.ca[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update((m.cb[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update((m.cc[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update(
+                    ([m.ca[t], m.cb[t]], 0.1) for t in meas_time_points
+                )
+
+        class ReactorErrorCovarianceException2(ReactorDesignExperimentDAE):
+            def label_model(self):
+
+                m = self.model
+
+                if isinstance(self.data, pd.DataFrame):
+                    meas_time_points = self.data.index
+                else:
+                    meas_time_points = list(self.data["ca"].keys())
+
+                m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_outputs.update(
+                    (m.ca[t], self.data["ca"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cb[t], self.data["cb"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cc[t], self.data["cc"][t]) for t in meas_time_points
+                )
+
+                m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.unknown_parameters.update(
+                    (k, pyo.ComponentUID(k)) for k in [m.k1, m.k2]
+                )
+
+                m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.measurement_error.update((m.ca[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update((m.cb[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update((m.cc[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update(
+                    ((m.ca[t], m.k1), 0.1) for t in meas_time_points
+                )
+
+        class ReactorIncompleteErrorException(ReactorDesignExperimentDAE):
+            def label_model(self):
+
+                m = self.model
+
+                if isinstance(self.data, pd.DataFrame):
+                    meas_time_points = self.data.index
+                else:
+                    meas_time_points = list(self.data["ca"].keys())
+
+                m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_outputs.update(
+                    (m.ca[t], self.data["ca"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cb[t], self.data["cb"][t]) for t in meas_time_points
+                )
+                m.experiment_outputs.update(
+                    (m.cc[t], self.data["cc"][t]) for t in meas_time_points
+                )
+
+                m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.unknown_parameters.update(
+                    (k, pyo.ComponentUID(k)) for k in [m.k1, m.k2]
+                )
+
+                m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.measurement_error.update((m.ca[t], 0.01) for t in meas_time_points)
+                m.measurement_error.update((m.cb[t], 0.01) for t in meas_time_points)
+
+        # create an experiment list with the incorrect definition of the
+        # measurement-error covariance
+        self.exp_list_df_incorrect_err_cov1 = [ReactorErrorCovarianceException1(data_df)]
+        self.exp_list_df_incorrect_err_cov2 = [ReactorErrorCovarianceException2(data_df)]
+        self.exp_list_df_incomplete_err = [ReactorIncompleteErrorException(data_df)]
 
     def test_unknown_parameters_exception(self):
         """
@@ -1328,6 +1431,58 @@ class TestReactorDesign_DAE(unittest.TestCase):
             parmest.Estimator(self.exp_list_dict_no_params, obj_function="SSE")
 
         self.assertIn("unknown_parameters", str(context.exception))
+
+    def test_incorrect_error_covariance_exception(self):
+        """
+        Test the exception raised by parmest when the measurement-error
+        covariance is defined incorrectly
+        """
+        pest1 = parmest.Estimator(self.exp_list_df_incorrect_err_cov1,
+                                  obj_function="SSE")
+
+        obj1, theta1 = pest1.theta_est()
+        with pytest.raises(
+            TypeError,
+            match=r"Expected a tuple of two measured variables when specifying a "
+            r"measurement-error covariance, e\.g\., "
+            r"measurement_error\[\(y1, y2\)\] = covariance\.",
+        ):
+            pest1.cov_est()
+
+        pest2 = parmest.Estimator(self.exp_list_df_incorrect_err_cov2,
+                                  obj_function="SSE")
+
+        obj2, theta2 = pest2.theta_est()
+        with pytest.raises(
+            ValueError,
+            match=r"Measurement-error covariance must be defined only between "
+            r"experiment output variables\.",
+        ):
+            pest2.cov_est()
+
+        pest3 = parmest.Estimator(self.exp_list_df_incomplete_err, obj_function="SSE")
+
+        obj3, theta3 = pest3.theta_est()
+        with pytest.raises(
+                KeyError,
+                match='One or more experiment outputs are not defined in the '
+                '"measurement_error" attribute. All the variables defined '
+                'in "experiment_outputs" must be defined as keys in '
+                '"measurement_error".',
+        ):
+            pest3.cov_est()
+
+        pest4 = parmest.Estimator(self.exp_list_df_incomplete_err,
+                                  obj_function="SSE_weighted")
+
+        with pytest.raises(
+            KeyError,
+            match='One or more experiment outputs are not defined in the '
+                  '"measurement_error" attribute. All the variables defined '
+                  'in "experiment_outputs" must be defined as keys in '
+                  '"measurement_error".',
+        ):
+            obj4, theta4 = pest4.theta_est()
 
     def test_dataformats(self):
         obj1, theta1 = self.pest_df.theta_est()

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -1413,8 +1413,12 @@ class TestReactorDesign_DAE(unittest.TestCase):
 
         # create an experiment list with the incorrect definition of the
         # measurement-error covariance
-        self.exp_list_df_incorrect_err_cov1 = [ReactorErrorCovarianceException1(data_df)]
-        self.exp_list_df_incorrect_err_cov2 = [ReactorErrorCovarianceException2(data_df)]
+        self.exp_list_df_incorrect_err_cov1 = [
+            ReactorErrorCovarianceException1(data_df)
+        ]
+        self.exp_list_df_incorrect_err_cov2 = [
+            ReactorErrorCovarianceException2(data_df)
+        ]
         self.exp_list_df_incomplete_err = [ReactorIncompleteErrorException(data_df)]
 
     def test_unknown_parameters_exception(self):
@@ -1437,8 +1441,9 @@ class TestReactorDesign_DAE(unittest.TestCase):
         Test the exception raised by parmest when the measurement-error
         covariance is defined incorrectly
         """
-        pest1 = parmest.Estimator(self.exp_list_df_incorrect_err_cov1,
-                                  obj_function="SSE")
+        pest1 = parmest.Estimator(
+            self.exp_list_df_incorrect_err_cov1, obj_function="SSE"
+        )
 
         obj1, theta1 = pest1.theta_est()
         with pytest.raises(
@@ -1449,8 +1454,9 @@ class TestReactorDesign_DAE(unittest.TestCase):
         ):
             pest1.cov_est()
 
-        pest2 = parmest.Estimator(self.exp_list_df_incorrect_err_cov2,
-                                  obj_function="SSE")
+        pest2 = parmest.Estimator(
+            self.exp_list_df_incorrect_err_cov2, obj_function="SSE"
+        )
 
         obj2, theta2 = pest2.theta_est()
         with pytest.raises(
@@ -1472,8 +1478,9 @@ class TestReactorDesign_DAE(unittest.TestCase):
         ):
             pest3.cov_est()
 
-        pest4 = parmest.Estimator(self.exp_list_df_incomplete_err,
-                                  obj_function="SSE_weighted")
+        pest4 = parmest.Estimator(
+            self.exp_list_df_incomplete_err, obj_function="SSE_weighted"
+        )
 
         with pytest.raises(
             KeyError,

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -1069,6 +1069,54 @@ class TestReactorDesign(unittest.TestCase):
             exp_list, obj_function="SSE", solver_options=solver_options
         )
 
+        # create an inherited class to test the results when a
+        # full measurement-error covariance matrix is used
+        class ReactorFullErrorCov(ReactorDesignExperiment):
+            def label_model(self):
+                m = self.model
+
+                m.experiment_outputs = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.experiment_outputs.update(
+                    [
+                        (m.ca, self.data_i['ca']),
+                        (m.cb, self.data_i['cb']),
+                        (m.cc, self.data_i['cc']),
+                        (m.cd, self.data_i['cd']),
+                    ]
+                )
+
+                m.unknown_parameters = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.unknown_parameters.update(
+                    (k, pyo.ComponentUID(k)) for k in [m.k1, m.k2, m.k3]
+                )
+
+                m.measurement_error = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+                m.measurement_error.update(
+                    [(m.ca, 1), (m.cb, 0.1), (m.cc, 0.1), (m.cd, 0.1)]
+                )
+                m.measurement_error.update(
+                    [
+                        ((m.ca, m.cb), 0),
+                        ((m.ca, m.cc), 0),
+                        ((m.ca, m.cd), 0),
+                        ((m.cb, m.cc), 0),
+                        ((m.cb, m.cd), 0),
+                        ((m.cc, m.cd), 0),
+                    ]
+                )
+
+                return m
+
+        exp_list_full_error = []
+        for i in range(data.shape[0]):
+            exp_list_full_error.append(ReactorFullErrorCov(data, i))
+
+        self.pest_full_error = parmest.Estimator(
+            exp_list_full_error,
+            obj_function="SSE_weighted",
+            solver_options=solver_options,
+        )
+
     def test_theta_est(self):
         # used in data reconciliation
         objval, thetavals = self.pest.theta_est()
@@ -1076,6 +1124,12 @@ class TestReactorDesign(unittest.TestCase):
         self.assertAlmostEqual(thetavals["k1"], 5.0 / 6.0, places=4)
         self.assertAlmostEqual(thetavals["k2"], 5.0 / 3.0, places=4)
         self.assertAlmostEqual(thetavals["k3"], 1.0 / 6000.0, places=7)
+
+        objval2, thetavals2 = self.pest_full_error.theta_est()
+
+        self.assertAlmostEqual(thetavals2["k1"], 5.0 / 6.0, places=4)
+        self.assertAlmostEqual(thetavals2["k2"], 5.0 / 3.0, places=4)
+        self.assertAlmostEqual(thetavals2["k3"], 1.0 / 6000.0, places=7)
 
     def test_return_values(self):
         objval, thetavals, data_rec = self.pest.theta_est(

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -1464,11 +1464,11 @@ class TestReactorDesign_DAE(unittest.TestCase):
 
         obj3, theta3 = pest3.theta_est()
         with pytest.raises(
-                KeyError,
-                match='One or more experiment outputs are not defined in the '
-                '"measurement_error" attribute. All the variables defined '
-                'in "experiment_outputs" must be defined as keys in '
-                '"measurement_error".',
+            KeyError,
+            match='One or more experiment outputs are not defined in the '
+            '"measurement_error" attribute. All the variables defined '
+            'in "experiment_outputs" must be defined as keys in '
+            '"measurement_error".',
         ):
             pest3.cov_est()
 
@@ -1478,9 +1478,9 @@ class TestReactorDesign_DAE(unittest.TestCase):
         with pytest.raises(
             KeyError,
             match='One or more experiment outputs are not defined in the '
-                  '"measurement_error" attribute. All the variables defined '
-                  'in "experiment_outputs" must be defined as keys in '
-                  '"measurement_error".',
+            '"measurement_error" attribute. All the variables defined '
+            'in "experiment_outputs" must be defined as keys in '
+            '"measurement_error".',
         ):
             obj4, theta4 = pest4.theta_est()
 

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -908,9 +908,7 @@ class TestModelVariants(unittest.TestCase):
                 cov.iloc[rate_constant_index, asymptote_index], -0.432265, places=2
             )  # -0.4322 from paper
             self.assertAlmostEqual(
-                cov.iloc[rate_constant_index, rate_constant_index],
-                0.041242,
-                places=2,
+                cov.iloc[rate_constant_index, rate_constant_index], 0.041242, places=2
             )  # 0.04124 from paper
         else:
             self.assertAlmostEqual(
@@ -1001,7 +999,7 @@ class TestModelVariants(unittest.TestCase):
 
         pest = parmest.Estimator(
             self.rooney_biegler_indexed_vars_exp_list,
-            obj_function=self.objective_function
+            obj_function=self.objective_function,
         )
 
         objval, thetavals = pest.theta_est()
@@ -1014,7 +1012,7 @@ class TestModelVariants(unittest.TestCase):
 
         pest = parmest.Estimator(
             self.rooney_biegler_indexed_vars_exp_list,
-            obj_function=self.objective_function
+            obj_function=self.objective_function,
         )
 
         objval, thetavals = pest.theta_est()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
1.  Currently, ParmEst and Pyomo.DoE support only independent and identically distributed (i.i.d.) measurement errors. This PR adds support for correlated measurement errors by enabling the construction of a full measurement-error covariance matrix (MCM), allowing correlations across time and between measurements collected at the same time point. The new implementation also supports proportional (heteroskedastic) error structures.
2.  Currently, the calculation of the parameter covariance/Fisher information matrix in ParmEst/Pyomo.DoE is not supported for indexed parameters. This PR develops the capability to compute these matrices for indexed parameters.


## Changes proposed in this PR:
- Update `_compute_jacobian`, `_kaug_FIM`, and `_cov_at_theta` in ParmEst to support covariance matrix estimation for indexed parameters
- Add a helper function in both ParmEst and Pyomo.DoE that builds the MCM from the user-supplied standard deviation and covariances
- Update `SSE_weighted` in ParmEst to use the MCM in computing the "SSE_weighted" objective function 
- Update `_kaug_FIM` and `_finite_difference_FIM` in ParmEst to use the MCM in computing the parameter covariance matrix
- Update `_kaug_FIM` and `_sequential_FIM` in Pyomo.DoE to use the MCM
- Update `create_doe_model` in Pyomo.DoE to use the MCM
- Replicate ParmEst's `_expanded_unknown_parameter_info` in Pyomo.DoE
- Update all appearances of `model.unknown_parameters` or `model.scenario_blocks.unknown_parameters` to use the expanded parameter objects
- Add tests in `test_parmest.py` and `test_doe_solve.py` to exercise the new capabilities

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [x] **AI tools were NOT used during the preparation of this PR**

or

- [ ] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
3. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
