### PR TITLE
Fix cuOpt solver name formatting for versions with != 3 components

### DIFF
--- a/pyomo/solvers/plugins/solvers/cuopt_direct.py
+++ b/pyomo/solvers/plugins/solvers/cuopt_direct.py
@@ -34,7 +34,7 @@ def _get_cuopt_version(cuopt, avail):
     if not avail:
         return
     CUOPTDirect._version = tuple(cuopt.__version__.split('.'))
-    CUOPTDirect._name = "cuOpt %s.%s%s" % CUOPTDirect._version
+    CUOPTDirect._name = "cuOpt %s" % (cuopt.__version__,)
 
 
 # Note: catch RuntimeError as the base for CUDARuntimeError, which can

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -42,14 +42,26 @@ class _FakeCuopt:
         self.__version__ = version
 
 
+_unset = object()
+
+
 class TestGetCuoptVersion(unittest.TestCase):
     def setUp(self):
-        self._orig_version = CUOPTDirect._version
-        self._orig_name = CUOPTDirect._name
+        # cuOpt may not be installed in this environment, in which case
+        # the attempt_import callback never ran and these class
+        # attributes were never set.
+        self._orig_version = CUOPTDirect.__dict__.get('_version', _unset)
+        self._orig_name = CUOPTDirect.__dict__.get('_name', _unset)
 
     def tearDown(self):
-        CUOPTDirect._version = self._orig_version
-        CUOPTDirect._name = self._orig_name
+        if self._orig_version is _unset:
+            del CUOPTDirect._version
+        else:
+            CUOPTDirect._version = self._orig_version
+        if self._orig_name is _unset:
+            del CUOPTDirect._name
+        else:
+            CUOPTDirect._name = self._orig_name
 
     def test_not_available(self):
         CUOPTDirect._version = None

--- a/pyomo/solvers/tests/checks/test_cuopt_direct.py
+++ b/pyomo/solvers/tests/checks/test_cuopt_direct.py
@@ -28,7 +28,46 @@ from pyomo.opt import check_available_solvers
 from pyomo.common.tee import capture_output
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.common.unittest as unittest
-from pyomo.solvers.plugins.solvers.cuopt_direct import cuopt_available, CUOPTDirect
+from pyomo.solvers.plugins.solvers.cuopt_direct import (
+    cuopt_available,
+    CUOPTDirect,
+    _get_cuopt_version,
+)
+
+
+class _FakeCuopt:
+    """Stand-in for the cuopt module, exposing only __version__."""
+
+    def __init__(self, version):
+        self.__version__ = version
+
+
+class TestGetCuoptVersion(unittest.TestCase):
+    def setUp(self):
+        self._orig_version = CUOPTDirect._version
+        self._orig_name = CUOPTDirect._name
+
+    def tearDown(self):
+        CUOPTDirect._version = self._orig_version
+        CUOPTDirect._name = self._orig_name
+
+    def test_not_available(self):
+        CUOPTDirect._version = None
+        CUOPTDirect._name = None
+        _get_cuopt_version(_FakeCuopt("26.10.00"), False)
+        self.assertIsNone(CUOPTDirect._version)
+        self.assertIsNone(CUOPTDirect._name)
+
+    def test_version_formats(self):
+        cases = [
+            ("26.10.0a37.post260819050903", "cuOpt 26.10.0a37.post260819050903"),
+            ("26.10.00a37", "cuOpt 26.10.00a37"),
+            ("26.10.00", "cuOpt 26.10.00"),
+        ]
+        for version, expected_name in cases:
+            _get_cuopt_version(_FakeCuopt(version), True)
+            self.assertEqual(CUOPTDirect._version, tuple(version.split('.')))
+            self.assertEqual(CUOPTDirect._name, expected_name)
 
 
 def _cuopt_at_least(*required):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

`_get_cuopt_version` formats the solver name with `"cuOpt %s.%s%s" % tuple(cuopt.__version__.split('.'))`, which requires the version to have exactly three dot-separated components. cuOpt nightly wheels carry a PEP 440 `.post` suffix (e.g. `26.10.0a37.post260819050903`), giving four components and raising:

```
pyomo/solvers/plugins/solvers/cuopt_direct.py:37: in _get_cuopt_version
    CUOPTDirect._name = "cuOpt %s.%s%s" % CUOPTDirect._version
E   TypeError: not all arguments converted during string formatting
```

Since this runs in the `attempt_import` callback, it fires when Pyomo resolves its solver plugins and aborts pytest collection for any module that touches the solver list, not just cuOpt's own tests.

It also fixes the 3-component case, which dropped a separator: `26.10.00` rendered as `cuOpt 26.1000`.

| `cuopt.__version__` | before | after |
|---|---|---|
| `26.10.0a37.post260819050903` | `TypeError` | `cuOpt 26.10.0a37.post260819050903` |
| `26.10.00a37` | `cuOpt 26.1000a37` | `cuOpt 26.10.00a37` |
| `26.10.00` | `cuOpt 26.1000` | `cuOpt 26.10.00` |

## Changes proposed in this PR:
- Format the cuOpt solver name from the version string directly, so it is correct for any number of version components. `_version` is unchanged, so `version()` behaviour is unaffected.

## AI-Use Disclosure
<!-- Contributors must disclose whether and how AI tools were used and highlight any areas of uncertainty or where they want focused reviewer feedback -->

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [x] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [ ] AI tools generated tests (baselines, examples, and/or code)
    - [x] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    
 **Notes for reviewers (optional):** The change is a one-line formatting fix. Verified by evaluating the format against the version strings cuOpt ships (release, nightly conda, nightly wheel) and by running `black --check`. No test was added — happy to add one if you'd like coverage for the version-parsing callback.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
