### PR TITLE
Make GDP enumeration lazy

### DIFF
--- a/pyomo/contrib/gdpopt/enumerate.py
+++ b/pyomo/contrib/gdpopt/enumerate.py
@@ -7,9 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
-import math
 from itertools import product
-from operator import index
 
 from pyomo.common.collections import ComponentSet
 from pyomo.common.config import document_kwargs_from_configdict
@@ -29,11 +27,7 @@ from pyomo.contrib.gdpopt.create_oa_subproblems import (
     get_subproblem,
 )
 from pyomo.contrib.gdpopt.solve_subproblem import solve_subproblem
-from pyomo.contrib.gdpopt.util import (
-    fix_discrete_solution_in_subproblem,
-    time_code,
-    get_main_elapsed_time,
-)
+from pyomo.contrib.gdpopt.util import fix_discrete_solution_in_subproblem, time_code
 
 from pyomo.core import value
 from pyomo.opt import TerminationCondition as tc
@@ -95,22 +89,6 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
                             integer_realization,
                         )
 
-    # Override logging so that we print progress in terms of the number of
-    # iterations needed to fully enumerate the discrete space.
-    def _log_current_state(self, logger, subproblem_type, primal_improved=False):
-        star = "*" if primal_improved else ""
-        logger.info(
-            self.log_formatter.format(
-                "{}/{}".format(self.iteration, self.num_discrete_solns),
-                subproblem_type,
-                self.LB,
-                self.UB,
-                self.relative_gap(),
-                get_main_elapsed_time(self.timing),
-                star,
-            )
-        )
-
     def _solve_gdp(self, original_model, config):
         util_block = self.original_util_block
         # From preprocessing to make sure this *is* a GDP, we already have
@@ -124,29 +102,16 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
 
         subproblem, subproblem_util_block = get_subproblem(original_model, util_block)
 
-        disjunctions = subproblem_util_block.disjunction_list
-        non_indicator_boolean_vars = (
-            subproblem_util_block.non_indicator_boolean_variable_list
-        )
-        discrete_vars = subproblem_util_block.discrete_variable_list
-
-        self.num_discrete_solns = math.prod(
-            len(disjunction.disjuncts) for disjunction in disjunctions
-        )
-        if config.force_subproblem_nlp:
-            self.num_discrete_solns *= 2 ** len(non_indicator_boolean_vars) * math.prod(
-                max(0, index(v.ub) - index(v.lb) + 1) for v in discrete_vars
-            )
-
         if self.reached_time_limit(config) or self.reached_iteration_limit(config):
             return
-        discrete_solns = self._discrete_solution_iterator(
-            disjunctions, non_indicator_boolean_vars, discrete_vars, config
-        )
-        for _ in range(self.num_discrete_solns):
+        for soln in self._discrete_solution_iterator(
+            subproblem_util_block.disjunction_list,
+            subproblem_util_block.non_indicator_boolean_variable_list,
+            subproblem_util_block.discrete_variable_list,
+            config,
+        ):
             if self.reached_time_limit(config) or self.reached_iteration_limit(config):
                 return
-            soln = next(discrete_solns)
 
             self.iteration += 1
 

--- a/pyomo/contrib/gdpopt/enumerate.py
+++ b/pyomo/contrib/gdpopt/enumerate.py
@@ -7,7 +7,9 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
+import math
 from itertools import product
+from operator import index
 
 from pyomo.common.collections import ComponentSet
 from pyomo.common.config import document_kwargs_from_configdict
@@ -110,8 +112,6 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
         )
 
     def _solve_gdp(self, original_model, config):
-        logger = config.logger
-
         util_block = self.original_util_block
         # From preprocessing to make sure this *is* a GDP, we already have
         # lists of:
@@ -124,19 +124,30 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
 
         subproblem, subproblem_util_block = get_subproblem(original_model, util_block)
 
-        discrete_solns = list(
-            self._discrete_solution_iterator(
-                subproblem_util_block.disjunction_list,
-                subproblem_util_block.non_indicator_boolean_variable_list,
-                subproblem_util_block.discrete_variable_list,
-                config,
-            )
+        disjunctions = subproblem_util_block.disjunction_list
+        non_indicator_boolean_vars = (
+            subproblem_util_block.non_indicator_boolean_variable_list
         )
-        self.num_discrete_solns = len(discrete_solns)
-        for soln in discrete_solns:
-            # We will interrupt based on time limit or iteration limit:
+        discrete_vars = subproblem_util_block.discrete_variable_list
+
+        self.num_discrete_solns = math.prod(
+            len(disjunction.disjuncts) for disjunction in disjunctions
+        )
+        if config.force_subproblem_nlp:
+            self.num_discrete_solns *= 2 ** len(non_indicator_boolean_vars) * math.prod(
+                max(0, index(v.ub) - index(v.lb) + 1) for v in discrete_vars
+            )
+
+        if self.reached_time_limit(config) or self.reached_iteration_limit(config):
+            return
+        discrete_solns = self._discrete_solution_iterator(
+            disjunctions, non_indicator_boolean_vars, discrete_vars, config
+        )
+        for _ in range(self.num_discrete_solns):
             if self.reached_time_limit(config) or self.reached_iteration_limit(config):
-                break
+                return
+            soln = next(discrete_solns)
+
             self.iteration += 1
 
             with time_code(self.timing, 'nlp'):
@@ -159,26 +170,23 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
                         # the whole problem is unbounded, we can stop
                         self._update_primal_bound_to_unbounded(config)
                         self._log_current_state(config.logger, 'subproblem', True)
-                        break
+                        return
 
                     else:
                         # Just log where we are
                         self._log_current_state(config.logger, 'subproblem')
 
-            if self.iteration == self.num_discrete_solns:
-                # We can terminate optimally or declare infeasibility: We have
-                # enumerated all solutions, so our incumbent is optimal (or
-                # locally optimal, depending on how we solved the subproblems)
-                # if it exists, and if not then there is no solution.
-                if self.incumbent_boolean_soln is None:
-                    self._update_dual_bound_to_infeasible()
-                    self._load_infeasible_termination_status(config)
-                else:  # the incumbent is optimal
-                    self._update_bounds(dual=self.primal_bound(), force_update=True)
-                    self._log_current_state(config.logger, '')
-                    config.logger.info(
-                        'GDPopt exiting--all discrete solutions have been '
-                        'enumerated.'
-                    )
-                    self.pyomo_results.solver.termination_condition = tc.optimal
-                    break
+        # We can terminate optimally or declare infeasibility: We have
+        # enumerated all solutions, so our incumbent is optimal (or
+        # locally optimal, depending on how we solved the subproblems)
+        # if it exists, and if not then there is no solution.
+        if self.incumbent_boolean_soln is None:
+            self._update_dual_bound_to_infeasible()
+            self._load_infeasible_termination_status(config)
+        else:  # the incumbent is optimal
+            self._update_bounds(dual=self.primal_bound(), force_update=True)
+            self._log_current_state(config.logger, '')
+            config.logger.info(
+                'GDPopt exiting--all discrete solutions have been enumerated.'
+            )
+            self.pyomo_results.solver.termination_condition = tc.optimal

--- a/pyomo/contrib/gdpopt/enumerate.py
+++ b/pyomo/contrib/gdpopt/enumerate.py
@@ -7,6 +7,7 @@
 # software.  This software is distributed under the 3-clause BSD License.
 # ____________________________________________________________________________________
 
+import math
 from itertools import product
 
 from pyomo.common.collections import ComponentSet
@@ -27,7 +28,11 @@ from pyomo.contrib.gdpopt.create_oa_subproblems import (
     get_subproblem,
 )
 from pyomo.contrib.gdpopt.solve_subproblem import solve_subproblem
-from pyomo.contrib.gdpopt.util import fix_discrete_solution_in_subproblem, time_code
+from pyomo.contrib.gdpopt.util import (
+    fix_discrete_solution_in_subproblem,
+    time_code,
+    get_main_elapsed_time,
+)
 
 from pyomo.core import value
 from pyomo.opt import TerminationCondition as tc
@@ -69,7 +74,9 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
     def _discrete_solution_iterator(
         self, disjunctions, non_indicator_boolean_vars, discrete_var_list, config
     ):
-        discrete_var_values = [range(v.lb, v.ub + 1) for v in discrete_var_list]
+        discrete_var_values = [
+            range(math.ceil(v.lb), math.floor(v.ub) + 1) for v in discrete_var_list
+        ]
         # we will calculate all the possible indicator_var realizations, and
         # then multiply those out by all the boolean var realizations and all
         # the integer var realizations.
@@ -89,6 +96,22 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
                             integer_realization,
                         )
 
+    # Override logging so that we print progress in terms of the number of
+    # iterations needed to fully enumerate the discrete space.
+    def _log_current_state(self, logger, subproblem_type, primal_improved=False):
+        star = "*" if primal_improved else ""
+        logger.info(
+            self.log_formatter.format(
+                "{}/{}".format(self.iteration, self.num_discrete_solns),
+                subproblem_type,
+                self.LB,
+                self.UB,
+                self.relative_gap(),
+                get_main_elapsed_time(self.timing),
+                star,
+            )
+        )
+
     def _solve_gdp(self, original_model, config):
         util_block = self.original_util_block
         # From preprocessing to make sure this *is* a GDP, we already have
@@ -102,13 +125,24 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
 
         subproblem, subproblem_util_block = get_subproblem(original_model, util_block)
 
+        disjunctions = subproblem_util_block.disjunction_list
+        non_indicator_boolean_vars = (
+            subproblem_util_block.non_indicator_boolean_variable_list
+        )
+        discrete_vars = subproblem_util_block.discrete_variable_list
+
+        self.num_discrete_solns = math.prod(
+            len(disjunction.disjuncts) for disjunction in disjunctions
+        )
+        if config.force_subproblem_nlp:
+            self.num_discrete_solns *= 2 ** len(non_indicator_boolean_vars) * math.prod(
+                max(0, math.floor(v.ub) - math.ceil(v.lb) + 1) for v in discrete_vars
+            )
+
         if self.reached_time_limit(config) or self.reached_iteration_limit(config):
             return
         for soln in self._discrete_solution_iterator(
-            subproblem_util_block.disjunction_list,
-            subproblem_util_block.non_indicator_boolean_variable_list,
-            subproblem_util_block.discrete_variable_list,
-            config,
+            disjunctions, non_indicator_boolean_vars, discrete_vars, config
         ):
             if self.reached_time_limit(config) or self.reached_iteration_limit(config):
                 return

--- a/pyomo/contrib/gdpopt/tests/test_enumerate.py
+++ b/pyomo/contrib/gdpopt/tests/test_enumerate.py
@@ -42,7 +42,7 @@ class TestGDPoptEnumerateUnit(unittest.TestCase):
     def test_large_space_not_enumerated_after_time_limit(self):
         m = ConcreteModel()
         m.x = Var(bounds=(-1, 1))
-        m.i = Var(domain=Integers, bounds=(0, 10**20))
+        m.i = Var(domain=Integers, bounds=(0.5, 10**20))
         m.obj = Objective(expr=m.x + m.i)
 
         def disjunction_rule(m, _):
@@ -52,28 +52,33 @@ class TestGDPoptEnumerateUnit(unittest.TestCase):
         solver = _ExpiredEnumerationSolver()
         results = solver.solve(m, force_subproblem_nlp=True, time_limit=1)
 
+        self.assertEqual(solver.num_discrete_solns, 2**32 * 10**20)
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.maxTimeLimit
         )
 
-    def test_completion_and_solver_reuse(self):
-        solver = GDP_Enumeration_Solver()
-        for num_disjuncts, expected_iterations, options in (
-            (2, 2, {'iterlim': 2}),
-            (3, 5, {}),
-        ):
-            m = ConcreteModel()
-            m.disjunction = Disjunction(
-                expr=[[Constraint.Infeasible] for _ in range(num_disjuncts)]
-            )
-            m.obj = Objective(expr=0)
+    def test_noninteger_integer_bounds(self):
+        m = ConcreteModel()
+        m.i = Var(domain=Integers, bounds=(0.5, 3.5))
+        solver = GDP_Enumeration_Solver(force_subproblem_nlp=True)
 
-            results = solver.solve(m, **options)
+        solutions = solver._discrete_solution_iterator([], [], [m.i], solver.config)
 
-            self.assertEqual(results.solver.iterations, expected_iterations)
-            self.assertEqual(
-                results.solver.termination_condition, TerminationCondition.infeasible
-            )
+        self.assertEqual([solution[2] for solution in solutions], [(1,), (2,), (3,)])
+
+    def test_completion(self):
+        m = ConcreteModel()
+        m.disjunction = Disjunction(
+            expr=[[Constraint.Infeasible], [Constraint.Infeasible]]
+        )
+        m.obj = Objective(expr=0)
+
+        results = GDP_Enumeration_Solver().solve(m, iterlim=2)
+
+        self.assertEqual(results.solver.iterations, 2)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.infeasible
+        )
 
 
 @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')

--- a/pyomo/contrib/gdpopt/tests/test_enumerate.py
+++ b/pyomo/contrib/gdpopt/tests/test_enumerate.py
@@ -25,6 +25,58 @@ from pyomo.gdp import Disjunction
 import pyomo.gdp.tests.models as models
 
 
+class _ExpiredEnumerationSolver(GDP_Enumeration_Solver):
+    """Enumeration solver that enters its GDP solve after the time limit."""
+
+    def _solve_gdp(self, original_model, config):
+        """Expire the active timer before running the real GDP solve."""
+        self.timing.main_timer_start_time -= config.time_limit
+        return super()._solve_gdp(original_model, config)
+
+    def _discrete_solution_iterator(self, *args):
+        """Fail instead of requesting a discrete solution."""
+        raise AssertionError('discrete solutions were enumerated')
+
+
+class TestGDPoptEnumerateUnit(unittest.TestCase):
+    def test_large_space_not_enumerated_after_time_limit(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(-1, 1))
+        m.i = Var(domain=Integers, bounds=(0, 10**20))
+        m.obj = Objective(expr=m.x + m.i)
+
+        def disjunction_rule(m, _):
+            return [[m.x <= 0], [m.x >= 0]]
+
+        m.disjunctions = Disjunction(range(32), rule=disjunction_rule)
+        solver = _ExpiredEnumerationSolver()
+        results = solver.solve(m, force_subproblem_nlp=True, time_limit=1)
+
+        self.assertEqual(solver.num_discrete_solns, 2**32 * (10**20 + 1))
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.maxTimeLimit
+        )
+
+    def test_completion_and_solver_reuse(self):
+        solver = GDP_Enumeration_Solver()
+        for num_disjuncts, expected_iterations, options in (
+            (2, 2, {'iterlim': 2}),
+            (3, 5, {}),
+        ):
+            m = ConcreteModel()
+            m.disjunction = Disjunction(
+                expr=[[Constraint.Infeasible] for _ in range(num_disjuncts)]
+            )
+            m.obj = Objective(expr=0)
+
+            results = solver.solve(m, **options)
+
+            self.assertEqual(results.solver.iterations, expected_iterations)
+            self.assertEqual(
+                results.solver.termination_condition, TerminationCondition.infeasible
+            )
+
+
 @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
 @unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'Gurobi not licensed')
 class TestGDPoptEnumerate(unittest.TestCase):

--- a/pyomo/contrib/gdpopt/tests/test_enumerate.py
+++ b/pyomo/contrib/gdpopt/tests/test_enumerate.py
@@ -52,7 +52,6 @@ class TestGDPoptEnumerateUnit(unittest.TestCase):
         solver = _ExpiredEnumerationSolver()
         results = solver.solve(m, force_subproblem_nlp=True, time_limit=1)
 
-        self.assertEqual(solver.num_discrete_solns, 2**32 * (10**20 + 1))
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.maxTimeLimit
         )


### PR DESCRIPTION
## Fixes #3953 

## Summary/Motivation:

`gdpopt.enumerate` previously materialized every discrete solution before checking the time and iteration limits. For large discrete spaces, this could exhaust available memory before solving began.

This change counts the discrete solution space without materializing it and requests solutions lazily after checking the configured limits. It preserves correct completion behavior and supports reusing the solver instance.

## Changes proposed in this PR:
- Enumerate discrete solutions lazily, checking time and iteration limits before requesting each solution.
- Add concise regression tests for large discrete spaces, completion behavior, and solver reuse.

## AI-Use Disclosure

- [ ] **AI tools were NOT used during the preparation of this PR**

or

- [x] **AI tools contributed to the development of this PR**
    - [ ] AI tools generated documentation (including the PR description/comments, code comments, and/or Sphinx documentation)
    - [x] AI tools generated tests (baselines, examples, and/or code)
    - [ ] AI tools generated code (apart from tests)
    
    *Review process (select ONE)*:
    - [ ] **Rewritten**: All AI-generated content was rewritten by me before being committed.
    - [x] **Reviewed/verified**: I retained AI-generated content and verified it before committing. Verification included (as applicable):
        - [x] Ran the code and fixed issues
        - [ ] Added and ran tests
        - [x] Checked correctness/logic of code and tests
        - [x] Checked for alignment with the contribution guide
        - [ ] Considered security implications
    - [ ] **As-is**: AI-generated content was commited directly to the repository
    

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
