### PR TITLE
Fix GLOA convex affine cut slope

### DIFF
--- a/pyomo/contrib/gdpopt/gloa.py
+++ b/pyomo/contrib/gdpopt/gloa.py
@@ -195,31 +195,49 @@ class GDP_GLOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
                 aff_utils_blocks[parent_block] = aff_utils
                 aff_utils.GDPopt_aff_cons = Constraint(NonNegativeIntegers)
             aff_cuts = aff_utils.GDPopt_aff_cons
-            cut_body = sum(
+            concave_cut_body = sum(
                 ccSlope[var] * (var - var.value)
                 for var in vars_in_constr
                 if not var.fixed
             )
-            if not is_potentially_variable(cut_body):
+            convex_cut_body = sum(
+                cvSlope[var] * (var - var.value)
+                for var in vars_in_constr
+                if not var.fixed
+            )
+            concave_cut_is_variable = is_potentially_variable(concave_cut_body)
+            convex_cut_is_variable = is_potentially_variable(convex_cut_body)
+
+            if not concave_cut_is_variable:
                 if (
-                    cut_body + ccStart >= lb_int - config.constraint_tolerance
-                    and cut_body + cvStart <= ub_int + config.constraint_tolerance
+                    value(concave_cut_body + ccStart)
+                    < lb_int - config.constraint_tolerance
                 ):
-                    # We won't add them, but nothing is wrong--they hold
-                    config.logger.debug("Affine cut is trivially True.")
-                else:
-                    # something went wrong.
                     raise DeveloperError("One of the affine cuts is trivially False.")
+            if not convex_cut_is_variable:
+                if (
+                    value(convex_cut_body + cvStart)
+                    > ub_int + config.constraint_tolerance
+                ):
+                    raise DeveloperError("One of the affine cuts is trivially False.")
+
+            if not concave_cut_is_variable and not convex_cut_is_variable:
+                # We won't add them, but nothing is wrong--they hold
+                config.logger.debug("Affine cut is trivially True.")
             else:
-                concave_cut = cut_body + ccStart >= lb_int
-                convex_cut = cut_body + cvStart <= ub_int
                 idx = len(aff_cuts)
-                aff_cuts[idx] = concave_cut
-                aff_cuts[idx + 1] = convex_cut
-                _add_bigm_constraint_to_transformed_model(m, aff_cuts[idx], aff_cuts)
-                _add_bigm_constraint_to_transformed_model(
-                    m, aff_cuts[idx + 1], aff_cuts
-                )
-                counter += 2
+                if concave_cut_is_variable:
+                    aff_cuts[idx] = concave_cut_body + ccStart >= lb_int
+                    _add_bigm_constraint_to_transformed_model(
+                        m, aff_cuts[idx], aff_cuts
+                    )
+                    idx += 1
+                    counter += 1
+                if convex_cut_is_variable:
+                    aff_cuts[idx] = convex_cut_body + cvStart <= ub_int
+                    _add_bigm_constraint_to_transformed_model(
+                        m, aff_cuts[idx], aff_cuts
+                    )
+                    counter += 1
 
                 config.logger.debug("Added %s affine cuts" % counter)

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -312,6 +312,41 @@ class TestGDPoptUnit(unittest.TestCase):
         self.assertEqual(c2.lower, 0)
         self.assertIsNone(c2.upper)
 
+    @unittest.skipIf(not mcpp_available(), "MC++ is not available")
+    def test_gloa_affine_cut_uses_convex_slope_for_upper_cut(self):
+        m = ConcreteModel()
+        m.P = Var(bounds=(0, 10), initialize=0.05)
+        m.Q = Var(bounds=(1, 10), initialize=1.000002190520329)
+        m.F = Var(bounds=(0, 10), initialize=0.050000453446344)
+        m.QP = Var(bounds=(0, 10), initialize=1.0)
+        m.c = Constraint(expr=m.P * m.Q - m.F * m.QP == 0)
+
+        m.GDPopt_utils = Block()
+        util_block = m.GDPopt_utils
+        util_block.algebraic_variable_list = [m.P, m.Q, m.F, m.QP]
+        util_block.global_constraint_list = [m.c]
+        util_block.constraints_by_disjunct = {}
+
+        config = Bunch(
+            logger=logging.getLogger('pyomo.contrib.gdpopt.tests'),
+            integer_tolerance=1e-6,
+            constraint_tolerance=1e-6,
+        )
+
+        SolverFactory('gdpopt.gloa')._add_cuts_to_discrete_problem(
+            util_block, util_block, None, config, Bunch()
+        )
+
+        feasible_point = [(m.P, 0.05), (m.Q, 1.1), (m.F, 0.055), (m.QP, 1.0)]
+        for var, val in feasible_point:
+            var.set_value(val)
+
+        aff_cuts = m.GDPopt_aff.GDPopt_aff_cons
+        self.assertEqual(len(aff_cuts), 2)
+        convex_cut = aff_cuts[1]
+        self.assertLessEqual(value(convex_cut.body), value(convex_cut.upper) + 1e-12)
+        self.assertAlmostEqual(value(convex_cut.body), -0.5)
+
     def test_complain_when_no_algorithm_specified(self):
         m = self.get_GDP_on_block()
         with self.assertRaisesRegex(

--- a/pyomo/contrib/mindtpy/tests/unit_test.py
+++ b/pyomo/contrib/mindtpy/tests/unit_test.py
@@ -7,14 +7,25 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
-import pyomo.common.unittest as unittest
-from pyomo.contrib.mindtpy.util import set_var_valid_value
+import logging
 
-from pyomo.environ import Var, Integers, ConcreteModel, Integers
+import pyomo.common.unittest as unittest
+from pyomo.common.collections import Bunch
+from pyomo.contrib.mcpp.pyomo_mcpp import mcpp_available
 from pyomo.contrib.mindtpy.algorithm_base_class import _MindtPyAlgorithm
 from pyomo.contrib.mindtpy.config_options import _get_MindtPy_OA_config
+from pyomo.contrib.mindtpy.cut_generation import add_affine_cuts
 from pyomo.contrib.mindtpy.tests.MINLP5_simple import SimpleMINLP5
-from pyomo.contrib.mindtpy.util import add_var_bound
+from pyomo.contrib.mindtpy.util import add_var_bound, set_var_valid_value
+from pyomo.environ import (
+    Block,
+    ConcreteModel,
+    Constraint,
+    ConstraintList,
+    Integers,
+    Var,
+    value,
+)
 
 
 class UnitTestMindtPy(unittest.TestCase):
@@ -93,6 +104,33 @@ class UnitTestMindtPy(unittest.TestCase):
         self.assertEqual(
             solver_object.working_model.y.upper, solver_object.config.integer_var_bound
         )
+
+    @unittest.skipIf(not mcpp_available(), "MC++ is not available")
+    def test_goa_affine_cut_uses_convex_slope_for_upper_cut(self):
+        m = ConcreteModel()
+        m.P = Var(bounds=(0, 10), initialize=0.05)
+        m.Q = Var(bounds=(1, 10), initialize=1.000002190520329)
+        m.F = Var(bounds=(0, 10), initialize=0.050000453446344)
+        m.QP = Var(bounds=(0, 10), initialize=1.0)
+        m.c = Constraint(expr=m.P * m.Q - m.F * m.QP == 0)
+
+        m.MindtPy_utils = Block()
+        m.MindtPy_utils.nonlinear_constraint_list = [m.c]
+        m.MindtPy_utils.cuts = Block()
+        m.MindtPy_utils.cuts.aff_cuts = ConstraintList()
+
+        config = Bunch(logger=logging.getLogger('pyomo.contrib.mindtpy.tests'))
+        add_affine_cuts(m, config, Bunch())
+
+        feasible_point = [(m.P, 0.05), (m.Q, 1.1), (m.F, 0.055), (m.QP, 1.0)]
+        for var, val in feasible_point:
+            var.set_value(val)
+
+        aff_cuts = list(m.MindtPy_utils.cuts.aff_cuts.values())
+        self.assertEqual(len(aff_cuts), 2)
+        convex_cut = aff_cuts[1]
+        self.assertLessEqual(value(convex_cut.body), value(convex_cut.upper) + 1e-12)
+        self.assertAlmostEqual(value(convex_cut.body), -0.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3939.

## Summary/Motivation:

GDPopt GLOA builds both of its affine cuts from a single `cut_body` expression computed from the MC++ concave slopes (`ccSlope`). The concave underestimator cut is correct, but the convex overestimator cut reuses those same concave slopes instead of the convex slopes (`cvSlope`). That produces an invalid upper cut, which can cut off feasible points and let GLOA terminate at a non-global solution.

MindtPy's GOA affine-cut path already uses the convex slope for its upper cut, so this brings GLOA in line with the existing correct implementation.

This is a replacement for #3940, which GitHub would not allow me to reopen after it was closed. The prior review discussion and history remain available there.

Integration evidence from GDPlib (recorded on #3940): on the GDPlib `methanol` GLOA benchmark, unpatched Pyomo `6.10.0` terminated after 1 iteration at objective `-1743.4292381783366`, while this branch ran 15 iterations and reached `-1793.4292385308854`, matching GDPlib's documented best-known objective `-1793.4292381783` to solver tolerance. This was the focused methanol GLOA case; I did not run the full GDPlib benchmark matrix.

## Changes proposed in this PR:

- Compute the concave and convex affine cut bodies separately in `pyomo/contrib/gdpopt/gloa.py`, so the convex overestimator cut uses `cvSlope` (MC++ `subcv()`) rather than reusing the concave `ccSlope`.
- Evaluate the trivially-True and trivially-False checks per cut, and add each cut independently, so a constant concave cut no longer suppresses a variable convex cut (and vice versa).
- Add `test_gloa_affine_cut_uses_convex_slope_for_upper_cut` to `pyomo/contrib/gdpopt/tests/test_gdpopt.py`, a solver-free regression covering the invalid-cut case from the issue.
- Add the matching `test_goa_affine_cut_uses_convex_slope_for_upper_cut` to `pyomo/contrib/mindtpy/tests/unit_test.py`, documenting that MindtPy GOA already uses the convex slope for its upper cut.
- Validation performed locally on this branch, rebased onto current `main`:
  - `python -m pytest -q pyomo/contrib/gdpopt/tests/test_gdpopt.py pyomo/contrib/mindtpy/tests/unit_test.py`
    - Result: `65 passed, 19 skipped, 3 deselected in 39.87s`
  - `python -m black --check pyomo/contrib/gdpopt/gloa.py pyomo/contrib/gdpopt/tests/test_gdpopt.py pyomo/contrib/mindtpy/tests/unit_test.py`
    - Result: passed, `3 files would be left unchanged`
  - `typos --config ./.github/workflows/typos.toml` on the three changed files
    - Result: passed, no findings

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [x] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [x] AI tools generated tests (baselines, examples, and/or code)
    - [x] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [x] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [x] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** This replacement PR carries over the implementation and tests from #3940 unchanged, then refreshes the branch against current `main`. The replacement PR description and branch-refresh workflow were prepared with AI assistance and reviewed before posting. Reviewers may want to focus on the restructured trivial-cut handling: previously a single `is_potentially_variable` check governed both cuts together, and this PR splits that into independent per-cut checks, so the trivially-False `DeveloperError` conditions are now evaluated separately for the concave lower cut and the convex upper cut.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
