### PR TITLE
Model viewer -- Add menu items to set font.

### DIFF
--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -114,6 +114,8 @@ else:
     QFileDialog = QtWidgets.QFileDialog
     QMainWindow = QtWidgets.QMainWindow
     QMdiArea = QtWidgets.QMdiArea
+    QMenu = QtWidgets.QMenu
+    QFontDialog = QtWidgets.QFontDialog
     QApplication = QtWidgets.QApplication
     QTableWidgetItem = QtWidgets.QTableWidgetItem
     QStatusBar = QtWidgets.QStatusBar

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -166,6 +166,47 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self._dialog_test_button = None  # button clicked on dialog in test mode
         self.mdiArea.setViewMode(myqt.QMdiArea.ViewMode.TabbedView)
 
+        view_menu = self.menuBar().actions()[0].menu()
+        view_menu.addSeparator()
+        font_menu = myqt.QMenu("Font", self)
+        menu_font_action = myqt.QAction("Menu", self)
+        tree_font_action = myqt.QAction("Tree View", self)
+        font_menu.addAction(menu_font_action)
+        font_menu.addAction(tree_font_action)
+        menu_font_action.triggered.connect(self.cb_set_menu_font)
+        tree_font_action.triggered.connect(self.cb_set_tree_font)
+        view_menu.addMenu(font_menu)
+
+    def cb_set_menu_font(self):
+        def _recursive_action_font(w, fnt):
+            w.setFont(fnt)
+            if (
+                hasattr(w, "actions")
+                and w.actions() is not None
+                and len(w.actions()) > 0
+            ):
+                for w2 in w.actions():
+                    _recursive_action_font(w2, fnt)
+            if (
+                hasattr(w, "menu")
+                and w.menu() is not None
+                and len(w.menu().actions()) > 0
+            ):
+                for w2 in w.menu().actions():
+                    _recursive_action_font(w2, fnt)
+
+        ok, fnt = myqt.QFontDialog().getFont()
+        if ok:
+            _recursive_action_font(self.menuBar(), fnt)
+
+    def cb_set_tree_font(self):
+        ok, fnt = myqt.QFontDialog().getFont()
+        if ok:
+            self.variables.setFont(fnt)
+            self.expressions.setFont(fnt)
+            self.parameters.setFont(fnt)
+            self.constraints.setFont(fnt)
+
     def toggle_tabs(self):
         if self.mdiArea.viewMode() == myqt.QMdiArea.ViewMode.SubWindowView:
             self.mdiArea.setViewMode(myqt.QMdiArea.ViewMode.TabbedView)


### PR DESCRIPTION
## Fixes None

Feature

## Summary/Motivation:

I'm getting old I guess and having trouble seeing.

## Changes proposed in this PR:
- Add options to the model viewer menu to change the menu and tree view font.  On some screens or operating systems, the default can be pretty small.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [X] **AI tools were NOT used during the preparation of this PR**

or

- [ ] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
