### PR TITLE
Support trivial constraints in SCIP interfaces

### DIFF
--- a/pyomo/contrib/solver/solvers/scip/base.py
+++ b/pyomo/contrib/solver/solvers/scip/base.py
@@ -46,6 +46,7 @@ from pyomo.core.expr.relational_expr import (
     EqualityExpression,
     InequalityExpression,
     RangedExpression,
+    TrivialRelationalExpression,
 )
 from pyomo.core.expr.visitor import StreamBasedExpressionVisitor
 from pyomo.gdp.disjunct import AutoLinkedBinaryVar
@@ -218,6 +219,12 @@ def _handle_inequality(node, data, opt, visitor):
     return data[0] <= data[1]
 
 
+def _handle_trivial_inequality(node, data, opt, visitor):
+    # Keep the constant relation symbolic so that PySCIPOpt creates a
+    # constraint instead of Python evaluating it to a bool.
+    return scip.Expr() + data[0] <= data[1]
+
+
 def _handle_named_expression(node, data, opt, visitor):
     return data[0]
 
@@ -244,6 +251,7 @@ _operator_map = {
     EqualityExpression: _handle_equality,
     RangedExpression: _handle_ranged,
     InequalityExpression: _handle_inequality,
+    TrivialRelationalExpression: _handle_trivial_inequality,
     ScalarExpression: _handle_named_expression,
     ExpressionData: _handle_named_expression,
     VarData: _handle_var,

--- a/pyomo/contrib/solver/tests/solvers/test_scip_direct.py
+++ b/pyomo/contrib/solver/tests/solvers/test_scip_direct.py
@@ -243,6 +243,26 @@ class TestScipDirect(unittest.TestCase):
                 m, load_solutions=True, raise_exception_on_nonoptimal_result=False
             )
 
+    def test_trivial_constraints(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(0, 1))
+        m.feasible = pyo.Constraint(expr=pyo.Constraint.Feasible)
+        m.obj = pyo.Objective(expr=m.x)
+
+        opt = ScipDirect()
+        res = opt.solve(m)
+        self.assertEqual(res.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(m.x.value, 0)
+
+        m.infeasible = pyo.Constraint(expr=pyo.Constraint.Infeasible)
+        res = opt.solve(
+            m, load_solutions=False, raise_exception_on_nonoptimal_result=False
+        )
+        self.assertEqual(
+            res.termination_condition, TerminationCondition.provenInfeasible
+        )
+        self.assertEqual(res.solution_status, SolutionStatus.noSolution)
+
     def test_timer(self):
         m = self.create_lp_model()
         timer = HierarchicalTimer()

--- a/pyomo/contrib/solver/tests/solvers/test_scip_persistent.py
+++ b/pyomo/contrib/solver/tests/solvers/test_scip_persistent.py
@@ -289,3 +289,24 @@ class TestScipPersistent(unittest.TestCase):
             opt.solve(
                 m, load_solutions=True, raise_exception_on_nonoptimal_result=False
             )
+
+    def test_trivial_constraints(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(0, 1))
+        m.feasible = pyo.Constraint(expr=pyo.Constraint.Feasible)
+        m.obj = pyo.Objective(expr=m.x)
+
+        opt = ScipPersistent()
+        res = opt.solve(m)
+        self.assertEqual(res.solution_status, SolutionStatus.optimal)
+        self.assertAlmostEqual(m.x.value, 0)
+
+        m.infeasible = pyo.Constraint(expr=pyo.Constraint.Infeasible)
+        opt.add_constraints([m.infeasible])
+        res = opt.solve(
+            m, load_solutions=False, raise_exception_on_nonoptimal_result=False
+        )
+        self.assertEqual(
+            res.termination_condition, TerminationCondition.provenInfeasible
+        )
+        self.assertEqual(res.solution_status, SolutionStatus.noSolution)


### PR DESCRIPTION
## Fixes #3976.

## Summary/Motivation:

`Constraint.Feasible` and `Constraint.Infeasible` are represented by `TrivialRelationalExpression`. The SCIP expression visitor dispatches on exact types, so both the direct and persistent interfaces currently raise `NotImplementedError` while compiling these constraints.

## Changes proposed in this PR:
- Translate a trivial relation into a symbolic zero-degree PySCIPOpt expression, rather than letting Python reduce the constant inequality to a `bool`. This preserves `Feasible` as `0 <= 0` and `Infeasible` as `1 <= 0`.
- Add direct and persistent interface regressions using `min x`, `0 <= x <= 1`: the feasible case has known optimum `x = 0`, while adding `Constraint.Infeasible` must produce `provenInfeasible` with no solution.

## Validation:

- `.venv/bin/pytest -q --solver=scip_direct pyomo/contrib/solver/tests/solvers/test_scip_direct.py` — 22 passed
- `.venv/bin/pytest -q --solver=scip_persistent pyomo/contrib/solver/tests/solvers/test_scip_persistent.py` — 18 passed
- `.venv/bin/black --check pyomo/contrib/solver/solvers/scip/base.py pyomo/contrib/solver/tests/solvers/test_scip_direct.py pyomo/contrib/solver/tests/solvers/test_scip_persistent.py` — unchanged

## AI-Use Disclosure

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [x] AI tools generated tests (baselines, examples, and/or code)
    - [x] AI tools generated code (apart from tests)

    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [x] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [x] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make contributions and grant the license. If my employer has rights to intellectual property that includes my contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.