### PR TITLE
Model viewer -- Fix issue where expressions that evaluate to numpy scalars don't display right

### DIFF
--- a/pyomo/contrib/viewer/tests/test_data_model_item.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_item.py
@@ -47,6 +47,7 @@ from pyomo.contrib.viewer.ui_data import UIData
 from pyomo.common.dependencies import DeferredImportError
 from pyomo.core.base.units_container import pint_available
 
+
 class Fake_numpy:
     class float64(float):
         pass

--- a/pyomo/contrib/viewer/tests/test_data_model_item.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_item.py
@@ -47,6 +47,13 @@ from pyomo.contrib.viewer.ui_data import UIData
 from pyomo.common.dependencies import DeferredImportError
 from pyomo.core.base.units_container import pint_available
 
+class Fake_numpy:
+    class float64(float):
+        pass
+
+    class int64(int):
+        pass
+
 
 @unittest.skipIf(not pint_available, "Pyomo units are not available")
 class TestDataModelItem(unittest.TestCase):
@@ -66,6 +73,8 @@ class TestDataModelItem(unittest.TestCase):
         m.b1.e3 = Expression(expr=m.x[3] * m.x[1])
         m.b1.e4 = Expression(expr=log(m.x[2]))
         m.b1.e5 = Expression(expr=log(m.x[2] - 2))
+        m.b1.e6 = Expression(expr=Fake_numpy.float64(3.2))
+        m.b1.e7 = Expression(expr=Fake_numpy.int64(3))
 
         def blackbox(a, b):
             return sin(a - b)
@@ -124,6 +133,24 @@ class TestDataModelItem(unittest.TestCase):
         )
         cdi.ui_data.calculate_expressions()
         self.assertIsNone(cdi.get("value"))
+
+    def test_expr_calc_numpy_float(self):
+        cdi = ComponentDataItem(
+            parent=None, ui_data=UIData(model=self.m), o=self.m.b1.e6
+        )
+        cdi.ui_data.calculate_expressions()
+        self.assertIsInstance(pyo.value(self.m.b1.e6), Fake_numpy.float64)
+        self.assertAlmostEqual(cdi.get("value"), 3.2)
+        self.assertNotIsInstance(cdi.get("value"), Fake_numpy.float64)
+
+    def test_expr_calc_numpy_int(self):
+        cdi = ComponentDataItem(
+            parent=None, ui_data=UIData(model=self.m), o=self.m.b1.e7
+        )
+        cdi.ui_data.calculate_expressions()
+        self.assertIsInstance(pyo.value(self.m.b1.e7), Fake_numpy.int64)
+        self.assertEqual(cdi.get("value"), 3)
+        self.assertNotIsInstance(cdi.get("value"), Fake_numpy.int64)
 
     def test_expr_calc_value_None(self):
         cdi = ComponentDataItem(

--- a/pyomo/contrib/viewer/ui_data.py
+++ b/pyomo/contrib/viewer/ui_data.py
@@ -118,6 +118,10 @@ class UIDataNoUi:
         for o in self.model.component_data_objects(pyo.Expression, active=True):
             try:
                 self.value_cache[o] = pyo.value(o, exception=False)
+                if "numpy.float" in str(type(self.value_cache[o])):
+                    self.value_cache[o] = float(self.value_cache[o])
+                elif "numpy.int" in str(type(self.value_cache[o])):
+                    self.value_cache[o] = int(self.value_cache[o])
             except ZeroDivisionError:
                 self.value_cache[o] = "Divide_by_0"
             try:


### PR DESCRIPTION
## Fixes

If an expression value is a numpy scalar it did not display right in the model viewer. 

## Summary/Motivation:

After calculating expression values, they don't show up in the viewer is the values are numpy objects.  This checks if the expression values are numpy scalars and if so converts them to int or float as appropriate.  This checks the string class name, so I can avoid importing numpy.       

## Changes proposed in this PR:
- Fix model viewer display issue

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [X] **AI tools were NOT used during the preparation of this PR**

or

- [ ] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [ ] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [ ] Checked correctness/logic of code and tests
        - [ ] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** <!-- Where should reviewers focus? What are you least confident about? -->

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
