### PR TITLE
Update (usage of) PyROS `UncertaintySet` validation routines

### DIFF
--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -12,6 +12,7 @@ Tests for the PyROS UncertaintySet class and subclasses.
 """
 
 import itertools as it
+from pyomo.common.errors import InvalidConstraintError
 import pyomo.common.unittest as unittest
 
 from pyomo.common.collections import Bunch
@@ -27,6 +28,7 @@ from pyomo.core.base import ConcreteModel, Param, Var, minimize, UnitInterval
 from pyomo.core.expr import RangedExpression
 from pyomo.core.expr.compare import assertExpressionsEqual
 from pyomo.environ import SolverFactory
+from pyomo.opt import assert_optimal_termination
 
 from pyomo.contrib.pyros.uncertainty_sets import (
     AxisAlignedEllipsoidalSet,
@@ -417,6 +419,20 @@ class TestBoxSet(unittest.TestCase):
         box_set = BoxSet(bounds=[[1.0, 2.0], [3.0, 4.0]])
         bounded_and_nonempty_check(self, box_set)
 
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty
+        box_set = BoxSet(bounds=[[1.0, 2.0], [3.0, 4.0]])
+        self.assertTrue(box_set.is_nonempty(config=CONFIG))
+        # nonempty (check using nominal values)
+        CONFIG.nominal_uncertain_param_vals = [1.5, 3.5]
+        self.assertTrue(box_set.is_nonempty(config=CONFIG))
+        # empty, since lower bounds > upper bounds
+        # (by more than tolerance)
+        box_set.bounds = [[2.0, 1.0], [1.0, 0.0]]
+        self.assertFalse(box_set.is_nonempty(config=CONFIG))
+
     def test_fbbt_error(self):
         """
         Test that `_fbbt_parameter_bounds` error message with bad bounds.
@@ -786,6 +802,16 @@ class TestBudgetSet(unittest.TestCase):
         budget_rhs_vec = [1.0, 3.0]
         budget_set = BudgetSet(budget_mat, budget_rhs_vec)
         bounded_and_nonempty_check(self, budget_set)
+
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty
+        buset = BudgetSet(budget_membership_mat=[[1, 0, 1], [0, 1, 0]], rhs_vec=[1, 3])
+        self.assertTrue(buset.is_nonempty(config=CONFIG))
+        # empty, due to negative budget RHS vector entry
+        buset.budget_rhs_vec = [-1, 3]
+        self.assertFalse(buset.is_nonempty(config=CONFIG))
 
     def test_is_coordinate_fixed(self):
         """
@@ -1240,6 +1266,25 @@ class TestFactorModelSet(unittest.TestCase):
         factor_set = FactorModelSet(origin, number_of_factors, psi_mat, beta)
         bounded_and_nonempty_check(self, factor_set)
 
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty
+        fset = FactorModelSet(
+            origin=[0, 0, 0],
+            number_of_factors=2,
+            psi_mat=[[1, 0], [0, 1], [1, 1]],
+            beta=0.5,
+        )
+        self.assertTrue(fset.is_nonempty(config=CONFIG))
+        # empty, due to negative beta value
+        # pyomo raises exception during constraint setup,
+        # before the solver is even called
+        fset.beta = -0.1
+        exc_str = r"Constraint\.Infeasible"
+        with self.assertRaisesRegex(InvalidConstraintError, exc_str):
+            fset.is_nonempty(config=CONFIG)
+
     def test_is_coordinate_fixed(self):
         """
         Test method for checking whether there are coordinates
@@ -1663,13 +1708,12 @@ class TestIntersectionSet(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, exc_str):
             intersection_set.validate(config=CONFIG)
 
-        # check when individual sets are not actually intersecting
+        # confirm intersection set is valid (i.e., bounded)
+        # if all operand sets are valid, even if intersection is empty
         bset1 = BoxSet(bounds=[[1, 2], [1, 2]])
         bset2 = BoxSet(bounds=[[-2, -1], [-2, -1]])
         intersection_set = IntersectionSet(box_set1=bset1, box_set2=bset2)
-        exc_str = r"Could not compute.*bound in dimension.*Solver status summary:.*"
-        with self.assertRaisesRegex(ValueError, exc_str):
-            intersection_set.validate(config=CONFIG)
+        intersection_set.validate(config=CONFIG)
 
     @unittest.skipUnless(baron_available, "BARON is not available")
     def test_bounded_and_nonempty(self):
@@ -1680,6 +1724,19 @@ class TestIntersectionSet(unittest.TestCase):
         aset = AxisAlignedEllipsoidalSet([0, 0, 0], [1, 1, 1])
         intersection_set = IntersectionSet(box_set=bset, axis_aligned_set=aset)
         bounded_and_nonempty_check(self, intersection_set)
+
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty (singleton)
+        bset1 = BoxSet(bounds=[[1, 2], [1, 2]])
+        bset2 = BoxSet(bounds=[[2, 3], [2, 3]])
+        iset = IntersectionSet(box_set1=bset1, box_set2=bset2)
+
+        # empty: even though the operands are nonempty,
+        #        they do not intersect
+        bset2.bounds = [[-2, -1], [-2, -1]]
+        self.assertFalse(iset.is_nonempty(config=CONFIG))
 
     @unittest.skipUnless(baron_available, "BARON is not available")
     def test_is_coordinate_fixed(self):
@@ -2166,6 +2223,18 @@ class TestCardinalitySet(unittest.TestCase):
         )
         bounded_and_nonempty_check(self, cardinality_set)
 
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+
+        # nonempty
+        cset = CardinalitySet(origin=[0, 0], gamma=2, positive_deviation=[1, 1])
+        self.assertTrue(cset.is_nonempty(config=CONFIG))
+
+        # empty, since gamma is negative
+        cset.gamma = -1
+        self.assertFalse(cset.is_nonempty(config=CONFIG))
+
     def test_is_coordinate_fixed(self):
         """
         Test method for checking whether there are coordinates
@@ -2583,6 +2652,12 @@ class TestAxisAlignedEllipsoidalSet(unittest.TestCase):
         half_lengths = [1.0, 3.0]
         a_ellipsoid_set = AxisAlignedEllipsoidalSet(center, half_lengths)
         bounded_and_nonempty_check(self, a_ellipsoid_set)
+
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        aeset = AxisAlignedEllipsoidalSet(center=[0, 0], half_lengths=[1.0, 3.0])
+        self.assertTrue(aeset.is_nonempty(config=CONFIG))
 
     def test_is_coordinate_fixed(self):
         """
@@ -3002,6 +3077,16 @@ class TestEllipsoidalSet(unittest.TestCase):
         ellipsoid_set = EllipsoidalSet(center, shape_matrix, scale)
         bounded_and_nonempty_check(self, ellipsoid_set)
 
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty
+        eset = EllipsoidalSet(center=[0, 0], shape_matrix=[[1, 0], [0, 2]], scale=1)
+        self.assertTrue(eset.is_nonempty(config=CONFIG))
+        # empty when `scale` has a negative value
+        eset.scale = -1
+        self.assertFalse(eset.is_nonempty(config=CONFIG))
+
     def test_is_coordinate_fixed(self):
         """
         Test method for checking whether there are coordinates
@@ -3277,6 +3362,16 @@ class TestPolyhedralSet(unittest.TestCase):
             rhs_vec=[2.0, -1.0, -1.0],
         )
         bounded_and_nonempty_check(self, polyhedral_set)
+
+    @unittest.skipUnless(baron_available, "BARON is not available")
+    def test_is_nonempty(self):
+        CONFIG = Bunch(global_solver=SolverFactory("baron"))
+        # nonempty set q >= 3
+        pset = PolyhedralSet(lhs_coefficients_mat=[[1], [1]], rhs_vec=[2, 3])
+        self.assertTrue(pset.is_nonempty(config=CONFIG))
+        # empty set q <= 2 and q >= 3
+        pset = PolyhedralSet(lhs_coefficients_mat=[[1], [-1]], rhs_vec=[2, -3])
+        self.assertFalse(pset.is_nonempty(config=CONFIG))
 
     @unittest.skipUnless(baron_available, "BARON is not available")
     def test_is_coordinate_fixed(self):
@@ -3829,7 +3924,7 @@ class CustomUncertaintySet(UncertaintySet):
 
     @property
     def geometry(self):
-        self.geometry = Geometry.LINEAR
+        return Geometry.LINEAR
 
     @property
     def dim(self):
@@ -3966,13 +4061,7 @@ class TestCustomUncertaintySet(unittest.TestCase):
         # feasibility problem passes
         baron = SolverFactory("baron")
         custom_set = CustomUncertaintySet(dim=2)
-        custom_set._solve_feasibility(baron)
-
-        # feasibility problem fails
-        custom_set.parameter_bounds = [[1, 2], [3, 4]]
-        exc_str = r"Could not successfully solve feasibility problem. .*"
-        with self.assertRaisesRegex(ValueError, exc_str):
-            custom_set._solve_feasibility(baron)
+        assert_optimal_termination(custom_set._solve_feasibility(baron))
 
     # test default is_bounded
     @unittest.skipUnless(baron_available, "BARON is not available")
@@ -4009,23 +4098,6 @@ class TestCustomUncertaintySet(unittest.TestCase):
 
         # constructing a feasibility problem
         self.assertTrue(custom_set.is_nonempty(config=CONFIG), "Set is empty")
-
-        # using provided nominal point
-        CONFIG.nominal_uncertain_param_vals = [0, 0]
-        self.assertTrue(custom_set.is_nonempty(config=CONFIG), "Set is empty")
-
-        # check when nominal point is not in set
-        CONFIG.nominal_uncertain_param_vals = [-2, -2]
-        self.assertFalse(
-            custom_set.is_nonempty(config=CONFIG), "Nominal point is in set"
-        )
-
-        # check when feasibility problem fails
-        CONFIG.nominal_uncertain_param_vals = None
-        custom_set.parameter_bounds = [[1, 2], [3, 4]]
-        exc_str = r"Could not successfully solve feasibility problem. .*"
-        with self.assertRaisesRegex(ValueError, exc_str):
-            custom_set.is_nonempty(config=CONFIG)
 
     def test_fbbt_values(self):
         """

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -2421,6 +2421,14 @@ class TestDiscreteScenarioSet(unittest.TestCase):
         discrete_set = DiscreteScenarioSet([[1, 2], [3, 4]])
         bounded_and_nonempty_check(self, discrete_set)
 
+    def test_is_nonempty(self):
+        # nonempty
+        discrete_set = DiscreteScenarioSet([[1, 2], [3, 4]])
+        self.assertTrue(discrete_set.is_nonempty(config=Bunch()))
+        # empty: scenarios list is empty
+        discrete_set.scenarios.clear()
+        self.assertFalse(discrete_set.is_nonempty(config=Bunch()))
+
     def test_is_coordinate_fixed(self):
         """
         Test method for checking whether there are coordinates

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -400,16 +400,25 @@ class TestBoxSet(unittest.TestCase):
         """
         Test validate bounds check performs as expected.
         """
-        CONFIG = Bunch()
+        CONFIG = Bunch(progress_logger=logging.getLogger("pyomo.contrib.pyros"))
 
         # construct valid box set
         box_set = BoxSet(bounds=[[1.0, 2.0], [3.0, 4.0]])
 
         # check when LB >= UB
-        box_set.bounds[0][0] = 5
+        box_set.bounds[0, 0] = 5
         exc_str = r"Lower bound 5.0 exceeds upper bound 2.0"
         with self.assertRaisesRegex(ValueError, exc_str):
             box_set.validate(config=CONFIG)
+
+        # check infinite bounds
+        box_set.bounds[0, 0] = -float("inf")
+        exc_str = r"Entry.*is not a finite numeric value"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            box_set.validate(config=CONFIG)
+        exc_str = r"Boundedness check failed.*BoxSet"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            UncertaintySet.validate(box_set, config=CONFIG)
 
     @unittest.skipUnless(baron_available, "BARON is not available")
     def test_bounded_and_nonempty(self):

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -28,7 +28,12 @@ from pyomo.core.base import ConcreteModel, Param, Var, minimize, UnitInterval
 from pyomo.core.expr import RangedExpression
 from pyomo.core.expr.compare import assertExpressionsEqual
 from pyomo.environ import SolverFactory
-from pyomo.opt import assert_optimal_termination
+from pyomo.opt import (
+    assert_optimal_termination,
+    SolverResults,
+    SolverStatus,
+    TerminationCondition,
+)
 
 from pyomo.contrib.pyros.uncertainty_sets import (
     AxisAlignedEllipsoidalSet,
@@ -3395,6 +3400,23 @@ class TestPolyhedralSet(unittest.TestCase):
         # empty set q <= 2 and q >= 3
         pset = PolyhedralSet(lhs_coefficients_mat=[[1], [-1]], rhs_vec=[2, -3])
         self.assertFalse(pset.is_nonempty(config=CONFIG))
+
+        class UnknownSolver:
+            def available(self, exception_flag=None):
+                return True
+
+            def solve(self, model, *args, **kwargs):
+                res = SolverResults()
+                res.solver.termination_condition = TerminationCondition.unknown
+                res.solver.status = SolverStatus.warning
+                return res
+
+        # nonemptiness check fails as nomemptiness/emptiness could
+        # not be deduced using this solver
+        CONFIG.global_solver = UnknownSolver()
+        exc_str = "Could not successfully confirm.*feasible or infeasible"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            pset.is_nonempty(config=CONFIG)
 
     @unittest.skipUnless(baron_available, "BARON is not available")
     def test_is_coordinate_fixed(self):

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -883,6 +883,11 @@ class TestFactorModelSet(unittest.TestCase):
         np.testing.assert_allclose(fset.psi_mat, [[1, 0], [0, 1], [1, 1]])
         np.testing.assert_allclose(fset.beta, 0.5)
 
+        # ensure finiteness check runs
+        exc_str = r"beta.*not a finite numeric value"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            fset.beta = float("inf")
+
     def test_error_on_factor_model_set_dim_change(self):
         """
         Test ValueError raised when attempting to change FactorModelSet
@@ -1930,6 +1935,11 @@ class TestCardinalitySet(unittest.TestCase):
         np.testing.assert_allclose(cset.positive_deviation, [3, 0])
         np.testing.assert_equal(cset.negative_deviation, [0, -1.5])
 
+        # ensure finiteness check runs
+        exc_str = r"gamma.*not a finite numeric value"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            cset.gamma = float("inf")
+
     def test_cardinality_constructor_args_order(self):
         """
         Check that `CardinalitySet` constructor allows
@@ -2761,6 +2771,11 @@ class TestEllipsoidalSet(unittest.TestCase):
             eset.gaussian_conf_lvl,
             err_msg="EllipsoidalSet Gaussian confidence level update not as expected",
         )
+
+        # ensure finiteness check runs
+        exc_str = r"scale.*not a finite numeric value"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            eset.scale = float("inf")
 
     def test_normal_construction_and_update_gaussian_conf_lvl(self):
         """

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -3271,6 +3271,12 @@ class TestPolyhedralSet(unittest.TestCase):
         computed_bounds = pset._compute_exact_parameter_bounds(SolverFactory("baron"))
         self.assertEqual(computed_bounds, [(1, 2), (-1, 1)])
 
+        # computation should fail here, since set is not bounded
+        pset2 = PolyhedralSet(lhs_coefficients_mat=[[1, 1]], rhs_vec=[2])
+        exc_str = r"Could not compute lower.*dimension 1"
+        with self.assertRaisesRegex(ValueError, exc_str):
+            pset2._compute_exact_parameter_bounds(SolverFactory("baron"))
+
     def test_point_in_set(self):
         """
         Test point in set checks work as expected.

--- a/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
+++ b/pyomo/contrib/pyros/tests/test_uncertainty_sets.py
@@ -4067,8 +4067,6 @@ class TestCustomUncertaintySet(unittest.TestCase):
         custom_set = CustomUncertaintySet(dim=2)
         uq = custom_set.set_as_constraint(uncertain_params=None, block=m)
 
-        con1, con2, con3 = uq.uncertainty_cons
-        var1, var2 = uq.uncertain_param_vars
         self.assertEqual(uq.auxiliary_vars, [])
         self.assertIs(uq.block, m)
         self.assertEqual(len(uq.uncertainty_cons), 3)
@@ -4156,8 +4154,16 @@ class TestCustomUncertaintySet(unittest.TestCase):
         CONFIG = pyros_config()
         CONFIG.global_solver = global_solver
 
-        # constructing a feasibility problem
-        self.assertTrue(custom_set.is_nonempty(config=CONFIG), "Set is empty")
+        # nonempty by itself
+        self.assertTrue(custom_set.is_nonempty(config=CONFIG))
+
+        # nonempty since nominal point is in set
+        CONFIG.nominal_uncertain_param_vals = [0, 0]
+        self.assertTrue(custom_set.is_nonempty(config=CONFIG))
+
+        # nonempty even if nominal point is not in set
+        CONFIG.nominal_uncertain_param_vals = [-2, -2]
+        self.assertTrue(custom_set.is_nonempty(config=CONFIG))
 
     def test_fbbt_values(self):
         """

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -658,8 +658,8 @@ class UncertaintySet(metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If the feasibility problem is neither solved to an
-            acceptable level nor found to be infeasible.
+            If neither nonemptiness nor emptiness of the uncertainty
+            set can be certified.
         """
         if config.nominal_uncertain_param_vals and self.point_in_set(
             config.nominal_uncertain_param_vals

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -666,9 +666,10 @@ class UncertaintySet(metaclass=abc.ABCMeta):
             If the feasibility problem is neither solved to an
             acceptable level nor found to be infeasible.
         """
-        if config.nominal_uncertain_param_vals:
-            if self.point_in_set(config.nominal_uncertain_param_vals):
-                return True
+        if config.nominal_uncertain_param_vals and self.point_in_set(
+            config.nominal_uncertain_param_vals
+        ):
+            return True
 
         res = self._solve_feasibility(config.global_solver)
         if check_optimal_termination(res):

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -500,32 +500,26 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
         int : Dimension of the uncertainty set (number of uncertain
         parameters in a corresponding optimization model of interest).
         """
-        raise NotImplementedError
+        ...
 
     @property
     @abc.abstractmethod
     def geometry(self):
-        """
-        Geometry : Geometry of the uncertainty set.
-        """
-        raise NotImplementedError
+        """Geometry : Geometry of the uncertainty set."""
+        ...
 
     @property
     @abc.abstractmethod
     def parameter_bounds(self):
         """
-        Bounds for the value of each uncertain parameter constrained
-        by the set (i.e. bounds for each set dimension).
-
-        Returns
-        -------
-        list[tuple[numbers.Real, numbers.Real]]
-            If the bounds can be calculated efficiently, then this list
-            should be of length ``self.dim`` and contain the
-            (lower, upper) bound pairs.
-            Otherwise, the list should be empty.
+        list[tuple[numbers.Real, numbers.Real]] : Valid lower and upper
+        bounds for the coordinate values of points comprising the
+        set. If the bounds can be calculated efficiently,
+        then this list should be of length ``self.dim``
+        and contain the (lower, upper) bound pairs.
+        Otherwise, the list should be empty.
         """
-        raise NotImplementedError
+        ...
 
     @property
     def _cache(self):
@@ -729,7 +723,7 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
         UncertaintyQuantification
             A collection of the components added or addressed.
         """
-        pass
+        ...
 
     def point_in_set(self, point):
         """

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -2708,6 +2708,13 @@ class FactorModelSet(UncertaintySet):
 
     @beta.setter
     def beta(self, val):
+        validate_arg_type(
+            arg_name="beta",
+            arg_val=val,
+            valid_types=native_numeric_types,
+            valid_type_desc="a valid numeric type",
+            is_entry_of_arg=False,
+        )
         self._beta = val
 
     @property

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -3707,16 +3707,16 @@ class DiscreteScenarioSet(UncertaintySet):
         ]
         return parameter_bounds
 
-    def is_bounded(self, config):
+    def is_nonempty(self, config):
         """
-        Return True if the uncertainty set is bounded, and False
+        Return True if the uncertainty set is nonempty, and False
         otherwise.
 
-        By default, the discrete scenario set is bounded,
-        as the entries of all uncertain parameter scenarios
-        are finite.
+        Returns
+        -------
+        bool
         """
-        return True
+        return len(self.scenarios) > 0
 
     @copy_docstring(UncertaintySet.set_as_constraint)
     def set_as_constraint(self, uncertain_params=None, block=None):

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -474,7 +474,7 @@ class Geometry(Enum):
     DISCRETE_SCENARIOS = 4
 
 
-class UncertaintySet(object, metaclass=abc.ABCMeta):
+class UncertaintySet(metaclass=abc.ABCMeta):
     """
     An object representing an uncertainty set to be passed to the
     PyROS solver.

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -578,7 +578,8 @@ class UncertaintySet(metaclass=abc.ABCMeta):
 
     def is_bounded(self, config):
         """
-        Determine whether the uncertainty set is bounded.
+        Return True if the uncertainty set is certified to be bounded,
+        False otherwise.
 
         Parameters
         ----------
@@ -587,9 +588,7 @@ class UncertaintySet(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        : bool
-            True if the uncertainty set is certified to be bounded,
-            and False otherwise.
+        bool
 
         Notes
         -----

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -959,8 +959,8 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
 
     def _solve_feasibility(self, solver):
         """
-        Construct and solve feasibility problem using uncertainty set
-        constraints defined by ``self.set_as_constraint(self, ...)``.
+        Construct and solve feasibility problem with constraints
+        defined by ``self.set_as_constraint(self, ...)``.
 
         Parameters
         ----------

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -41,6 +41,7 @@ from pyomo.core.base import (
 )
 from pyomo.core.expr import mutable_expression, native_numeric_types, value
 from pyomo.core.util import quicksum, dot_product
+from pyomo.opt import TerminationCondition
 from pyomo.opt.results import check_optimal_termination
 from pyomo.contrib.pyros.util import (
     copy_docstring,
@@ -649,7 +650,12 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
 
     def is_nonempty(self, config):
         """
-        Determine whether the uncertainty set is nonempty.
+        Return True if the uncertainty set is known to be nonempty,
+        False if the uncertainty set is known to be empty.
+
+        This check is performed by constructing and solving a
+        feasibility problem with constraints defined by
+        ``self.set_as_constraint(self, ...)``.
 
         Parameters
         ----------
@@ -658,31 +664,33 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        : bool
-            True if the uncertainty set is nonempty,
-            and False otherwise.
+        bool
+
+        Raises
+        ------
+        ValueError
+            If the feasibility problem is neither solved to an
+            acceptable level nor found to be infeasible.
         """
-        # check if nominal point is in set for quick test
         if config.nominal_uncertain_param_vals:
-            set_nonempty = self.point_in_set(config.nominal_uncertain_param_vals)
+            if self.point_in_set(config.nominal_uncertain_param_vals):
+                return True
+
+        res = self._solve_feasibility(config.global_solver)
+        if check_optimal_termination(res):
+            return True
+        elif res.solver.termination_condition == TerminationCondition.infeasible:
+            return False
         else:
-            # construct feasibility problem and solve otherwise
-            self._solve_feasibility(config.global_solver)
-            set_nonempty = True
-
-        # log result
-        if not set_nonempty:
-            config.progress_logger.error(
-                "Nominal point is not within the uncertainty set. "
-                f"Got nominal point: {config.nominal_uncertain_param_vals}"
+            raise ValueError(
+                "Could not successfully confirm whether feasibility problem "
+                f"for {type(self).__name__} instance was feasible or infeasible. "
+                f"Solver status summary:\n {res.solver}."
             )
-
-        return set_nonempty
 
     def validate(self, config):
         """
-        Validate the uncertainty set with a nonemptiness
-        and boundedness check.
+        Validate the uncertainty set with a boundedness check.
 
         Parameters
         ----------
@@ -692,12 +700,8 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If nonemptiness check or boundedness check fails.
+            If boundedness check fails.
         """
-        # perform validation checks
-        if not self.is_nonempty(config=config):
-            raise ValueError(f"Nonemptiness check failed for uncertainty set {self}.")
-
         if not self.is_bounded(config=config):
             raise ValueError(f"Boundedness check failed for uncertainty set {self}.")
 
@@ -956,28 +960,25 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
     def _solve_feasibility(self, solver):
         """
         Construct and solve feasibility problem using uncertainty set
-        constraints and parameter bounds using `set_as_constraint` and
-        `_add_bounds_on_uncertain_parameters` of self.
+        constraints defined by ``self.set_as_constraint(self, ...)``.
 
         Parameters
         ----------
         solver : Pyomo solver
-            Optimizer capable of solving bounding problems to
-            global optimality.
+            Optimizer that can obtain a feasible solution to the
+            bounding problem or certify that the problem is
+            globally infeasible.
 
-        Raises
-        ------
-        ValueError
-            If feasibility problem fails to solve.
+        Returns
+        -------
+        pyomo.opt.SolverResults
+            Solver results for the feasibility problem.
         """
         model = ConcreteModel()
         model.u = Var(within=NonNegativeReals)
 
         # construct param vars
         model.param_vars = Var(range(self.dim))
-
-        # add bounds on param vars
-        self._add_bounds_on_uncertain_parameters(model.param_vars, global_solver=solver)
 
         # add constraints
         self.set_as_constraint(uncertain_params=model.param_vars, block=model)
@@ -988,12 +989,7 @@ class UncertaintySet(object, metaclass=abc.ABCMeta):
             return model.u
 
         # solve feasibility problem
-        res = solver.solve(model, load_solutions=False)
-        if not check_optimal_termination(res):
-            raise ValueError(
-                "Could not successfully solve feasibility problem. "
-                f"Solver status summary:\n {res.solver}."
-            )
+        return solver.solve(model, load_solutions=False)
 
     def _add_bounds_on_uncertain_parameters(
         self, uncertain_param_vars, global_solver=None
@@ -2113,7 +2109,7 @@ class PolyhedralSet(UncertaintySet):
             If any uncertainty set attributes are not valid.
             (e.g., numeric values are infinite,
             or ``self.coefficients_mat`` has column of zeros).
-            If bounded and nonempty checks fail.
+            If boundedness check fails.
         """
         lhs_coeffs_arr = self.coefficients_mat
         rhs_vec_arr = self.rhs_vec
@@ -2147,7 +2143,7 @@ class PolyhedralSet(UncertaintySet):
                 "Ensure column has at least one nonzero entry"
             )
 
-        # check boundedness and nonemptiness
+        # boundedness check
         super().validate(config)
 
 
@@ -4064,6 +4060,10 @@ class IntersectionSet(UncertaintySet):
     def validate(self, config):
         """
         Check IntersectionSet validity.
+
+        This check is performed by validating each operand
+        set of the intersection and then validating the
+        intersection as a whole.
 
         Raises
         ------

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -647,10 +647,6 @@ class UncertaintySet(metaclass=abc.ABCMeta):
         Return True if the uncertainty set is known to be nonempty,
         False if the uncertainty set is known to be empty.
 
-        This check is performed by constructing and solving a
-        feasibility problem with constraints defined by
-        ``self.set_as_constraint(self, ...)``.
-
         Parameters
         ----------
         config : ConfigDict


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Summary/Motivation:

Following up on PRs #3558 and #3877, this PR modifies the (usage of) PyROS uncertainty set validation methods.

## Changes proposed in this PR:
- Remove `UncertaintySet.is_nonempty()` call from `UncertaintySet.validate()`. The call to `UncertaintySet.is_nonempty()` is considered redundant in the context of `PyROS.solve()`, since PyROS already checks, outside of `UncertaintySet.validate()`, the stricter criterion that the uncertainty set contains the user-provided nominal point.
- Ensure that `UncertaintySet.is_nonempty()` always returns True if the uncertainty set is nonempty, even if the uncertainty set does not contain the user-provided nominal point (see #3558).
- Fix the `is_nonempty()` and `is_bounded()` methods for `DiscreteScenarioSet`.
- Update/extend documentation and testing of `UncertaintySet.is_bounded()`, `UncertaintySet.is_nonempty()`, `UncertaintySet.validate()`, and `UncertaintySet` subclass instance validation routines.
- Simplify `UncertaintySet` base class implementation.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [x] **AI tools were NOT used during the preparation of this PR**


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
