### PR TITLE
Add pixi environment directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ cplex.log
 
 # Mac tracking files
 *.DS_Store*
+
+# Pixi local environments
+.pixi/

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,32 @@
-# temporary editor files
+# Mac tracking files
+*.DS_Store*
+
+# Temporary editor files
 *~
 .#*
 \#*#
 
-# IDE configuration files
+# IDE / editor configuration
 .idea
 .spyder*
 .ropeproject
 .vscode
+
+# Environment / package manager directories
 .pixi/
 
 # Python generates numerous files when byte compiling / installing packages
 __pycache__/
-*.pyx
 *.py[cod]
+*.pyx
 *.egg-info/
+
+# Results from pytest --with-coverage
+.coverage
+*.cover
+
+# Jupyterhub/Jupyterlab checkpoints
+.ipynb_checkpoints
 
 # Documentation builds
 doc/OnlineDocs/api
@@ -25,13 +37,3 @@ doc/OnlineDocs/**/*.spy
 *.out
 gurobi.log
 cplex.log
-
-# Results from pytest --with-coverage
-.coverage
-*.cover
-
-# Jupyterhub/Jupyterlab checkpoints
-.ipynb_checkpoints
-
-# Mac tracking files
-*.DS_Store*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .spyder*
 .ropeproject
 .vscode
+.pixi/
 
 # Python generates numerous files when byte compiling / installing packages
 __pycache__/
@@ -34,6 +35,3 @@ cplex.log
 
 # Mac tracking files
 *.DS_Store*
-
-# Pixi local environments
-.pixi/


### PR DESCRIPTION
## Fixes # .

None — minor development-environment housekeeping; no linked issue.

## Summary/Motivation:

[Pixi](https://pixi.sh) is a conda-ecosystem environment/package manager that stores its generated environments in a `.pixi/` directory at the project root. Like the IDE configuration directories already ignored (`.vscode`, `.idea`, `.spyder*`), this directory is machine-generated, potentially large, and specific to a contributor's local setup, so checkouts of contributors who manage their Pyomo development environment with pixi currently show thousands of untracked files.

## Changes proposed in this PR:
- Add `.pixi/` to `.gitignore`, alongside the existing editor/tool entries.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [x] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)

    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [ ] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository

 **Notes for reviewers (optional):** AI assistance was limited to drafting this description and the commit message; the one-line `.gitignore` entry itself was authored manually in a local checkout before being upstreamed here.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
